### PR TITLE
Bug fix for multiple enrollments.

### DIFF
--- a/app/Models/Slot.php
+++ b/app/Models/Slot.php
@@ -420,6 +420,9 @@ class Slot extends ApiModel
      * Is the slot part of a session group?
      */
     public function isPartOfSessionGroup($slot) {
-        return $slot->sessionGroupName() == $this->sessionGroupName();
+        $ourPart = $this->sessionGroupPart();
+        $theirPart = $slot->sessionGroupPart();
+
+        return ($ourPart && $theirPart && $slot->sessionGroupName() == $this->sessionGroupName());
     }
 }


### PR DESCRIPTION
Signups were being allowed where a full day could be signed up for, and then a half-day training session. The reverse was already blocked.