### PR TITLE
People by position API implementation

### DIFF
--- a/app/Http/Controllers/PositionController.php
+++ b/app/Http/Controllers/PositionController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Person;
+use App\Models\PersonPosition;
 use App\Models\Position;
 use App\Http\Controllers\ApiController;
 
+use DB;
 use Illuminate\Http\Request;
 
 class PositionController extends ApiController
@@ -85,12 +88,84 @@ class PositionController extends ApiController
     }
 
     /**
+     * Lists people who have (or do not have, for "all rangers" cases) a position.
+     * Parameters: onPlaya - If true, only people on site will be returned.
+     * Result: {positions: […], people: […]}.
+     * Position objects are {id, title, type, all_rangers, new_user_eligible, num_people, num_on_site, personIds,
+     * missingPersonIds} with the num fields counting the number of people with the position assigned, the personId
+     * felds containing lists of people IDs who have the position and the other fields taken directly from the
+     * position table.
+     * Person objects are {id, callsign, status, on_site} taken from the person table.  personIds and missingPersonIds
+     * from position objects can be looked up in the people list (not denormalized so as to save space).
+     */
+    public function peopleByPosition(Request $request)
+    {
+        $this->authorize('index', Person::class);
+        $params = request()->validate([
+            'onPlaya' => 'sometimes|boolean'
+        ]);
+        $positions = array();
+        $allPeople = array();
+        // Statuses that qualify for "all rangers"
+        $rangerStatuses = array(Person::ACTIVE, Person::INACTIVE, Person::INACTIVE_EXTENSION, Person::SUSPENDED);
+        // Statuses that do not qualify for "new user eligible"
+        $nonTrainingStatuses = array(Person::DECEASED, Person::DISMISSED, Person::RESIGNED, Person::UBERBONKED);
+        $positionQuery = Position::select(
+            'id',
+            'title',
+            'type',
+            'new_user_eligible',
+            'all_rangers',
+            DB::raw("(SELECT COUNT(*) FROM person_position WHERE position_id = position.id) AS num_people"),
+            DB::raw("(SELECT COUNT(*) FROM person_position"
+                ." INNER JOIN person ON person.id = person_position.person_id"
+                ." WHERE position_id = position.id AND person.on_site) AS num_on_site")
+        );
+        foreach ($positionQuery->get() as $pos) {
+            $position = $pos->toArray();
+            if (!$position['new_user_eligible'] && !$position['all_rangers']) { // show people with the position
+                $pps = PersonPosition::where('position_id', $pos->id);
+                if ($params['onPlaya']) {
+                    $pps = $pps->join('person', 'person.id', '=', 'person_position.person_id')
+                               ->where('person.on_site', true);
+                }
+                $personIds = $pps->pluck('person_id')->toArray();
+                $position['personIds'] = $personIds;
+            } else { // show Rangers (or all people) who don't have the position
+                if ($position['new_user_eligible']) {
+                    $missingPeopleQuery = Person::whereNotIn('status', $nonTrainingStatuses);
+                } elseif ($position['all_rangers']) {
+                    $missingPeopleQuery = Person::whereIn('status', $rangerStatuses);
+                }
+                if ($params['onPlaya']) {
+                    $missingPeopleQuery = $missingPeopleQuery->where('on_site', true);
+                }
+                $personIds = $missingPeopleQuery
+                    ->whereNotExists(function ($query) use ($position) {
+                        $query->select(DB::raw(1))
+                              ->from('person_position')
+                              ->where('position_id', $position['id'])
+                              ->whereRaw('person_position.person_id = person.id');
+                    })->pluck('id')->toArray();
+                $position['missingPersonIds'] = $personIds;
+            }
+            foreach ($personIds as $pid) {
+                $allPeople[$pid] = true;
+            }
+            $positions[] = $position;
+        }
+        $people = Person::whereIn('id', array_keys($allPeople))
+            ->select('id', 'callsign', 'status', 'on_site')
+            ->get();
+        return response()->json(array('positions' => $positions, 'people' => $people));
+    }
+
+    /**
      * Sandman Qualification Report
      */
-
     public function sandmanQualifiedReport()
     {
         $this->authorize('sandmanQualified', Position::class);
-        return response()->json( Position::retrieveSandPeopleQualifications());
+        return response()->json(Position::retrieveSandPeopleQualifications());
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -161,6 +161,7 @@ Route::group([
     Route::post('position-credit/copy', 'PositionCreditController@copy');
     Route::resource('position-credit', 'PositionCreditController');
 
+    Route::get('position/people-by-position', 'PositionController@peopleByPosition');
     Route::get('position/sandman-qualified', 'PositionController@sandmanQualifiedReport');
     Route::resource('position', 'PositionController');
 


### PR DESCRIPTION
Returns each position with a few attributes.  For all_rangers and
new_user_eligible positions, returns a list of people who should have
the position but don't (excluding deceased, dismissed, etc. people).
For granted positions returns a list of people with the position.
Separately returns a slim view of all people who are referenced by one
of these positions.  The onPlaya parameter will return only people who
are on site.