### PR TITLE
Switch over to metaphone for searching. Photo url tweaks. GHD tweaks.

### DIFF
--- a/app/Console/Commands/GroundhogDay.php
+++ b/app/Console/Commands/GroundhogDay.php
@@ -134,13 +134,19 @@ class GroundhogDay extends Command
         }
 
         $settings = [
-            'BroadcastClubhouseSandbox' => true,
-            'BroadcastClubhouseNotify'  => false,
-            'TwilioAuthToken'           => 'deadbeef',
-            'LambaseJumpinUrl'          => 'https://example.com',
-            'TwilioAccountSID'          => 'deadbeef',
-            'TimesheetCorrectionEnable' => true,
-            'TimesheetCorrectionYear'   => $year,
+            'BroadcastClubhouseNotify'         => false,
+            'BroadcastClubhouseSandbox'        => true,
+            'LambaseJumpinUrl'                 => 'https://example.com',
+            'ManualReviewAuthConfig'           => '',
+            'ManualReviewDisabledAllowSignups' => true,
+            'MealInfoAvailable'                => true,
+            'RadioInfoAvailable'               => true,
+            'SFprdClientId'                    => '',
+            'TicketingPeriod'                  => 'offseason',
+            'TimesheetCorrectionEnable'        => true,
+            'TimesheetCorrectionYear'          => $year,
+            'TwilioAccountSID'                 => 'deadbeef',
+            'TwilioAuthToken'                  => 'deadbeef',
         ];
 
         foreach ($settings as $name => $value) {
@@ -167,7 +173,7 @@ class GroundhogDay extends Command
             'vehicle_paperwork' => false,
             'timesheet_confirmed' => false,
             'behavioral_agreement' => false,
-
+            'message'   => '',
             'emergency_contact' => 'On-playa: John Smith (father), camped at 3:45 and G. Off-playa: Jane Smith (mother), phone 123-456-7890, email jane@noemail.none',
         ]);
 

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Lambase;
+use Illuminate\Support\Facades\Auth;
 
 class Photo
 {
@@ -43,7 +44,11 @@ class Photo
         if ($source == 'Lambase') {
             $lambase = new LambasePhoto($person);
 
-            if (setting('PhotoUploadEnable')) {
+            $user = Auth::user();
+
+            // Only return a upload url if uploads are enabled, and the user is person requested,
+            // or the user is an admin.
+            if ($user && ($user->id == $person->id || $user->isAdmin()) && setting('PhotoUploadEnable')) {
                 $uploadUrl = $lambase->getUploadUrl();
             } else {
                 $uploadUrl = null;

--- a/app/Models/TimesheetMissing.php
+++ b/app/Models/TimesheetMissing.php
@@ -172,9 +172,9 @@ class TimesheetMissing extends ApiModel
             $partner = $sql->get(['id', 'callsign'])->first();
 
             if (!$partner) {
-                // Try soundex lookup
-                $soundex = soundex($name);
-                $partner = Person::where('callsign_soundex', $name)->get(['id', 'callsign'])->first();
+                // Try metaphone lookup
+                $metaphone = metaphone($name);
+                $partner = Person::where('callsign_soundex', $metaphone)->get(['id', 'callsign'])->first();
                 if (!$partner) {
                     $partners[] = [ 'callsign' => $name ];
                     continue;

--- a/database/migrations/2019_06_24_220101_switch_soundex_to_metaphone.php
+++ b/database/migrations/2019_06_24_220101_switch_soundex_to_metaphone.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+use App\Models\Person;
+
+class SwitchSoundexToMetaphone extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $people = Person::all();
+        foreach ($people as $person) {
+            // callsign setter will take of things.
+            $person->callsign = $person->callsign;
+            $person->saveWithoutValidation();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}


### PR DESCRIPTION
- Using metaphone instead of soundex to reduce false positives.
- Search on email only when '@' is in the query string
- GroundHog Day - turn off manual review requirement