### PR TITLE
Timesheet corrections fixes.

### DIFF
--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -362,15 +362,19 @@ class PersonController extends ApiController
     {
         $params = request()->validate([
             'include_training'   => 'sometimes|boolean',
+            'include_mentee' => 'sometimes|boolean',
             'year'               => 'required_if:include_training,true|integer'
         ]);
 
         $this->authorize('view', $person);
 
-        if (@$params['include_training']) {
+        $includeTraining = $params['include_training'] ?? false;
+        $includeMentee = $params['include_mentee'] ?? false;
+
+        if ($includeTraining) {
             $positions = Training::findPositionsWithTraining($person, $params['year']);
         } else {
-            $positions = PersonPosition::findForPerson($person->id);
+            $positions = PersonPosition::findForPerson($person->id, $includeMentee);
         }
 
         return response()->json([ 'positions' =>  $positions]);

--- a/app/Http/Controllers/PersonMessageController.php
+++ b/app/Http/Controllers/PersonMessageController.php
@@ -82,8 +82,13 @@ class PersonMessageController extends ApiController
     {
         $this->authorize('markread', $person_message);
 
-        if (!$person_message->markRead()) {
-            return $this->restError('Cannot mark message as read');
+        $params = request()->validate([
+            'delivered' => 'required|boolean'
+        ]);
+
+        $person_message->delivered = $params['delivered'];
+        if (!$person_message->save()) {
+            return $this->restError($person_message);
         }
 
         return $this->success();

--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -459,9 +459,8 @@ class TimesheetController extends ApiController
         $this->authorize('correctionRequests', [ Timesheet::class ]);
 
         return response()->json([
-               'corrections'    => Timesheet::retrieveCorrectionRequestsForYear($year),
-               'missing_requests'   => TimesheetMissing::retrieveForPersonOrAllForYear(null, $year)
-           ]);
+            'requests' => Timesheet::retrieveCombinedCorrectionRequestsForYear($year)
+        ]);
     }
     /*
      * Timesheet Unconfirmed Report

--- a/app/Models/PersonMessage.php
+++ b/app/Models/PersonMessage.php
@@ -79,18 +79,20 @@ class PersonMessage extends ApiModel
             return false;
         }
 
-        /* Find callsigns and verify contents */
+        if (!$this->exists) {
+            /* Find callsigns and verify contents */
 
-        $recipient = Person::findByCallsign($this->recipient_callsign);
-        if (!$recipient) {
-            if ($throwOnFailure) {
-                throw new \Illuminate\Database\Eloquent\ModelNotFoundException("Callsign $this->recipient_callsign does not exist");
+            $recipient = Person::findByCallsign($this->recipient_callsign);
+            if (!$recipient) {
+                if ($throwOnFailure) {
+                    throw new \Illuminate\Database\Eloquent\ModelNotFoundException("Callsign $this->recipient_callsign does not exist");
+                }
+                $this->addError('recipient_callsign', 'Callsign does not exist');
+                return false;
             }
-            $this->addError('recipient_callsign', 'Callsign does not exist');
-            return false;
-        }
 
-        $this->person_id = $recipient->id;
+            $this->person_id = $recipient->id;
+        }
 
         return true;
     }

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -502,19 +502,10 @@ class TimesheetControllerTest extends TestCase
 
         $person = $this->targetPerson;
 
-        $data = [
-             'on_duty'          => $onDuty,
-             'off_duty'         => $offDuty,
-             'person_id'        => $this->targetPerson->id,
-             'create_person_id' => $this->user->id,
-             'position_id'      => Position::DIRT,
-             'notes'            => 'Give me hours!',
-         ];
-
         factory(TimesheetMissing::class)->create([
              'on_duty'          => $onDuty,
              'off_duty'         => $offDuty,
-             'person_id'        => $this->targetPerson->id,
+             'person_id'        => $person->id,
              'create_person_id' => $this->user->id,
              'position_id'      => Position::DIRT,
              'notes'            => 'Give me hours!',
@@ -524,20 +515,25 @@ class TimesheetControllerTest extends TestCase
         $response->assertStatus(200);
 
         $response->assertJson([
-             'corrections' => [
+             'requests' => [
                  [
-                     'id' => $timesheet->id,
                      'notes' => 'Would thoust correctith thine entry?',
                      'person' => [
                          'id'   => $person->id,
                          'callsign' => $person->callsign
                      ]
-                 ]
+                 ],
+                 [
+                      'on_duty'  => $onDuty,
+                      'off_duty' => $offDuty,
+                      'notes'       => 'Give me hours!',
+                      'is_missing'  => true,
+                      'person'   => [
+                          'id'       => $person->id,
+                          'callsign' => $person->callsign
+                      ],
+                  ]
             ],
-
-            'missing_requests' => [
-                $data
-            ]
          ]);
     }
 


### PR DESCRIPTION
- person/{person_id}/positions has new option 'include_mentee' to include the mentee positions. Mentees positions may disappear after the person has been trained. Also include the Alpha position if the person has an alpha timesheet entry.
- Combined correction and missing timesheet requests into one report.
- Allow a message to be marked as unread