### PR TITLE
Reformat a phone number when its assumed to be a US number.

### DIFF
--- a/app/Http/Controllers/SmsController.php
+++ b/app/Http/Controllers/SmsController.php
@@ -285,12 +285,17 @@ class SmsController extends ApiController
             return '';
         }
 
-        // assume the format is correct.
-        if (substr($phone, 0, 1) != '+') {
+        $len = strlen($phone);
+        if (substr($phone, 0, 1) == '+') {
+            if ($person->country == 'US' && $len == 11 && substr($phone, 1, 1) != '1') {
+                // add +1 to the number
+                $phone = '+1'.substr($phone, 1);
+            }
+        } else {
             // Only area code & number given, add the USA/Canadian +1 country code.
-            if (strlen($phone) == 10) {
+            if ($len == 10) {
                 $phone = '+1'.$phone;
-            } else if (substr($phone, 0, 1) == '1' && strlen($phone) == 11) {
+            } else if (substr($phone, 0, 1) == '1' && $len == 11) {
                 // Assume USA or Canadian number, add the +
                 $phone = '+'.$phone;
             }


### PR DESCRIPTION
When the number begins with '+' followed by ten digits and the first
phone number digit is not a '1', AND the user is in the US, assume
the number was encorrectly entered and insert a 1 between the +
and number.