### PR TITLE
Trainer Attendance work.

### DIFF
--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -11,6 +11,8 @@ use App\Models\Slot;
 use App\Models\PersonSlot;
 use App\Models\PositionCredit;
 use App\Models\Role;
+use App\Models\TraineeStatus;
+use App\Models\TrainerStatus;
 
 use App\Helpers\SqlHelper;
 
@@ -226,6 +228,8 @@ class SlotController extends ApiController
 
         $slot->delete();
         PersonSlot::deleteForSlot($slot->id);
+        TraineeStatus::deleteForSlot($slot->id);
+        TrainerStatus::deleteForSlot($slot->id);
 
         $this->log('slot-delete', 'delete', [ 'slot' => $slot ]);
 

--- a/app/Http/Controllers/TrainingController.php
+++ b/app/Http/Controllers/TrainingController.php
@@ -73,6 +73,19 @@ class TrainingController extends ApiController
     }
 
     /*
+     * Show who has not completed training or not signed up for training
+     * (ART modules only)
+     */
+
+    public function trainerAttendanceReport($id)
+    {
+        list($training, $year) = $this->getTrainingAndYear($id);
+
+        return response()->json([ 'trainers' => $training->retrieveTrainerAttendanceForYear($year) ]);
+    }
+
+
+    /*
      * Obtain the training position, and year requested
      */
 
@@ -87,4 +100,5 @@ class TrainingController extends ApiController
 
         return [ $training, $params['year'] ];
     }
+
 }

--- a/app/Lib/Alpha.php
+++ b/app/Lib/Alpha.php
@@ -45,7 +45,7 @@ class Alpha
             ->whereRaw("EXISTS
                 (SELECT 1 FROM person_slot JOIN slot ON person_slot.slot_id=slot.id
                     AND slot.position_id=? AND YEAR(slot.begins)=?
-                WHERE person_slot.person_id=person.id LIMIT 1)", [ Position::DIRT_TRAINING, $year ])
+                WHERE person_slot.person_id=person.id LIMIT 1)", [ Position::TRAINING, $year ])
             ->orderBy('callsign');
 
         $rows = $sql->get();

--- a/app/Lib/RBS.php
+++ b/app/Lib/RBS.php
@@ -636,7 +636,7 @@ class RBS
             $trainingCond .= " (SELECT 1 FROM trainee_status
                 INNER JOIN slot on slot.id = trainee_status.slot_id
                 WHERE trainee_status.person_id = person.id
-                     AND slot.position_id = ".Position::DIRT_TRAINING."
+                     AND slot.position_id = ".Position::TRAINING."
                      AND YEAR(slot.begins) = $year";
             if ($training == 'passed') {
                 $trainingCond .= " AND passed=1";

--- a/app/Models/Bmid.php
+++ b/app/Models/Bmid.php
@@ -363,7 +363,7 @@ class Bmid extends ApiModel
          * Find people who have signed up shifts starting before their WAP access date
          */
 
-        $positionIds = implode(',', [ Position::DIRT_TRAINING, Position::TRAINER, Position::TRAINER_ASSOCIATE, Position::TRAINER_UBER]);
+        $positionIds = implode(',', [ Position::TRAINING, Position::TRAINER, Position::TRAINER_ASSOCIATE, Position::TRAINER_UBER]);
         $ids = DB::select("SELECT ps.person_id as id
             FROM person_slot ps
             JOIN slot s ON s.id=ps.slot_id
@@ -387,7 +387,7 @@ class Bmid extends ApiModel
          * Find people who signed up early shifts yet do not have a WAP
          */
 
-        $positionIds = implode(',', [ Position::DIRT_TRAINING, Position::TRAINER, Position::TRAINER_ASSOCIATE, Position::TRAINER_UBER, Position::GREEN_DOT_TRAINER, Position::GREEN_DOT_TRAINING]);
+        $positionIds = implode(',', [ Position::TRAINING, Position::TRAINER, Position::TRAINER_ASSOCIATE, Position::TRAINER_UBER, Position::GREEN_DOT_TRAINER, Position::GREEN_DOT_TRAINING]);
         $ids = DB::select("SELECT ps.person_id as id
                 FROM person_slot ps
                 JOIN slot s ON s.id=ps.slot_id

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -634,7 +634,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
                 )
                 ->join('person', 'person.id', 'timesheet.person_id')
                 ->whereIn('status', [ Person::ACTIVE, Person::INACTIVE ])
-                ->whereNotIn('position_id', [ Position::ALPHA, Position::DIRT_TRAINING ])
+                ->whereNotIn('position_id', [ Position::ALPHA, Position::TRAINING ])
                 ->where('vintage', false)
                 ->groupBy([ 'person_id', 'callsign', 'status', 'email' ])
                 ->havingRaw('count(distinct(YEAR(on_duty))) >= 10')

--- a/app/Models/PersonPosition.php
+++ b/app/Models/PersonPosition.php
@@ -54,7 +54,7 @@ class PersonPosition extends ApiModel
             $rows->prepend((object) [
                 'position_id'          => Position::DIRT,
                 'title'                => 'Dirt',
-                'training_position_id' => Position::DIRT_TRAINING
+                'training_position_id' => Position::TRAINING
             ]);
         }
 

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Facades\DB;
 class Position extends ApiModel
 {
     const ALPHA = 1;
+
     const DIRT = 2;
-    const DIRT_TRAINING = 13;
     const DIRT_PRE_EVENT = 53;
     const DIRT_POST_EVENT = 120;
     const DIRT_SHINY_PENNY = 107;
@@ -137,7 +137,7 @@ class Position extends ApiModel
     //
 
     const TRAINERS = [
-        Position::DIRT_TRAINING => [
+        Position::TRAINING => [
              Position::TRAINER,
              Position::TRAINER_ASSOCIATE,
              Position::TRAINER_UBER
@@ -235,7 +235,7 @@ class Position extends ApiModel
             ->orderBy('title');
 
         if ($excludeDirt) {
-            $sql = $sql->where('id', '!=', Position::DIRT_TRAINING);
+            $sql = $sql->where('id', '!=', Position::TRAINING);
         }
 
         return $sql->get()->toArray();

--- a/app/Models/Slot.php
+++ b/app/Models/Slot.php
@@ -5,10 +5,11 @@ namespace App\Models;
 use Illuminate\Support\Facades\DB;
 
 use App\Models\ApiModel;
+use App\Models\EventDate;
 use App\Models\PersonSlot;
 use App\Models\Position;
-use App\Models\EventDate;
 use App\Models\Timesheet;
+use App\Models\TrainerStatus;
 
 use Carbon\Carbon;
 
@@ -69,6 +70,10 @@ class Slot extends ApiModel
 
     public function person_slot() {
         return $this->hasMany(PersonSlot::class);
+    }
+
+    public function trainer_status() {
+        return $this->hasMany(TrainerStatus::class, 'trainer_slot_id');
     }
 
     public static function findForQuery($query) {
@@ -303,7 +308,7 @@ class Slot extends ApiModel
                 // The check for the mentee shift is a hack to prevent past years from showing
                 // a GD Mentee as a qualified GD.
                 if ($haveGDPosition ) {
-                    $person->is_greendot = TraineeStatus::didPersonPassForYear($person->person_id, Position::GREEN_DOT_TRAINING, $year);
+                    $person->is_greendot = Training::didPersonPassForYear($person->person_id, Position::GREEN_DOT_TRAINING, $year);
                     if (!$person->is_greendot || ($positionId == Position::GREEN_DOT_MENTEE)) {
                         $person->is_greendot = false; // just in case
                         // Not trained - remove the GD positions
@@ -387,7 +392,7 @@ class Slot extends ApiModel
     }
 
     public function isArt() {
-        return ($this->position_id != Position::DIRT_TRAINING);
+        return ($this->position_id != Position::TRAINING);
     }
 
     /*

--- a/app/Models/TraineeStatus.php
+++ b/app/Models/TraineeStatus.php
@@ -18,7 +18,8 @@ class TraineeStatus extends ApiModel
 
     protected $casts = [
         'passed'    => 'boolean',
-        'begins'    => 'date'
+        'begins'    => 'date',
+        'ends'  => 'date'
     ];
 
     /**
@@ -62,8 +63,16 @@ class TraineeStatus extends ApiModel
                 ->exists();
     }
 
-    public static function firstOrCreateForSession($personId, $sessionId) {
-        return self::firstOrCreate([ 'person_id' => $personId, 'slot_id' => $sessionId]);
+    public static function firstOrNewForSession($personId, $sessionId) {
+        return self::firstOrNew([ 'person_id' => $personId, 'slot_id' => $sessionId]);
+    }
+
+    /*
+     * Delete all records refering to a slot. Used by slot deletion.
+     */
+
+    public static function deleteForSlot($slotId) {
+        self::where('slot_id', $slotId)->delete();
     }
 
     public function setRankAttribute($value) {

--- a/app/Models/TrainerStatus.php
+++ b/app/Models/TrainerStatus.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\ApiModel;
+use App\Models\Slot;
+use Illuminate\Support\Facades\DB;
+
+class TrainerStatus extends ApiModel
+{
+    protected $table = 'trainer_status';
+    public $timestamps = true;
+
+    const ATTENDED = 'attended';
+    const PENDING = 'pending';
+    const NO_SHOW = 'no-show';
+
+    protected $guarded = [];
+
+    /*
+     * trainer_slot_id refers to the Trainer sign up (Trainer / Trainer Associate / Trainer Uber /etc)
+     * slot_id refers to the training session (trainee)
+     */
+
+    public static function firstOrNewForSession($sessionId, $personId) {
+        return self::firstOrNew([ 'person_id' => $personId, 'slot_id' => $sessionId]);
+    }
+
+    public static function findBySlotPersonIds($slotId, $personIds) {
+        return self::where('slot_id', $slotId)->whereIn('person_id', $personIds)->get();
+    }
+
+    /**
+     * Did a person teach a session?
+     *
+     * @param integer $personId the person to query
+     * @param integer $positionId the position (Training / Green Dot Training / etc) to see if they taught
+     * @param integer $year the year to check
+     * @return bool return true if the person taught
+     */
+
+    public static function didPersonTeachForYear($personId, $positionId, $year) {
+        $positionIds = Position::TRAINERS[$positionId] ?? null;
+        if (!$positionIds) {
+            return false;
+        }
+
+        return self::join('slot', 'slot.id', 'trainer_status.slot_id')
+                ->where('trainer_status.person_id', $personId)
+                ->whereIn('slot.position_id', $positionIds)
+                ->whereYear('slot.begins', $year)
+                ->where('status', self::ATTENDED)
+                ->exists();
+    }
+
+    /**
+     * Retrieve all the sessions the person may have taught
+     *
+     * @param integer $personId the person to check
+     * @param array $positionIds the positions to check (Trainer / Trainer Assoc. / Uber /etc)
+     * @param integer $year the year to check
+     * @return array the slots the person signed up for with optional trainer status
+     */
+
+    public static function retrieveSessionsForPerson($personId, $positionIds, $year)
+    {
+        return DB::table('slot')
+                ->select('slot.id', 'slot.begins', 'slot.ends', 'slot.description', 'slot.position_id', 'trainer_status.status')
+                ->join('person_slot', function ($q) use ($personId)  {
+                    $q->on('person_slot.slot_id', 'slot.id');
+                    $q->where('person_slot.person_id', $personId);
+                })
+                ->leftJoin('trainer_status', function ($q) use ($personId) {
+                    $q->on('trainer_status.trainer_slot_id', 'slot.id');
+                    $q->where('trainer_status.person_id', $personId);
+                })
+                ->whereYear('slot.begins', $year)
+                ->whereIn('position_id', $positionIds)
+                ->orderBy('slot.begins')
+                ->get();
+    }
+
+    /*
+     * Delete all records refering to a slot. Used by slot deletion.
+     */
+
+    public static function deleteForSlot($slotId) {
+        self::where('slot_id', $slotId)->delete();
+        self::where('trainer_slot_id', $slotId)->delete();
+    }
+}

--- a/app/Policies/TrainingSessionPolicy.php
+++ b/app/Policies/TrainingSessionPolicy.php
@@ -46,6 +46,16 @@ class TrainingSessionPolicy
         return $this->checkForArt($user, $training_session);
     }
 
+    /**
+     * Can the user set trainer status?
+     *
+     */
+
+    public function trainerStatus(Person $user, TrainingSession $training_session)
+    {
+        return $this->checkForArt($user, $training_session);
+    }
+
     private function checkForArt(Person $user, TrainingSession $training_session) {
         return ($training_session->isArt() && $user->hasRole(Role::ART_TRAINER));
     }

--- a/database/factories/TrainerStatus.php
+++ b/database/factories/TrainerStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+use Faker\Generator as Faker;
+use App\Models\TrainerStatus;
+
+$factory->define(TrainerStatus::class, function (Faker $faker) {
+    return [
+        'status'   => TrainerStatus::ATTENDED
+    ];
+});

--- a/database/migrations/2019_11_10_202334_create_trainer_status_table.php
+++ b/database/migrations/2019_11_10_202334_create_trainer_status_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTrainerStatusTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('trainer_status', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('person_id')->unsigned();
+            $table->bigInteger('trainer_slot_id')->unsigned();
+            $table->bigInteger('slot_id')->unsigned();
+            $table->enum('status', [ 'attended', 'no-show', 'pending' ])->default('attended');
+            $table->unique(['person_id','slot_id'], 'person_id_and_slot_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('trainer_status');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -238,10 +238,12 @@ Route::group([
     Route::get('training-session/sessions', 'TrainingSessionController@sessions');
     Route::get('training-session/{id}', 'TrainingSessionController@show');
     Route::post('training-session/{id}/score', 'TrainingSessionController@score');
+    Route::post('training-session/{id}/trainer-status', 'TrainingSessionController@trainerStatus');
 
     Route::get('training/{id}/multiple-enrollments', 'TrainingController@multipleEnrollmentsReport');
     Route::get('training/{id}/capacity', 'TrainingController@capacityReport');
     Route::get('training/{id}/people-training-completed', 'TrainingController@peopleTrainingCompleted');
+    Route::get('training/{id}/trainer-attendance', 'TrainingController@trainerAttendanceReport');
     Route::get('training/{id}/untrained-people', 'TrainingController@untrainedPeopleReport');
     Route::get('training/{id}', 'TrainingController@show');
 

--- a/tests/Feature/PersonScheduleControllerTest.php
+++ b/tests/Feature/PersonScheduleControllerTest.php
@@ -48,7 +48,7 @@ class PersonScheduleControllerTest extends TestCase
         // Setup default (real world) positions
         $this->trainingPosition = factory(Position::class)->create(
             [
-                'id'    => Position::DIRT_TRAINING,
+                'id'    => Position::TRAINING,
                 'title' => 'Training',
                 'type'  => 'Training',
             ]
@@ -87,7 +87,7 @@ class PersonScheduleControllerTest extends TestCase
                 [
                     'begins'      => date("$year-05-$day 09:45:00"),
                     'ends'        => date("$year-05-$day 17:45:00"),
-                    'position_id' => Position::DIRT_TRAINING,
+                    'position_id' => Position::TRAINING,
                     'description' => "Training #$i",
                     'signed_up'   => 0,
                     'max'         => 10,

--- a/tests/Feature/SlotControllerTest.php
+++ b/tests/Feature/SlotControllerTest.php
@@ -32,7 +32,7 @@ class SlotControllerTest extends TestCase
         // Setup default (real world) positions
         $this->trainingPosition = factory(Position::class)->create(
             [
-                'id'    => Position::DIRT_TRAINING,
+                'id'    => Position::TRAINING,
                 'title' => 'Training',
                 'type'  => 'Training',
             ]
@@ -45,7 +45,7 @@ class SlotControllerTest extends TestCase
                 [
                     'begins'      => date("$year-05-$day 09:45:00"),
                     'ends'        => date("$year-05-$day 17:45:00"),
-                    'position_id' => Position::DIRT_TRAINING,
+                    'position_id' => Position::TRAINING,
                     'description' => "Training #$i",
                     'signed_up'   => 0,
                     'max'         => 10,

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -49,7 +49,7 @@ class TimesheetControllerTest extends TestCase
 
         factory(Position::class)->create(
             [
-                'id'    => Position::DIRT_TRAINING,
+                'id'    => Position::TRAINING,
                 'title' => 'Training',
                 'type'  => 'Training',
             ]
@@ -117,7 +117,7 @@ class TimesheetControllerTest extends TestCase
         $slot = factory(Slot::class)->create([
             'begins'    => date("Y-01-01 00:00:00"),
             'ends'      => date('Y-01-01 01:00:00'),
-            'position_id'  => Position::DIRT_TRAINING,
+            'position_id'  => Position::TRAINING,
         ]);
 
         factory(PersonSlot::class)->create([
@@ -323,7 +323,7 @@ class TimesheetControllerTest extends TestCase
         $response->assertJson([
             'status'         => 'not-trained',
             'position_title' => 'Training',
-            'position_id'    => Position::DIRT_TRAINING,
+            'position_id'    => Position::TRAINING,
         ]);
     }
 

--- a/tests/Feature/TrainingControllerTest.php
+++ b/tests/Feature/TrainingControllerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+
+use App\Models\PersonPosition;
+use App\Models\PersonSlot;
+use App\Models\Position;
+use App\Models\Role;
+use App\Models\Slot;
+use App\Models\TrainerStatus;
+
+class TrainingControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /*
+     * have each test have a fresh user that is logged in.
+     */
+
+    public function setUp() : void
+    {
+        parent::setUp();
+        $this->signInUser();
+        $this->addRole(Role::TRAINER);
+    }
+
+    /*
+     * Test the Trainer Attendance report
+     */
+
+    public function testTrainerAttendanceReport()
+    {
+        $personId = $this->user->id;
+
+        factory(Position::class)->create([
+            'id'    => Position::GREEN_DOT_TRAINER,
+            'title' => 'Green Dot Trainer'
+        ]);
+
+        factory(Position::class)->create([
+            'id'    => Position::GREEN_DOT_TRAINING,
+            'title' => 'Green Dot Training',
+            'type' => 'Training'
+        ]);
+
+        $traineeSlot = factory(Slot::class)->create([
+            'begins' => date('Y-07-20 11:00:00'),
+            'ends'   => date('Y-07-20 12:00:00'),
+            'position_id'   => Position::GREEN_DOT_TRAINING,
+            'description' => 'GD Training'
+        ]);
+
+        $trainerSlot = factory(Slot::class)->create([
+            'begins' => date('Y-07-20 11:00:00'),
+            'ends'   => date('Y-07-20 12:00:00'),
+            'position_id'   => Position::GREEN_DOT_TRAINER,
+            'description' => 'GD Training'
+        ]);
+
+        $futureTraineeSlot = factory(Slot::class)->create([
+            'begins' => date('Y-12-31 23:00:00'),
+            'ends'   => date('Y-12-31 23:01:00'),
+            'position_id'   => Position::GREEN_DOT_TRAINING,
+            'description' => 'New Years Training'
+        ]);
+
+        $futureTrainerSlot = factory(Slot::class)->create([
+            'begins' => date('Y-12-31 23:00:00'),
+            'ends'   => date('Y-12-31 23:01:00'),
+            'position_id'   => Position::GREEN_DOT_TRAINER,
+            'description' => 'New Years Training'
+        ]);
+
+        factory(PersonPosition::class)->create([
+            'person_id' => $personId,
+            'position_id' => Position::GREEN_DOT_TRAINER
+        ]);
+
+        factory(PersonSlot::class)->create([
+            'person_id' => $personId,
+            'slot_id' => $trainerSlot->id,
+        ]);
+
+        factory(PersonSlot::class)->create([
+            'person_id' => $personId,
+            'slot_id' => $futureTrainerSlot->id,
+        ]);
+
+        factory(TrainerStatus::class)->create([
+            'person_id' => $personId,
+            'slot_id'   => $traineeSlot->id,
+            'trainer_slot_id' => $trainerSlot->id,
+            'status'    => TrainerStatus::ATTENDED
+        ]);
+
+        $response = $this->json('GET', "training/".Position::GREEN_DOT_TRAINING."/trainer-attendance", [ 'year' => current_year() ]);
+        $response->assertStatus(200);
+
+        $response->assertJsonCount(1, 'trainers.*.id');
+        $response->assertJson([
+            'trainers' => [
+                [
+                    'id'    => $this->user->id,
+                    'callsign' => $this->user->callsign,
+                    'slots' => [
+                        [
+                            'id'    => $trainerSlot->id,
+                            'begins' => (string) $trainerSlot->begins,
+                            'description' => $trainerSlot->description,
+                            'status'    => TrainerStatus::ATTENDED
+                        ],
+                        [
+                            'id'    => $futureTrainerSlot->id,
+                            'begins' => (string) $futureTrainerSlot->begins,
+                            'description' => $futureTrainerSlot->description,
+                            'status'    => TrainerStatus::PENDING
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+    }
+}


### PR DESCRIPTION
- New table: trainer_status. Use to indicate if a trainer attended/taught a session.
- Use trainer_status to determine if a person can sign into a position, and indicate if a training session was 'passed' as a trainer.
- New report training/{id}/trainer-attendance - retrieves all trainers for a module in a given year and indicates the status of each session signed up for.