### PR TITLE
Throw a validation exception on bulk copy failure

### DIFF
--- a/app/Http/Controllers/PositionCreditController.php
+++ b/app/Http/Controllers/PositionCreditController.php
@@ -123,7 +123,7 @@ class PositionCreditController extends ApiController
                 if (!empty($position)) {
                     $target->position_id = $position;
                 }
-                $target->save();
+                $target->saveOrThrow();
                 array_push($results, $target);
             }
         });

--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -202,7 +202,7 @@ class SlotController extends ApiController
                     }
                     $target->signed_up = 0;
                     $target->active = $activate;
-                    $target->save();
+                    $target->saveOrThrow();
                     array_push($results, $target);
                 }
             });

--- a/app/Models/ApiModel.php
+++ b/app/Models/ApiModel.php
@@ -35,7 +35,7 @@ abstract class ApiModel extends Model //implements AuditableContract
         return get_called_class()::where('id', $id)->exists();
     }
 
-    public function validate($rules = null)
+    public function validate($rules = null, $throwOnFailure = false)
     {
         if ($rules === null) {
             if ($this->exists) {
@@ -66,6 +66,9 @@ abstract class ApiModel extends Model //implements AuditableContract
 
         if ($validator->fails()) {
             $this->errors = $validator->errors();
+            if ($throwOnFailure) {
+                throw new \Illuminate\Validation\ValidationException($validator);
+            }
             return false;
         }
 
@@ -79,6 +82,14 @@ abstract class ApiModel extends Model //implements AuditableContract
         }
 
         return parent::save($options);
+    }
+
+    public function saveOrThrow($options = [])
+    {
+        $this->validate(null, true); // throws if validation fails
+        if (!parent::save($options)) {
+            throw new \RuntimeException("Could not save $this");
+        }
     }
 
     public function saveWithoutValidation($options = [])

--- a/app/Models/PersonMessage.php
+++ b/app/Models/PersonMessage.php
@@ -74,8 +74,8 @@ class PersonMessage extends ApiModel
      * @param return bool true if model is valid
      */
 
-    public function validate($rules=null): bool {
-        if (!parent::validate($rules)) {
+    public function validate($rules = null, $throwOnFailure = false): bool {
+        if (!parent::validate($rules, $throwOnFailure)) {
             return false;
         }
 
@@ -83,6 +83,9 @@ class PersonMessage extends ApiModel
 
         $recipient = Person::findByCallsign($this->recipient_callsign);
         if (!$recipient) {
+            if ($throwOnFailure) {
+                throw new \Illuminate\Database\Eloquent\ModelNotFoundException("Callsign $this->recipient_callsign does not exist");
+            }
             $this->addError('recipient_callsign', 'Callsign does not exist');
             return false;
         }


### PR DESCRIPTION
Adds a saveOrThrow method to ApiModel.  This is often cleaner than
if (!$model->save()) {
  return $this->restError(...);
}
because it will appropriately break out of a transaction or helper.