### PR TITLE
Timesheet Corrections work.

### DIFF
--- a/app/Http/Filters/TimesheetFilter.php
+++ b/app/Http/Filters/TimesheetFilter.php
@@ -17,7 +17,8 @@ class TimesheetFilter
 
     const USER_FIELDS = [
         'notes',
-        'verified'
+        'verified',
+        'is_incorrect'
     ];
 
     const MANAGE_FIELDS = [

--- a/app/Lib/LambaseBMID.php
+++ b/app/Lib/LambaseBMID.php
@@ -24,7 +24,7 @@ class LambaseBMID
 
     const DEBUG = 0;
 
-    public static function upload($bmids, $returnExchange = false)
+    public static function upload($bmids, $returnExchange = false, $printStatus = "readytoprint")
     {
         $records = [];
         foreach ($bmids as $bmid) {
@@ -42,7 +42,7 @@ class LambaseBMID
                 'title2'      => $bmid->title2,
                 'title3'      => $bmid->title3,
                 'batchid'     => $bmid->batch,
-                'printstatus' => "readytoprint",
+                'printstatus' => $printStatus,
             ];
 
             switch ($bmid->status) {

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -42,11 +42,14 @@ class Timesheet extends ApiModel
         'timesheet_confirmed_at',
         'timesheet_confirmed',
         'verified',
+
+        // Meta information - not part of the schema
+        'is_incorrect', // is the entry to be marked as incorrect?
     ];
 
     protected $rules = [
         'person_id' => 'required|integer',
-        'position_id' => 'required|integer'
+        'position_id' => 'required|integer',
     ];
 
     protected $appends = [
@@ -64,9 +67,12 @@ class Timesheet extends ApiModel
 
     protected $casts = [
         'verified' => 'boolean',
+        'is_incorrect' => 'boolean'
     ];
 
     public $credits;
+
+    public $_is_incorrect;
 
     const RELATIONSHIPS = [ 'reviewer_person:id,callsign', 'verified_person:id,callsign', 'position:id,title,count_hours' ];
 
@@ -260,6 +266,7 @@ class Timesheet extends ApiModel
         $rows = self::with([ 'person:id,callsign', 'position:id,title'])
             ->whereYear('on_duty', $year)
             ->where('verified', false)
+            ->where('notes', '!=', '')
             ->where('review_status', 'pending')
             ->whereNotNull('off_duty')
             ->orderBy('on_duty')
@@ -792,5 +799,10 @@ class Timesheet extends ApiModel
     public function setVerifiedAtToNow()
     {
         $this->verified_at = SqlHelper::now();
+    }
+
+    public function setIsIncorrectAttribute($value)
+    {
+        $this->_is_incorrect = $value;
     }
 }


### PR DESCRIPTION
- Fixed timesheet correction report which was including all unverified entry.
- Use new is_incorrect flag on timesheet update to differentiate between simply updating
  the verified flag versus marking (or remarking) an entry incorrect.