### PR TITLE
Fixed PhotoStoreLocally setting to work with photo caching for on playa operations.

### DIFF
--- a/app/Console/Commands/LambaseSyncPhotosCommand.php
+++ b/app/Console/Commands/LambaseSyncPhotosCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+use App\Models\Person;
+use App\Models\PersonPhoto;
+use App\Models\Photo;
+
+class LambaseSyncPhotosCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'lambase:syncphotos';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+
+    protected $description = 'Rebuild the photo status cache, and download available mugshots. Used for on playa operations.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     *
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (!setting('PhotoStoreLocally')) {
+            $this->error("PhotoStoreLocally setting is not enabled. Enable the setting and then rerun this command.");
+            return;
+        }
+
+        // Blow away the cached statuses
+        PersonPhoto::truncate();
+
+        $people = Person::whereIn('status', Person::LIVE_STATUSES)
+                  ->orWhere('status', Person::NON_RANGER)
+                  ->get();
+
+        $this->info("Syncing ".$people->count()." photos");
+        foreach ($people as $person) {
+            $this->info("Syncing #{$person->id} {$person->callsign}");
+            Photo::retrieveInfo($person, true);
+        }
+
+        $this->info("finished.");
+    }
+}

--- a/app/Http/Controllers/BmidController.php
+++ b/app/Http/Controllers/BmidController.php
@@ -279,7 +279,6 @@ EOM;
 
         $lambase = new LambasePhoto($person);
         $url = $lambase->getUploadUrl();
-        error_log("PHOTO $url");
 
         $client = new GuzzleHttp\Client();
         $res = $client->request('GET', $url);

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -60,7 +60,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
 
     // Statuses consider 'live' or still active account allowed
     // to login, and do stuff.
-    // Used by App\Validator\StateForCountry & BroadcastController
+    // Used by App\Validator\StateForCountry & BroadcastController & Sync Photos
 
     const LIVE_STATUSES = [
         'active',


### PR DESCRIPTION
- New command 'lambase:syncphotos' used to rebuild photo status cache and download available mugshots.