### PR TITLE
Minor tweaks.

### DIFF
--- a/app/Http/Controllers/PersonMessageController.php
+++ b/app/Http/Controllers/PersonMessageController.php
@@ -48,7 +48,7 @@ class PersonMessageController extends ApiController
         $person_message->creator_person_id = $this->user->id;
 
         if ($person_message->save()) {
-            $person = Person::find($person_message->person_id);
+            $person = $person_message->person;
             RBS::clubhouseMessageNotify($person, $this->user->id,
                 $person_message->message_from, $person_message->subject, $person_message->body);
             return $this->success($person_message);

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -101,6 +101,21 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         Person::SUSPENDED
     ];
 
+    /*
+     * No messages status are those that should not receive any messages
+     * either Clubhouse Messaging or the RBS
+     */
+
+    const NO_MESSAGES_STATUSES = [
+        Person::BONKED,
+        Person::DECEASED,
+        Person::DISMISSED,
+        Person::PAST_PROSPECTIVE,
+        Person::RESIGNED,
+        Person::SUSPENDED,
+        Person::UBERBONKED
+    ];
+
 
     /**
      * The database table name.

--- a/app/Models/PersonMessage.php
+++ b/app/Models/PersonMessage.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 use App\Models\ApiModel;
 use App\Helpers\DateHelper;
+use App\Models\Person;
 
 class PersonMessage extends ApiModel
 {
@@ -59,6 +60,10 @@ class PersonMessage extends ApiModel
             ->get(['person_message.*', 'creator.callsign as creator_callsign', 'sender.id as sender_person_id']);
     }
 
+    public function person() {
+        return $this->belongsTo(Person::class);
+    }
+
     public static function countUnread($personId)
     {
         return PersonMessage::where('person_id', $personId)->where('delivered', false)->count();
@@ -88,6 +93,11 @@ class PersonMessage extends ApiModel
                     throw new \Illuminate\Database\Eloquent\ModelNotFoundException("Callsign $this->recipient_callsign does not exist");
                 }
                 $this->addError('recipient_callsign', 'Callsign does not exist');
+                return false;
+            }
+
+            if (in_array($recipient->status, Person::NO_MESSAGES_STATUSES)) {
+                $this->addError('recipient_callsign', "Person has the status {$recipient->status} and may not be sent a message.");
                 return false;
             }
 

--- a/app/Models/PersonPhoto.php
+++ b/app/Models/PersonPhoto.php
@@ -372,6 +372,9 @@ class PersonPhoto extends ApiModel
             }
 
             $info['rejections'] = $rejections;
+            if (!empty($photo->reject_message)) {
+                $info['reject_message'] = $photo->reject_message;
+            }
         }
 
         return $info;

--- a/bin/checkphpsyntax
+++ b/bin/checkphpsyntax
@@ -22,7 +22,7 @@ fi;
 
 tmp="$(mktemp)";
 
-paths="${@:-./api ./src ./standard}";
+paths="${@:-./app ./tests ./database}";
 
 find ${paths} -name "*.php" -exec "${php_cmd}" -l {} ";" \
     | grep -v "No syntax errors detected in " \


### PR DESCRIPTION
- Send back the reject message for photo status (only reject reasons were sent)
- Clubhouse Messages were not honoring the RBS sandbox settings
- Ensure Cubhouse Messages block sending to inappropriate statuses (deceased, uberbonked, etc). Frontend already does this (via callsign lookup)