### PR TITLE
New Unified Flagging View support.

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -3,6 +3,8 @@
 namespace app\Http\Controllers;
 
 use Illuminate\Support\Facades\Auth;
+use \Illuminate\Support\Facades\DB;
+
 use Illuminate\Database\Eloquent\Collection;
 
 use App\Http\Controllers\Controller;
@@ -13,8 +15,6 @@ use App\Models\Role;
 
 use App\Http\RestApi\SerializeRecord;
 use App\Http\RestApi\DeserializeRecord;
-
-use DB;
 
 class ApiController extends Controller
 {
@@ -119,6 +119,16 @@ class ApiController extends Controller
         return response()->json($json);
     }
 
+    /**
+     * Return either a JSON success if all arguments are null or
+     * a REST json success response
+     *
+     * @param mixed $resource an array, eloquent collection, or similar to return
+     * @param mixed $meta any meta information
+     * @param mixed $resourceName name of the resource, used when the collection is empty.
+     * @return \Illuminate\Http\JsonResponse
+     */
+
     public function success($resource=null, $meta=null, $resourceName = null)
     {
         if ($resource === null) {
@@ -194,6 +204,13 @@ class ApiController extends Controller
             $targetPersonId
         );
     }
+
+    /**
+     * Tells the user (via Handler::render) the operation is not authorized
+     *
+     * @param $message string to send back
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
 
     public function notPermitted($message)
     {

--- a/app/Http/Controllers/IntakeController.php
+++ b/app/Http/Controllers/IntakeController.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Validation\Rule;
+
+use App\Lib\Intake;
+
+use App\Models\Person;
+use App\Models\PersonIntake;
+use App\Models\PersonIntakeNote;
+
+use App\Http\Controllers\ApiController;
+
+use App\Models\Role;
+
+class IntakeController extends ApiController
+{
+    /**
+     * Retrieve all the PNVs and their intake history for a given year
+     *
+     * @return \Illuminate\Http\JsonResponse
+     * @throws AuthorizationException
+     */
+    public function index()
+    {
+        $this->roleCheck();
+        $year = $this->getYear();
+
+        return response()->json([ 'people' => Intake::retrieveAllForYear($year) ]);
+    }
+
+    /**
+     * Retrieve the PNV intake history for a given year.
+     * (similar to IntakeController::index but for a specific person)
+     *
+     * @param Person $person
+     * @return \Illuminate\Http\JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function history(Person $person)
+    {
+        $this->roleCheck();
+        $year = $this->getYear();
+
+        return response()->json(['person' => Intake::retrieveIdsForYear([$person->id], $year, false)[0]]);
+    }
+
+    /**
+     * Append a note and/or set a ranking for a type & year
+     *
+     * @param Person $person
+     * @return \Illuminate\Http\JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function appendNote(Person $person)
+    {
+        $params = request()->validate([
+            'year' => 'required|integer',
+            'type' => [
+                'required',
+                Rule::in(['rrn', 'vc', 'mentor'])
+            ],
+            'note' => 'sometimes|string',
+            'ranking' => 'sometimes|integer|nullable'
+        ]);
+
+        $type = $params['type'];
+        switch ($type) {
+            case 'vc':
+                $role = Role::VC;
+                break;
+            case 'mentor':
+                $role = Role::MENTOR;
+                break;
+            default:
+                $role = Role::INTAKE;
+                break;
+
+        }
+
+        if (!$this->userHasRole($role)) {
+            $this->notPermitted("Not authorized");
+        }
+
+        $year = $params['year'];
+        $personId = $person->id;
+
+        $note = $params['note'] ?? null;
+
+        if ($note) {
+            PersonIntakeNote::record($personId, $year, $type, $note);
+        }
+
+        if (isset($params['ranking'])) {
+            $rank = $params['ranking'];
+            $rankAttr = $type . "_rank";
+            $intake = PersonIntake::findForPersonYearOrNew($personId, $year);
+            $intake->{$rankAttr} = $rank;
+            if ($intake->isDirty($rankAttr)) {
+                $rankUpdated = true;
+                $oldRank = $intake->getOriginal($rank);
+            } else {
+                $rankUpdated = false;
+            }
+            $intake->save();
+            if ($rankUpdated) {
+                PersonIntakeNote::record($personId, $year, $type, "rank change [". ($oldRank ?? 'no rank')."] -> [".($rank ?? 'no rank')."]", true);
+            }
+        }
+
+        return $this->success();
+    }
+
+    /**
+     * Set or clear the black flag on a person / year intake record
+     *
+     * @param Person $person
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+
+    public function setBlackFlag(Person $person)
+    {
+        if (!$this->userHasRole(Role::ADMIN)) {
+            $this->notPermitted('Not authorized');
+        }
+
+        $params = request()->validate([
+            'year' => 'required|integer',
+            'black_flag' => 'required|boolean'
+        ]);
+
+        $intake = PersonIntake::findForPersonYearOrNew($person->id, $params['year']);
+        $intake->black_flag = $params['black_flag'];
+        $changes = $intake->getChangedValues();
+        $isNew = !$intake->id;
+        $intake->save();
+
+        $this->logIntakeChanges($person, $changes, $isNew, $intake);
+
+        return $this->success();
+    }
+
+    /**
+     * Check for the INTAKE role.
+     *
+     * @return void
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+
+    private function roleCheck() : void {
+        if (!$this->userHasRole(Role::INTAKE)) {
+            $this->notPermitted('Must have the Intake role');
+        }
+    }
+
+    /**
+     * Log any changes to an intake record
+     *
+     * @param Person $person person to log
+     * @param array $changes the changes to record
+     * @param bool $isNew true if the intake record was created
+     * @param PersonIntake $intake record itself
+     */
+
+    private function logIntakeChanges(Person $person, array $changes, bool $isNew, PersonIntake $intake)
+    {
+        if (empty($changes)) {
+            return;
+        }
+
+        if (!$isNew) {
+            $changes['id'] = $intake->id;
+        }
+
+        $this->log($isNew ? 'person-intake-create' : 'person-intake-update', '', $isNew ? $intake : $changes, $person->id);
+    }
+}

--- a/app/Http/Controllers/MaintenanceController.php
+++ b/app/Http/Controllers/MaintenanceController.php
@@ -261,10 +261,12 @@ class MaintenanceController extends ApiController
 
             if ($person->resetCallsign()) {
                 $person->callsign_approved = false;
+                $oldStatus = $person->status;
                 $person->status = Person::PAST_PROSPECTIVE;
                 $changes = $person->getChangedValues();
                 $person->saveWithoutValidation();
                 $this->log('person-update', 'maintenance - pnv reset', $changes, $person->id);
+                $person->changeStatus(Person::PAST_PROSPECTIVE, $oldStatus, 'maintenance - pnv reset');
                 $result['callsign_reset'] = $person->callsign;
             } else {
                 $result['error'] = 'Cannot reset callsign';

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -216,6 +216,8 @@ class PersonController extends ApiController
                     //'contact_log',
                     'manual_review',
                     'mentee_status',
+                    'person_intake',
+                    'person_intake_note',
                     'person_language',
                     'person_mentor',
                     'person_message',
@@ -226,6 +228,7 @@ class PersonController extends ApiController
                     'timesheet',
                     'timesheet_log',
                     'timesheet_missing',
+                    'trainee_note',
                     'trainee_status',
                     'trainer_status'
                 ];
@@ -894,7 +897,10 @@ class PersonController extends ApiController
         if (!empty($photoStatus)) {
             $photo = PersonPhoto::where('person_id', $person->id)->first();
             if (!$photo) {
-                $photo = new PersonPhoto([ 'person_id' => $person->id ]);
+                $photo = new PersonPhoto;
+                $photo->person_id = $person->id;
+                $photo->image_filename = 'test.jpg';
+                $photo->orig_filename = 'test-orig.jpg';
             }
 
             $photo->status = $photoStatus;
@@ -1066,5 +1072,16 @@ class PersonController extends ApiController
         }
 
         throw new \InvalidArgumentException("Unknown onboard debugging command");
+    }
+
+    /**
+     * Retrieve status history
+     */
+
+    public function statusHistory(Person $person)
+    {
+        $this->authorize('statusHistory', Person::class);
+
+        return response()->json([ 'history' => PersonStatus::retrieveAllForId($person->id) ]);
     }
 }

--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -13,6 +13,7 @@ use App\Models\PositionCredit;
 use App\Models\Role;
 use App\Models\TraineeStatus;
 use App\Models\TrainerStatus;
+use App\Models\TraineeNote;
 
 use App\Helpers\SqlHelper;
 
@@ -28,6 +29,7 @@ class SlotController extends ApiController
      *
      * @return \Illuminate\Http\Response
      */
+
     public function index()
     {
         $this->authorize('index', Slot::class);
@@ -230,6 +232,7 @@ class SlotController extends ApiController
         PersonSlot::deleteForSlot($slot->id);
         TraineeStatus::deleteForSlot($slot->id);
         TrainerStatus::deleteForSlot($slot->id);
+        TraineeNote::deleteForSlot($slot->id);
 
         $this->log('slot-delete', 'delete', [ 'slot' => $slot ]);
 

--- a/app/Http/Filters/PersonFilter.php
+++ b/app/Http/Filters/PersonFilter.php
@@ -107,10 +107,9 @@ class PersonFilter
         'bpguid',
     ];
 
-    const MENTOR_FIELDS = [
-        'mentors_flag',
-        'mentors_flag_note',
-        'mentors_notes',
+    const INTAKE_FIELDS = [
+        'known_rangers',
+        'known_pnvs'
     ];
 
     const SMS_FIELDS = [
@@ -163,7 +162,7 @@ class PersonFilter
         [ self::EVENT_FIELDS, true, [ Role::VIEW_PII,  Role::MANAGE, Role::VC, Role::TRAINER, Role::EDIT_BMIDS ] ],
         [ self::BMID_FIELDS, true, [ Role::VIEW_PII,  Role::MANAGE, Role::VC, Role::TRAINER, Role::MENTOR, Role::EDIT_BMIDS ] ],
         // Note: self is not allowed to see mentor notes
-        [ self::MENTOR_FIELDS, false, [ Role::MENTOR, Role::TRAINER, Role::VC ] ],
+        [ self::INTAKE_FIELDS, false, [ Role::MENTOR, Role::TRAINER, Role::VC, Role::INTAKE ] ],
         [ self::SMS_FIELDS, true, [ Role::ADMIN ]],
         [ self::SMS_ADMIN_FIELDS, true, [ Role::ADMIN ]],
         [ self::RANGER_ADMIN_FIELDS ],
@@ -185,7 +184,7 @@ class PersonFilter
         [ self::AGREEMENT_FIELDS, true, [ Role::ADMIN ]],
         [ self::EVENT_FIELDS, false, [ Role::MANAGE, Role::VC, Role::TRAINER, Role::MENTOR ]],
         [ self::BMID_FIELDS, true, [  Role::EDIT_BMIDS ] ],
-        [ self::MENTOR_FIELDS, false, [ Role::MENTOR, Role::TRAINER, Role::VC ] ],
+        [ self::INTAKE_FIELDS, false, [ Role::INTAKE, Role::VC ] ],
         [ self::SMS_FIELDS, true, [ Role::ADMIN ]],
         [ self::SMS_ADMIN_FIELDS, false, [ Role::ADMIN ]],
         [ self::PERSONNEL_FIELDS, false, [ Role::ADMIN ]],

--- a/app/Lib/Alpha.php
+++ b/app/Lib/Alpha.php
@@ -3,13 +3,15 @@
 namespace App\Lib;
 
 use App\Models\Person;
+use App\Models\PersonIntake;
+use App\Models\PersonIntakeNote;
 use App\Models\PersonMentor;
+use App\Models\PersonPhoto;
 use App\Models\PersonPosition;
 use App\Models\PersonSlot;
-use App\Models\PersonPhoto;
 use App\Models\Position;
 use App\Models\Slot;
-use App\Models\TraineeStatus;
+use App\Models\Timesheet;
 use App\Models\Training;
 
 use Illuminate\Support\Facades\DB;
@@ -22,90 +24,99 @@ class Alpha
         $positionId = Position::MENTOR;
 
         $rows = DB::table('person')
-                ->select(
-                    'person.id',
-                    'person.callsign',
-                    DB::raw("EXISTS (SELECT 1 FROM timesheet WHERE timesheet.person_id=person.id AND position_id=$positionId AND YEAR(on_duty)=$year AND off_duty IS NULL) as working")
-                )
-                ->join('person_position', 'person_position.person_id', '=', 'person.id')
-                ->where('person_position.position_id', Position::MENTOR)
-                ->orderBy('callsign')
-                ->get();
+            ->select(
+                'person.id',
+                'person.callsign',
+                DB::raw("EXISTS (SELECT 1 FROM timesheet WHERE timesheet.person_id=person.id AND position_id=$positionId AND YEAR(on_duty)=$year AND off_duty IS NULL) as working")
+            )
+            ->join('person_position', 'person_position.person_id', '=', 'person.id')
+            ->where('person_position.position_id', Position::MENTOR)
+            ->orderBy('callsign')
+            ->get();
         return $rows;
     }
 
-    public static function retrievePotentials($noBonks = false, $excludePhotos=false)
+    /**
+     * Retrieve Potential Alphas
+     *
+     * @param bool $noBonks true if Bonked status are to be included
+     * @return array
+     */
+
+    public static function retrievePotentials($noBonks = false)
     {
         $year = current_year();
 
         // Find potential alphas who signed up for training this year.
-        $statuses = $noBonks ? [ 'alpha', 'prospective' ] : [ 'alpha', 'prospective', 'bonked' ];
+        $statuses = $noBonks ? [Person::ALPHA, Person::PROSPECTIVE] : [Person::ALPHA, Person::PROSPECTIVE, Person::BONKED];
         $sql = Person::whereIn('status', $statuses)
             ->where('user_authorized', true)
             ->whereRaw("EXISTS
                 (SELECT 1 FROM person_slot JOIN slot ON person_slot.slot_id=slot.id
                     AND slot.position_id=? AND YEAR(slot.begins)=?
-                WHERE person_slot.person_id=person.id LIMIT 1)", [ Position::TRAINING, $year ])
+                WHERE person_slot.person_id=person.id LIMIT 1)", [Position::TRAINING, $year])
             ->orderBy('callsign');
 
         $rows = $sql->get();
 
-        return self::buildAlphaInformation($rows, current_year(), $excludePhotos);
+        return self::buildAlphaInformation($rows, $year);
     }
 
-    public static function buildAlphaInformation($people, $year, $excludePhotos = false)
+    public static function buildAlphaInformation($people, $year)
     {
         if ($people->isEmpty()) {
             return [];
         }
 
+        list ($intakeHistory, $intakeNotes, $trainings) = self::retrieveIntakeHistory($people->pluck('id')->toArray());
+
         // Find out the signed up shifts
         $alphaSlots = DB::table('person_slot')
-                ->select(
-                    'slot.id as slot_id',
-                    'slot.description',
-                    'slot.begins',
-                    'person_slot.person_id'
-               )->join('slot', function ($j) use ($year) {
-                   $j->on('slot.id', 'person_slot.slot_id');
-                   $j->whereYear('slot.begins', $year);
-                   $j->where('slot.position_id', Position::ALPHA);
-               })
-                ->whereIn('person_slot.person_id', $people->pluck('id')->toArray())
-                ->orderBy('slot.begins')
-                ->get()
-                ->groupBy('person_id');
+            ->select(
+                'slot.id as slot_id',
+                'slot.description',
+                'slot.begins',
+                'person_slot.person_id'
+            )->join('slot', function ($j) use ($year) {
+                $j->on('slot.id', 'person_slot.slot_id');
+                $j->whereYear('slot.begins', $year);
+                $j->where('slot.position_id', Position::ALPHA);
+            })
+            ->whereIn('person_slot.person_id', $people->pluck('id')->toArray())
+            ->orderBy('slot.begins')
+            ->get()
+            ->groupBy('person_id');
 
-        $potentials = $people->map(function ($row) use ($year, $alphaSlots, $excludePhotos) {
-            $person = self::buildPerson($row, $year, $excludePhotos);
+        $potentials = [];
+        foreach ($people as $row) {
+            $person = self::buildPerson($row, $year, $intakeHistory, $intakeNotes, $trainings);
             $slot = $alphaSlots[$row->id] ?? null;
             if ($slot) {
                 // Only grab the first slot
                 $slot = $slot[0];
-
                 $person->alpha_slot = [
-                    'slot_id'   => $slot->slot_id,
-                    'begins'    => $slot->begins,
+                    'slot_id' => $slot->slot_id,
+                    'begins' => $slot->begins,
                     'description' => $slot->description,
                 ];
             }
-            return $person;
-        });
+            $potentials[] = $person;
+        }
 
         return $potentials;
     }
 
-    public static function findAllAlphas()
+    public static function retrieveAllAlphas()
     {
         $rows = PersonPosition::where('position_id', Position::ALPHA)
-                ->with('person')
-                ->get()
-                ->filter(function ($r) {
-                    return $r->person != null;
-                })
-                ->sortBy('person.callsign', SORT_NATURAL|SORT_FLAG_CASE)
-                ->pluck('person')
-                ->values();
+            ->with('person')
+            ->get()
+            ->filter(function ($r) {
+                return $r->person != null;
+            })
+            ->sortBy('person.callsign', SORT_NATURAL | SORT_FLAG_CASE)
+            ->pluck('person')
+            ->values();
 
         return self::buildAlphaInformation($rows, current_year());
     }
@@ -114,89 +125,116 @@ class Alpha
     {
         // Find the Alpha slots
         $slots = Slot::whereYear('begins', $year)
-                ->where('position_id', Position::ALPHA)
-                ->get();
+            ->where('position_id', Position::ALPHA)
+            ->get();
 
         // Next, find the Alpha sign ups
         $rows = PersonSlot::whereIn('slot_id', $slots->pluck('id')->toArray())
-                ->with('person')
-                ->get()
-                ->sortBy('person.callsign', SORT_NATURAL|SORT_FLAG_CASE)
-                ->values();
+            ->with('person')
+            ->get()
+            ->sortBy('person.callsign', SORT_NATURAL | SORT_FLAG_CASE)
+            ->values();
 
-        $slotInfo = $slots->map(function($slot) {
-            return (object) [
-                'id'          => $slot->id,
-                'begins'      => (string) $slot->begins,
+        $slotInfo = $slots->map(function ($slot) {
+            return (object)[
+                'id' => $slot->id,
+                'begins' => (string)$slot->begins,
                 'description' => $slot->description,
-                'people'      => []
+                'people' => []
             ];
         });
 
 
         $slotsById = $slotInfo->keyBy('id');
 
+        list ($intakeHistory, $intakeNotes, $trainings) = self::retrieveIntakeHistory($rows->pluck('person_id'));
+
         foreach ($rows as $row) {
-            $slotsById[$row->slot_id]->people[] = self::buildPerson($row->person, $year, true);
+            $slotsById[$row->slot_id]->people[] = self::buildPerson($row->person, $year, $intakeHistory, $intakeNotes, $trainings);
         }
 
         return $slotInfo;
     }
 
-    public static function buildPerson($row, $year, $excludePhotos=false) {
-        $fka = $row->formerly_known_as;
-        if (empty($fka)) {
-            $fka = null;
-        } else {
-            $fka = preg_split('/\s*,\s*/', $fka);
-        }
-        $person = (object) [
-            'id'                => $row->id,
-            'callsign'          => $row->callsign,
-            'callsign_approved' => $row->callsign_approved,
-            'fka'               => $fka,
-            'first_name'        => $row->first_name,
-            'last_name'         => $row->last_name,
-            'email'             => $row->email,
-            'status'            => $row->status,
-            'gender'            => Person::summarizeGender($row->gender),
-            'mentors_flag'      => $row->mentors_flag,
-            'mentors_flag_note' => $row->mentors_flag_note,
-            'mentors_notes'     => $row->mentors_notes,
-            'mentor_history'    => PersonMentor::retrieveMentorHistory($row->id),
-            'has_note_on_file'  => $row->has_note_on_file,
-            'create_date'       => (string) $row->create_date,
-            'city'              => $row->city,
-            'state'             => $row->state,
-            'country'           => $row->country,
-            'longsleeveshirt_size_style' => $row->longsleeveshirt_size_style,
-            'teeshirt_size_style' => $row->teeshirt_size_style,
-            'trained'           => false,
-            'trainings'         => Training::retrieveDirtTrainingsForPersonYear($row->id, $year),
+    public static function buildPerson($person, $year, $intakeHistory, $intakeNotes, $trainings)
+    {
+        $personId = $person->id;
+        $potential = (object)[
+            'id' => $personId,
+            'callsign' => $person->callsign,
+            'callsign_approved' => $person->callsign_approved,
+            'fkas' => $person->formerlyKnownAsArray(true),
+            'first_name' => $person->first_name,
+            'last_name' => $person->last_name,
+            'email' => $person->email,
+            'status' => $person->status,
+            'gender' => $person->gender,
+            'mentor_history' => PersonMentor::retrieveMentorHistory($person->id),
+            'photo_approved' => PersonPhoto::retrieveStatus($person) == PersonPhoto::APPROVED,
+            'has_note_on_file' => $person->has_note_on_file,
+            'city' => $person->city,
+            'state' => $person->state,
+            'country' => $person->country,
+            'longsleeveshirt_size_style' => $person->longsleeveshirt_size_style,
+            'teeshirt_size_style' => $person->teeshirt_size_style,
+            'trained' => false,
+            'trainings' => $trainings[$personId] ?? [],
+            'on_alpha_shift' => Timesheet::isPersonSignIn($personId, Position::ALPHA)
         ];
 
-        $result = DB::select('SELECT 1 AS on_duty FROM timesheet WHERE person_id=? AND YEAR(on_duty)=? AND position_id=? AND off_duty IS NULL LIMIT 1',
-                    [ $row->id, $year, Position::ALPHA] );
-        $person->on_alpha_shift = (isset($result[0]) && $result[0]->on_duty);
+        $rrnRanks = [];
+        $vcRanks = [];
 
-        if (!$excludePhotos) {
-            $photo = PersonPhoto::retrieveInfo($row);
-            $person->photo_approved = ($photo['photo_status'] == 'approved');
-            $person->photo_status = $photo['photo_status'];
-            if ($person->photo_approved) {
-                $person->photo_url = $photo['photo_url'];
+        $teamHistory = $intakeHistory[$personId] ?? null;
+        if (!empty($teamHistory)) {
+            foreach ($teamHistory as $r) {
+                if ($r->year == $year && $r->black_flag) {
+                    $potential->black_flag = true;
+                }
+
+                if ($r->rrn_rank > 0 && $r->rrn_rank != Intake::AVERAGE) {
+                    $rrnRanks[] = ['year' => $r->year, 'rank' => $r->rrn_rank];
+                }
+
+                if ($r->vc_rank > 0 && $r->vc_rank != Intake::AVERAGE) {
+                    $vcRanks[$r->year] = ['year' => $r->year, 'rank' => $r->vc_rank];
+                }
             }
         }
 
-        // Figure out if the person passed (any) training
-        foreach ($person->trainings as $t) {
-            if ($t->passed) {
-                $person->trained = true;
-                break;
+        $potential->rrn_ranks = $rrnRanks;
+        $potential->vc_ranks = $vcRanks;
+        $potential->mentor_team = Intake::buildIntakeTeam('mentor', $teamHistory, $intakeNotes[$personId] ?? null, $haveFlag);
+
+        if (!empty($teamHistory)) {
+            foreach ($teamHistory as $history) {
+                if ($history->mentor_rank >= Intake::BELOW_AVERAGE) {
+                    $potential->have_mentor_flags = true;
+                }
+
+                if ($history->year == $year && $history->black_flag) {
+                    $potential->black_flag = true;
+                }
             }
         }
 
-        return $person;
+        foreach ($potential->trainings as $training) {
+            if ($training->slot_year == $year && $training->training_passed) {
+                $potential->trained = true;
+            }
+        }
+
+        if ($potential->status == Person::PROSPECTIVE && $potential->callsign_approved && $potential->photo_approved) {
+            $potential->alpha_status_eligible = true;
+        } else if ($potential->status == Person::ALPHA) {
+            $potential->alpha_status_eligible = true;
+        }
+
+        if ($potential->trained && $potential->callsign_approved && $potential->photo_approved) {
+            $potential->alpha_position_eligible = true;
+        }
+
+        return $potential;
     }
 
     public static function retrieveVerdicts()
@@ -204,12 +242,31 @@ class Alpha
         $year = current_year();
 
         $people = DB::table('person')
-                ->select('person.id', 'callsign', 'person.status', 'first_name', 'last_name',
-                    DB::raw("(SELECT person_mentor.status FROM person_mentor WHERE person_mentor.person_id=person.id AND mentor_year=$year GROUP BY person_mentor.status LIMIT 1) as mentor_status")
-                )
-                ->where('status', 'alpha')
-                ->orderBy('person.callsign')
-                ->get();
-        return $people->filter(function ($p) { return $p->mentor_status != 'pending'; })->values();
+            ->select('person.id', 'callsign', 'person.status', 'first_name', 'last_name',
+                DB::raw("(SELECT person_mentor.status FROM person_mentor WHERE person_mentor.person_id=person.id AND mentor_year=$year GROUP BY person_mentor.status LIMIT 1) as mentor_status")
+            )
+            ->where('status', Person::ALPHA)
+            ->orderBy('person.callsign')
+            ->get();
+        return $people->filter(function ($p) {
+            return $p->mentor_status != 'pending';
+        })->values();
+    }
+
+    public static function retrieveIntakeHistory($pnvIds)
+    {
+        $year = current_year();
+
+        $intakeHistory = PersonIntake::whereIn('person_id', $pnvIds)
+            ->orderBy('person_id')
+            ->orderBy('year')
+            ->get()
+            ->groupBy('person_id');
+
+        $intakeNotes = PersonIntakeNote::retrieveHistoryForPersonIds($pnvIds, $year);
+
+        $trainings = Training::retrieveTrainingHistoryForIds($pnvIds, Position::TRAINING, $year);
+
+        return [$intakeHistory, $intakeNotes, $trainings];
     }
 }

--- a/app/Lib/Intake.php
+++ b/app/Lib/Intake.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace App\Lib;
+
+use App\Models\Person;
+use App\Models\PersonStatus;
+use App\Models\PersonMentor;
+use App\Models\PersonIntake;
+use App\Models\PersonIntakeNote;
+use App\Models\Position;
+use App\Models\Training;
+use App\Models\Timesheet;
+
+use Carbon\Carbon;
+
+class Intake
+{
+    /**
+     * Retrieve all PNVs in a given year.
+     *
+     * @param int $year Year to find the PNVs
+     * @return array
+     */
+
+    const ABOVE_AVERAGE = 1;
+    const AVERAGE = 2;
+    const BELOW_AVERAGE = 3;
+    const FLAG = 4;
+
+    public static function retrieveAllForYear(int $year)
+    {
+        // Find any PNVs in a given year
+        $pnvIds = PersonStatus::select('person_id')
+            ->whereYear('created_at', $year)
+            ->whereIn('new_status', [Person::PROSPECTIVE, Person::ALPHA])
+            ->groupBy('person_id')
+            ->get()
+            ->pluck('person_id')->toArray();
+
+        return self::retrieveIdsForYear($pnvIds, $year);
+    }
+
+    /**
+     * Retrieve the intake history for a given set of Ids
+     * (this assumes the ids were originally found in self::retrieveAllForYear)
+     *
+     * @param array $pnvIds PNV ids to find
+     * @param int $year
+     * @return array
+     */
+
+    public static function retrieveIdsForYear(array $pnvIds, int $year, bool $onlyFlagged = true)
+    {
+        // Find the ALL intake records for the folks in question.
+        $peopleIntake = PersonIntake::whereIn('person_id', $pnvIds)
+            ->where('year', '<=', $year)
+            ->orderBy('person_id')
+            ->orderBy('year')
+            ->get()
+            ->groupBy('person_id');
+
+        $personStatuses = PersonStatus::whereIn('person_id', $pnvIds)
+            ->whereIn('new_status', [Person::AUDITOR, Person::PROSPECTIVE, Person::ALPHA])
+            ->whereYear('created_at', '<=', $year)
+            ->orderBy('person_id')
+            ->orderBy('created_at')
+            ->get()
+            ->groupBy('person_id');
+
+        $peopleIntakeNotes = PersonIntakeNote::retrieveHistoryForPersonIds($pnvIds, $year);
+
+        $trainings = Training::retrieveTrainingHistoryForIds($pnvIds, Position::TRAINING, $year);
+        $mentors = PersonMentor::retrieveAllMentorsForIds($pnvIds, $year);
+        $alphaEntries = Timesheet::retrieveAllForPositionIds($pnvIds, Position::ALPHA, $year);
+
+        // Find the people
+        $people = Person::whereIn('id', $pnvIds)->orderBy('callsign')->get();
+
+        $pnvs = [];
+        foreach ($people as $person) {
+            $haveFlag = false;
+
+            $personId = $person->id;
+            $pnv = [
+                'id' => $person->id,
+                'callsign' => $person->callsign,
+                'status' => $person->status,
+                'first_name' => $person->first_name,
+                'last_name' => $person->last_name,
+                'formerly_known_as' => $person->formerlyKnownAsArray(true),
+                'known_rangers' => $person->knownRangersArray(),
+                'known_pnvs' => $person->knownPnvsArray(),
+                'black_flag_years' => [],
+            ];
+
+            $intakeYears = $peopleIntake[$personId] ?? null;
+            $intakeNotes = $peopleIntakeNotes[$personId] ?? null;
+            foreach (['rrn', 'mentor', 'vc'] as $type) {
+                $pnv[$type . '_team'] = self::buildIntakeTeam($type, $intakeYears, $intakeNotes, $haveFlag);
+            }
+
+            if (!empty($intakeYears)) {
+                foreach ($intakeYears as $r) {
+                    if ($r->black_flag) {
+                        $pnv['black_flag_years'][] = $r->year;
+                        if ($r->year == $year) {
+                            $pnv['black_flag'] = true;
+                        }
+                    }
+                }
+            }
+
+            /*
+             * Build up the PNV mentor history
+             */
+
+            $pnvHistory = [];
+            if (isset($mentors[$personId])) {
+                foreach ($mentors[$personId] as $year => $mentorship) {
+                    $status = $mentorship['status'];
+                    $pnvHistory[(int) $year] = (object)[
+                        'mentor_status' => $mentorship['status'] ?? 'none',
+                        'mentors' => $mentorship['mentors'],
+                        'training_status' => 'none',
+                        'have_alpha_shift' => false
+                    ];
+
+                    if ($status == PersonMentor::BONK || $status == PersonMentor::SELF_BONK) {
+                        $haveFlag = true;
+                    }
+                }
+            }
+
+            if (isset($trainings[$personId])) {
+                $pnv['trainings'] = $trainings[$personId];
+
+                /*
+                 * Dig through the training records and find out years passed
+                 */
+                foreach ($trainings[$personId] as $training) {
+                    $trainYear = Carbon::parse($training->slot_begins)->year;
+
+                    if (!isset($pnvHistory[$trainYear])) {
+                        $pnvHistory[$trainYear] = (object)[
+                            'training_status' => 'none',
+                            'mentor_status' => 'none',
+                            'have_alpha_shift' => false
+                        ];
+                        // See if the person was an auditor that year
+                        if (isset($personStatuses[$personId]) && self::wasAuditorInYear($personStatuses[$personId], $trainYear)) {
+                            $pnvHistory[$trainYear]->was_auditor = true;
+                        }
+                    }
+
+                    $history = $pnvHistory[$trainYear];
+
+                    if ($training->training_rank >= self::BELOW_AVERAGE) {
+                        $haveFlag = true;
+                    }
+
+                    if ($history->training_status != 'pass') {
+                        if ($training->slot_has_ended) {
+                            $history->training_status = $training->training_passed ? 'pass' : 'no pass';
+                        } else {
+                            $history->training_status = 'pending';
+                        }
+                    }
+                }
+            } else {
+                $pnv['trainings'] = [];
+            }
+
+            // Bail out if only flagged PNVs are being searched for
+            if ($onlyFlagged && !$haveFlag) {
+                continue;
+            }
+
+            /*
+              * Find any Alpha shifts
+              */
+
+            if (isset($alphaEntries[$personId])) {
+                foreach ($alphaEntries[$personId] as $alphaYear => $entries) {
+                    if (!isset($pnvHistory[$alphaYear])) {
+                        // An alpha shift without a mentor status.. hmmm..
+                        $pnvHistory[$alphaYear] = (object)[
+                            'training_status' => 'none',
+                            'mentor_status' => 'none'
+                        ];
+                    }
+                    $pnvHistory[$alphaYear]->have_alpha_shift = true;
+                }
+            }
+
+            /*
+             * Fill in any years based on status history
+             */
+
+            if (isset($personStatuses[$personId])) {
+                $statusHistory = $personStatuses[$personId];
+                foreach ($statusHistory as $history) {
+                    $year = $history->created_at->year;
+                    if (!isset($pnvHistory[$year])) {
+                        $pnvHistory[$year] = (object)[
+                            'training_status' => 'none',
+                            'mentor_status' => 'none'
+                        ];
+
+                        if (self::wasAuditorInYear($statusHistory, $year)) {
+                            $pnvHistory[$year]->was_auditor = true;
+                        }
+                    }
+                }
+            }
+
+            $pnv['pnv_history'] = $pnvHistory;
+
+            $pnvs[] = $pnv;
+        }
+
+        return $pnvs;
+    }
+
+    public static function wasAuditorInYear($statuses, $year)
+    {
+        $possible = null;
+        foreach ($statuses as $row) {
+            $status = $row->new_status;
+            $statusYear = $row->created_at->year;
+            if ($statusYear < $year) {
+                if ($status == Person::AUDITOR) {
+                    $possible = $row;
+                }
+            } else if ($statusYear == $year) {
+                return ($status == Person::AUDITOR);
+            } else if ($statusYear > $year) {
+                return ($possible && $possible->new_status == Person::AUDITOR);
+            }
+        }
+
+        return ($possible && $possible->new_status == Person::AUDITOR);
+    }
+
+    public static function buildIntakeTeam($type, $rankings, $notes, &$haveFlag)
+    {
+        $teamYears = [];
+        $rankName = $type . '_rank';
+
+        if (!empty($rankings)) {
+            foreach ($rankings as $r) {
+                $rank = $r->{$rankName};
+                // Skip non-ranking
+                if (!$rank) {
+                    continue;
+                }
+
+                $teamYears[$r->year] = [ 'rank' => $rank ];
+
+                if ($rank >= self::BELOW_AVERAGE) {
+                    $haveFlag = true;
+                }
+            }
+        }
+
+        if (!empty($notes)) {
+            $haveNote = false;
+            foreach ($notes as $note) {
+                if ($note->type != $type) {
+                    continue;
+                }
+                $teamYears[$note->year]['notes'][] = $note;
+                if (!$note->is_log) {
+                    // A year may have only a rank and no text notes (only audit log notes)
+                    $teamYears[$note->year]['have_notes'] = true;
+                }
+            }
+        }
+
+        $result = [];
+        foreach ($teamYears as $year => $info) {
+            $info['year'] = $year;
+            $result[] = $info;
+        }
+
+        usort($result, function ($a, $b) { return $a['year'] <=> $b['year']; });
+        return $result;
+    }
+}

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -14,6 +14,7 @@ class ActionLog extends Model
     protected $guarded = [];
 
     protected $casts = [
+        'created_at' => 'datetime',
         'data' => 'array'
     ];
 
@@ -157,7 +158,7 @@ class ActionLog extends Model
         $log = new ActionLog;
         $log->event = $event;
         $log->person_id = $person ? $person->id : null;
-        $log->message = $message;
+        $log->message = $message ?? '';
         $log->target_person_id = $targetPersonId;
 
         if ($data) {

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -54,16 +54,17 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
     const INACTIVE = 'inactive';
     const INACTIVE_EXTENSION = 'inactive extension';
     const NON_RANGER = 'non ranger';
-    const PAST_PROSPECTIVE = 'past prospective';
+    const PAST_PROSPECTIVE = 'past prospective'; // No longer used - retained for archival proposes
     const PROSPECTIVE = 'prospective';
     const PROSPECTIVE_WAITLIST = 'prospective waitlist';
     const RESIGNED = 'resigned';
     const RETIRED = 'retired';
     const SUSPENDED = 'suspended';
     const UBERBONKED = 'uberbonked';
+    const VINTAGE = 'vintage'; // No longer used -- retained for archival proposes
 
     /*
-     *Statuses consider 'live' or still active account allowed
+     * Statuses consider 'live' or still active account allowed
      * to login, and do stuff.
      * Used by App\Validator\StateForCountry & BroadcastController
      */
@@ -75,9 +76,10 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         Person::INACTIVE_EXTENSION,
         Person::NON_RANGER,
         Person::PAST_PROSPECTIVE,
-        Person::PROSPECTIVE_WAITLIST,
+//        Person::PROSPECTIVE_WAITLIST,
         Person::PROSPECTIVE,
-        Person::RETIRED
+        Person::RETIRED,
+//        Person::VINTAGE
     ];
 
     const ACTIVE_STATUSES = [
@@ -215,9 +217,9 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
 
         'active_next_event',
         'has_note_on_file',
-        'mentors_flag',
-        'mentors_flag_note',
-        'mentors_notes',
+
+        'known_rangers',
+        'known_pnvs',
 
         // 'meta' objects
        'languages',
@@ -1099,4 +1101,33 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         // Can't determine - return the value
         return $gender;
     }
+
+    public function formerlyKnownAsArray($filter=false) {
+        return self::splitCommas($this->formerly_known_as, $filter);
+    }
+
+    public function knownPnvsArray() {
+        return self::splitCommas($this->known_pnvs);
+    }
+
+    public function knownRangersArray() {
+        return self::splitCommas($this->known_rangers);
+    }
+
+    public static function splitCommas($str, $filter=false)
+    {
+        if (empty($str)) {
+            return [];
+        }
+
+        $names =  preg_split('/\s*,\s*/', trim($str));
+        if (!$filter) {
+            return $names;
+        }
+
+        return array_values(array_filter($names, function ($name) {
+           return !preg_match('/\d{2,4}[B]?(\(NR\))?$/', $name);
+        }));
+    }
+
 }

--- a/app/Models/PersonIntake.php
+++ b/app/Models/PersonIntake.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\ApiModel;
+use App\Models\Person;
+use Illuminate\Support\Facades\Auth;
+use App\Helpers\SqlHelper;
+
+class PersonIntake extends ApiModel
+{
+    protected $table = 'person_intake';
+    public $timestamps = true;
+
+    protected $guarded = [
+        'person_id',
+        'created_at',
+        'updated_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'date',
+        'updated_at' => 'date',
+        'black_flag' => 'boolean',
+    ];
+
+    public function person()
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public static function findForPersonYearOrNew($personId, $year)
+    {
+        $ps = self::where([ 'person_id' => $personId, 'year' => $year ])->first();
+        if ($ps) {
+            return $ps;
+        }
+
+        $ps = new self;
+        $ps->person_id = $personId;
+        $ps->year = $year;
+        return $ps;
+    }
+
+    public static function retrieveBlackFlagForIdsYear($personIds, $year) {
+        return self::select('person_id')
+                ->whereIn('person_id', $personIds)
+                ->where('black_flag', true)
+                ->where('year', $year)
+                ->pluck('person_id')
+                ->toArray();
+    }
+
+    public function setRrnRankAttribute($value) {
+        $this->attributes['rrn_rank'] = ($value == '') ? null : $value;
+    }
+
+    public function setMentorRankAttribute($value) {
+        $this->attributes['mentor_rank'] = ($value == '') ? null : $value;
+    }
+
+    public function setVcRankAttribute($value) {
+        $this->attributes['vc_rank'] = ($value == '') ? null : $value;
+    }
+}

--- a/app/Models/PersonIntakeNote.php
+++ b/app/Models/PersonIntakeNote.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\ApiModel;
+use App\Models\Person;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+
+class PersonIntakeNote extends ApiModel
+{
+    protected $table = 'person_intake_note';
+    public $timestamps = true;
+
+    protected $guarded = [ ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    protected $rules = [
+        'note'   => 'sometimes|string|nullable|max:64000'
+    ];
+
+    public function person()
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function person_source()
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    /**
+     * Find all the intake notes for the given people, and return
+     * the results grouped by the ids
+     *
+     * @param  $pnvIds
+     * @param int $year include all records up to the year
+     * @return Collection
+     */
+
+    public static function retrieveHistoryForPersonIds($pnvIds, int $year) {
+        return self::whereIn('person_id', $pnvIds)
+                ->where('year', '<=', $year)
+                ->orderBy('person_id')
+                ->orderBy('created_at')
+                ->with('person_source:id,callsign')
+                ->get()
+                ->groupBy('person_id');
+    }
+
+    /**
+     * Find all the intake notes for a person
+     *
+     * @param int $personId
+     * @param string $type
+     * @return Collection
+     */
+    public static function findAllForPersonType(int $personId, string $type) {
+        return self::whereIn('person_id', $personId)
+            ->where('type', $type)
+            ->orderBy('created_at')
+            ->with('person_source:id,callsign')
+            ->get();
+    }
+
+    /**
+     * Record the intake notes for a person
+     *
+     * @param int $personId Person to record
+     * @param int $year Year to record in
+     * @param string $noteType note type (vc, rrn, mentor)
+     * @param string $note the note itself
+     * @param bool $isLog true if the note is an audit note about the rank
+     * @return void
+     */
+    public static function record(int $personId, int $year, string $noteType, string $note, bool $isLog = false) : void
+    {
+        $user = Auth::user();
+
+        self::create([
+            'person_id' => $personId,
+            'year' => $year,
+            'type' => $noteType,
+            'note' => $note,
+            'is_log' => $isLog,
+            'person_source_id' => $user ? $user->id : 0
+        ]);
+    }
+}

--- a/app/Models/PersonPhoto.php
+++ b/app/Models/PersonPhoto.php
@@ -219,6 +219,7 @@ class PersonPhoto extends ApiModel
         $personStatus = $params['person_status'] ?? null;
         $personId = $params['person_id'] ?? null;
         $includeRejects = $params['include_rejects'] ?? null;
+        $sort = $params['sort'] ?? '';
 
         $page = $params['page'] ?? 1;
         $pageSize = $params['page_size'] ?? 100;
@@ -238,6 +239,7 @@ class PersonPhoto extends ApiModel
         if ($personStatus) {
             $sql->where('person.status', $personStatus);
         }
+
 
         // How many total for the query
         $total = $sql->count();
@@ -265,8 +267,11 @@ class PersonPhoto extends ApiModel
             $sql->orderBy('is_active', 'desc')
                 ->orderBy('person_photo.created_at', 'desc');
         } else {
-            $sql->orderBy('person.callsign', 'asc')
-            ->orderBy('person_photo.created_at');
+            if ($sort == 'callsign') {
+                $sql->orderBy('person.callsign', 'asc');
+            }
+
+            $sql->orderBy('person_photo.created_at', 'desc');
         }
 
         $rows = $sql->offset($page * $pageSize)
@@ -544,7 +549,7 @@ class PersonPhoto extends ApiModel
     }
 
     public static function storagePath(string $filename) : string {
-        $path = config('clubhouse.DeploymentEnvironment') == 'Staging' ? self::STORAGE_STAGING_DIR : self::STORAGE_DIR;
+        $path = (!app()->isLocal() && config('clubhouse.DeploymentEnvironment') == 'Staging') ? self::STORAGE_STAGING_DIR : self::STORAGE_DIR;
         return $path . $filename;
     }
 }

--- a/app/Models/PersonStatus.php
+++ b/app/Models/PersonStatus.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -13,7 +14,11 @@ class PersonStatus extends ApiModel
 {
     protected $table = 'person_status';
 
-    protected $guarded = [ ];
+    protected $guarded = [];
+
+    protected $casts = [
+        'created_at' => 'datetime'
+    ];
 
     public function person()
     {
@@ -25,14 +30,75 @@ class PersonStatus extends ApiModel
         return $this->belongsTo(Person::class);
     }
 
+    /**
+     * Record the change in a person's status.
+     *
+     * @param $personId person to track
+     * @param $oldStatus old status
+     * @param $newStatus new status
+     * @param $reason reason it changed
+     * @param $personSourceId user who made the change
+     */
+
     public static function record($personId, $oldStatus, $newStatus, $reason, $personSourceId)
     {
         self::create([
-            'person_id'        => $personId,
+            'person_id' => $personId,
             'person_source_id' => $personSourceId,
-            'old_status'       => $oldStatus,
-            'new_status'       => $newStatus,
-            'reason'           => $reason
+            'old_status' => $oldStatus,
+            'new_status' => $newStatus,
+            'reason' => $reason
         ]);
     }
+
+    /**
+     * Retrieve the status history for a person
+     *
+     * @param $personId
+     * @return Collection
+     */
+
+    public static function retrieveAllForId($personId)
+    {
+        return self::where('person_id', $personId)
+            ->with('person_source:id,callsign')
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    /**
+     * Find the PersonStatus record that exists on or before the time given.
+     * Used to determine a person's status at a given point in time.
+     *
+     * @param int $personId
+     * @param string|Carbon $time
+     * @return PersonStatus
+     */
+
+    public static function findForTime($personId, $time)
+    {
+        return self::where('person_id', $personId)
+            ->where('created_at', '<=', $time)
+            ->orderBy('created_at', 'desc')
+            ->first();
+    }
+
+    /**
+     * Find the PersonStatus record that exists on or before the time given.
+     * Used to determine a person's status at a given point in time.
+     *
+     * @param array $personId
+     * @param string|Carbon $time
+     * @return Collection
+     */
+
+    public static function findStatusForIdsTime($personIds, $time)
+    {
+        return self::whereIn('person_id', $personIds)
+            ->where('created_at', '<=', $time)
+            ->whereRaw("created_at = (SELECT ps.created_at FROM person_status ps WHERE ps.person_id=person_status.person_id AND ps.created_at <= ? ORDER BY ps.created_at DESC LIMIT 1)", [(string)$time])
+            ->get()
+            ->keyBy('person_id');
+    }
+
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -18,6 +18,7 @@ class Role extends ApiModel
     const EDIT_SLOTS       = 7;   // Edit Slots
     const LOGIN            = 11;  // Person allowed to login
     const MANAGE           = 12;  // Ranger HQ: access other schedule, asset checkin/out, send messages
+    const INTAKE           = 13;  // Intake Management
     const MENTOR           = 101; // Mentor - access mentor section
     const TRAINER          = 102; // Trainer
     const VC               = 103; // Volunteer Coordinator -

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -323,6 +323,28 @@ class Timesheet extends ApiModel
                 ->exists();
     }
 
+    /**
+     * Retrieve all the timesheet for the given people and position.
+     *
+     * @param array $personIds
+     * @param int $positionId
+     * @return Collection group by person_id and sub-grouped by year
+     */
+
+    public static function retrieveAllForPositionIds(array $personIds, int $positionId)
+    {
+        return self::whereIn('person_id', $personIds)
+                ->where('position_id', $positionId)
+                ->orderBy('on_duty')
+                ->get()
+                ->groupBy([
+                    'person_id',
+                    function ($row) {
+                        return $row->on_duty->year;
+                    }
+                ]);
+    }
+
     /*
      * Retrieve all corrections requests for a given year
      */

--- a/app/Models/TraineeNote.php
+++ b/app/Models/TraineeNote.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\ApiModel;
+use App\Models\Person;
+use App\Models\Slot;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+
+class TraineeNote extends ApiModel
+{
+    protected $table = 'trainee_note';
+    public $timestamps = true;
+
+    // Trainee Notes are not directly accessed
+    protected $guarded = [];
+
+    public function person_source()
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function person()
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function slot()
+    {
+        return $this->belongsTo(Slot::class);
+    }
+
+    /**
+     * Find all the training notes for a person in a slot
+     *
+     * @param int $personId person to find
+     * @param int $slotId slot to find
+     * @return Collection
+     */
+
+    public static function findAllForPersonSlot(int $personId, int $slotId): Collection
+    {
+        return self::where('person_id', $personId)
+            ->where('slot_id', $slotId)
+            ->orderBy('created_at')
+            ->with('person_source:id,callsign')
+            ->get();
+    }
+
+    /**
+     * Delete all records referring to a slot. Used by slot deletion.
+     *
+     * @param int $slotId Parent slot ID
+     * @return void
+     */
+
+    public static function deleteForSlot($slotId) : void
+    {
+        self::where('slot_id', $slotId)->delete();
+    }
+
+
+    /**
+     * Record the training notes for a person
+     *
+     * @param int $personId Person to record
+     * @param int $slotId training slot
+     * @param string $note the note itself
+     * @param bool $isLog true if the note is an audit note about the rank
+     * @return void
+     */
+
+    public static function record(int $personId, int $slotId, string $note, bool $isLog = false): void
+    {
+        self::create([
+            'person_id' => $personId,
+            'slot_id' => $slotId,
+            'note' => $note,
+            'is_log' => $isLog,
+            'person_source_id' => Auth::id(),
+        ]);
+    }
+
+}

--- a/app/Policies/PersonPhotoPolicy.php
+++ b/app/Policies/PersonPhotoPolicy.php
@@ -65,7 +65,7 @@ class PersonPhotoPolicy
         return false;
     }
 
-    public function review(Person $user, PersonPhoto $personPhoto) {
+    public function rejectPreview(Person $user, PersonPhoto $personPhoto) {
         return false;
     }
 }

--- a/app/Policies/PersonPolicy.php
+++ b/app/Policies/PersonPolicy.php
@@ -148,4 +148,8 @@ class PersonPolicy
     public function peopleByStatusChange(Person $user) {
         return $user->hasRole(Role::ADMIN);
     }
+
+    public function statusHistory(Person $user) {
+        return $user->hasRole([ Role::ADMIN, Role::VC, Role::INTAKE ]);
+    }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -65,7 +65,8 @@ return [
     |
     */
 
-    'timezone' => 'America/Los_Angeles',
+    // Using a city which does not observe PDT, so UTC-7 works year round.
+    'timezone' => 'America/Phoenix',
 
     /*
     |--------------------------------------------------------------------------

--- a/database/factories/PersonIntake.php
+++ b/database/factories/PersonIntake.php
@@ -1,0 +1,12 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\PersonIntake;
+use Faker\Generator as Faker;
+
+$factory->define(PersonIntake::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/database/factories/PersonStatus.php
+++ b/database/factories/PersonStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\PersonStatus;
+use Faker\Generator as Faker;
+
+$factory->define(PersonStatus::class, function (Faker $faker) {
+    return [
+    ];
+});

--- a/database/migrations/2020_02_02_091228_create_person_status_table.php
+++ b/database/migrations/2020_02_02_091228_create_person_status_table.php
@@ -50,9 +50,10 @@ class CreatePersonStatusTable extends Migration
                 ]);
             }
         }
+ /*
         $rows = ActionLog::where('event', 'person-status-change')->get();
         foreach ($rows as $row) {
-            $data = json_decode($row->data);
+             $data = json_decode($row->data);
             $status = $data->status;
             PersonStatus::create([
                 'person_id' => $row->target_person_id,
@@ -63,7 +64,7 @@ class CreatePersonStatusTable extends Migration
                 'created_at' => $row->created_at
             ]);
         }
-
+*/
     }
 
     /**

--- a/database/migrations/2020_02_10_150001_create_person_intake.php
+++ b/database/migrations/2020_02_10_150001_create_person_intake.php
@@ -1,0 +1,118 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+use App\Models\Person;
+use App\Models\PersonIntake;
+use App\Models\PersonIntakeNote;
+use App\Models\PersonStatus;
+
+class CreatePersonIntake extends Migration
+{
+    /**
+     * Setup to support the Unified Flagging View
+     *
+     * - Create person_intake to hold the {VC,RRN,Mentor} ranks, and Personnel Black Flag
+     * - Create person_intake_notes to hold the year's {VC,RRN,Mentor} notes
+     *
+     * - Add feedback_delivered to trainee_status to indicate lead trainer gave feedback
+     * - Add known_{rangers,pnvs} to person
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('person_intake', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('person_id');
+            $table->integer('year');
+            $table->integer('mentor_rank')->nullable();
+            $table->integer('rrn_rank')->nullable();
+            $table->integer('vc_rank')->nullable();
+            $table->boolean('black_flag')->default(false);
+            $table->timestamps();
+
+            $table->unique(['person_id', 'year']);
+        });
+
+        Schema::create('person_intake_note', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('person_id');
+            $table->bigInteger('person_source_id');
+            $table->integer('year');
+            $table->boolean('is_log')->default(false);
+            $table->enum('type', ['mentor', 'rrn', 'vc']);
+            $table->text('note');
+            $table->timestamps();
+
+            $table->index(['person_id', 'year']);
+        });
+
+        Schema::table('trainee_status', function (Blueprint $table) {
+            $table->boolean('feedback_delivered')->default(false);
+        });
+
+        Schema::table('person', function (Blueprint $table) {
+            $table->text('known_rangers')->nullable();
+            $table->text('known_pnvs')->nullable();
+        });
+
+        DB::table('trainee_status')->update(['feedback_delivered' => true]);
+
+        /*
+         * Convert mentor notes and flag over to person_intake & person_intake_notes
+         */
+        $people = Person::where('mentors_notes', '!=', '')
+                    ->orWhere('mentors_flag', true)
+                    ->get();
+
+        foreach ($people as $person) {
+            $ps = PersonStatus::where('person_id', $person->id)
+                ->whereIn('new_status', ['prospective', 'past prospective', 'alpha', 'bonked', 'uberbonked'])
+                ->orderBy('created_at', 'desc')
+                ->first();
+
+            $date = $ps ? $ps->created_at : ($person->status_date ?? $person->create_date);
+            $year = $date->year;
+            if ($person->mentors_flag) {
+                $intake = new PersonIntake;
+                $intake->person_id = $person->id;
+                $intake->year = $year;
+                $intake->mentor_rank = 4;
+
+                if (!$intake->save()) {
+                    error_log("COULD NOT SAVE " . $person->id);
+                }
+                PersonIntakeNote::record($person->id, $year, 'mentor', "imported rank 4", true);
+            }
+
+            if (!empty($person->mentors_notes)) {
+                PersonIntakeNote::record($person->id, $year, 'mentor', $person->mentors_notes);
+            }
+
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('person_intake');
+        Schema::dropIfExists('person_intake_note');
+        Schema::table('trainee_status', function (Blueprint $table) {
+            $table->dropColumn('feedback_delivered');
+        });
+        Schema::table('person', function (Blueprint $table) {
+            $table->dropColumn('known_rangers');
+            $table->dropColumn('known_pnvs');
+        });
+
+    }
+}

--- a/database/migrations/2020_02_11_111332_add_intake_role.php
+++ b/database/migrations/2020_02_11_111332_add_intake_role.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class AddIntakeRole extends Migration
+{
+    /**
+     * Add the new INTAKE role
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('role')->insert([ 'id' => 13, 'title' => 'Intake Management', 'new_user_eligible' => false ]);
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::table('role')->where('id', 13)->delete();
+    }
+}

--- a/database/migrations/2020_02_20_165528_create_trainee_note.php
+++ b/database/migrations/2020_02_20_165528_create_trainee_note.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTraineeNote extends Migration
+{
+    /**
+     * Create the trainee_note to handle multiple notes stored in for a training record.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('trainee_note', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('person_id');
+            $table->integer('person_source_id')->nullable();
+            $table->integer('slot_id');
+            $table->text('note');
+            $table->boolean('is_log')->default(false);
+            $table->timestamps();
+            $table->index( [ 'person_id', 'slot_id' ]);
+        });
+
+        /*
+         * Convert the notes over
+         */
+        $rows = DB::select('SELECT trainee_status.*, slot.ends FROM trainee_status JOIN slot ON slot_id=slot.id WHERE LENGTH(notes) > 0');
+
+        foreach ($rows as $row) {
+            DB::table('trainee_note')->insert([
+                'person_id' => $row->person_id,
+                'slot_id' => $row->slot_id,
+                'person_source_id' => null,
+                'note' => $row->notes,
+                'created_at' => (string) $row->ends,
+                'updated_at' => (string) $row->ends,
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('trainee_note');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,7 +27,7 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 Route::group([
     'middleware' => 'api',
-], function($router) {
+], function ($router) {
     Route::get('config', 'ConfigController@show');
 
     Route::post('auth/login', 'AuthController@login');
@@ -38,13 +38,14 @@ Route::group([
     Route::post('error-log/record', 'ErrorLogController@record');
     Route::post('action-log/record', 'ActionLogController@record');
 
-    Route::match([ 'GET', 'POST'], 'sms/inbound', 'SmsController@inbound');
+    Route::match(['GET', 'POST'], 'sms/inbound', 'SmsController@inbound');
 
     Route::get('maintenance/daily-report', 'MaintenanceController@dailyReport');
     Route::get('maintenance', 'MaintenanceController@index');
 
     // Only used for development.
     Route::get('photos/{file}', 'PersonPhotoController@photoImage')->where('file', '.*');
+    Route::get('staging/{file}', 'PersonPhotoController@photoImage')->where('file', '.*');
 });
 
 
@@ -53,12 +54,11 @@ Route::group([
  */
 
 Route::group([
-    'middleware' => [ 'api', 'auth' ],
+    'middleware' => ['api', 'auth'],
 ], function ($router) {
 
     Route::post('auth/logout', 'AuthController@logout');
     Route::post('auth/refresh', 'AuthController@refresh');
-
 
     Route::get('access-document/current', 'AccessDocumentController@current');
     Route::get('access-document/expiring', 'AccessDocumentController@expiring');
@@ -75,8 +75,8 @@ Route::group([
 
     Route::resource('access-document-delivery', 'AccessDocumentDeliveryController');
 
-    Route::resource('action-log', 'ActionLogController', [ 'only' => 'index' ]);
-    Route::resource('clubhouse1-log', 'Clubhouse1LogController', [ 'only' => 'index' ]);
+    Route::resource('action-log', 'ActionLogController', ['only' => 'index']);
+    Route::resource('clubhouse1-log', 'Clubhouse1LogController', ['only' => 'index']);
 
     Route::resource('alert', 'AlertController');
 
@@ -118,10 +118,15 @@ Route::group([
     Route::resource('language', 'LanguageController');
 
     Route::delete('error-log/purge', 'ErrorLogController@purge');
-    Route::resource('error-log', 'ErrorLogController', [ 'only' => 'index' ]);
+    Route::resource('error-log', 'ErrorLogController', ['only' => 'index']);
 
     Route::get('event-dates/year', 'EventDatesController@showYear');
     Route::resource('event-dates', 'EventDatesController');
+
+    Route::get('intake', 'IntakeController@index');
+    Route::get('intake/{person}/history', 'IntakeController@history');
+    Route::post('intake/{person}/note', 'IntakeController@appendNote');
+    Route::post('intake/{person}/black-flag', 'IntakeController@setBlackFlag');
 
     Route::post('maintenance/update-positions', 'MaintenanceController@updatePositions');
     Route::post('maintenance/mark-off-site', 'MaintenanceController@markOffSite');
@@ -136,7 +141,7 @@ Route::group([
     Route::resource('manual-review', 'ManualReviewController');
 
     Route::patch('messages/{person_message}/markread', 'PersonMessageController@markread');
-    Route::resource('messages', 'PersonMessageController', [ 'only' => [ 'index', 'store', 'destroy' ]]);
+    Route::resource('messages', 'PersonMessageController', ['only' => ['index', 'store', 'destroy']]);
 
     Route::get('mentor/alphas', 'MentorController@alphas');
     Route::get('mentor/alpha-schedule', 'MentorController@alphaSchedule');
@@ -172,7 +177,7 @@ Route::group([
     Route::get('person/{person}/schedule/imminent', 'PersonScheduleController@imminent');
     Route::get('person/{person}/schedule/expected', 'PersonScheduleController@expected');
     Route::get('person/{person}/schedule/summary', 'PersonScheduleController@scheduleSummary');
-    Route::resource('person/{person}/schedule', 'PersonScheduleController', [ 'only' => [ 'index', 'store', 'destroy' ]]);
+    Route::resource('person/{person}/schedule', 'PersonScheduleController', ['only' => ['index', 'store', 'destroy']]);
 
     Route::get('person/{person}/positions', 'PersonController@positions');
     Route::post('person/{person}/positions', 'PersonController@updatePositions');
@@ -182,16 +187,19 @@ Route::group([
     Route::get('person/{person}/roles', 'PersonController@roles');
     Route::post('person/{person}/roles', 'PersonController@updateRoles');
 
+    Route::get('person/{person}/status-history', 'PersonController@statusHistory');
+
     Route::get('person/{person}/user-info', 'PersonController@userInfo');
     Route::get('person/{person}/unread-message-count', 'PersonController@UnreadMessageCount');
     Route::get('person/{person}/event-info', 'PersonController@eventInfo');
     Route::post('person/{person}/onboard-debug', 'PersonController@onboardDebug');
 
-    Route::resource('person', 'PersonController', [ 'only' => [ 'index','show','store','update','destroy' ]]);
+    Route::resource('person', 'PersonController', ['only' => ['index', 'show', 'store', 'update', 'destroy']]);
 
     Route::get('person-photo/review-config', 'PersonPhotoController@reviewConfig');
     Route::post('person-photo/{person_photo}/replace', 'PersonPhotoController@replace');
     Route::post('person-photo/{person_photo}/activate', 'PersonPhotoController@activate');
+    Route::get('person-photo/{person_photo}/reject-preview', 'PersonPhotoController@rejectPreview');
     Route::resource('person-photo', 'PersonPhotoController');
 
     Route::post('position-credit/copy', 'PositionCreditController@copy');
@@ -244,7 +252,7 @@ Route::group([
 
     Route::get('training-session/sessions', 'TrainingSessionController@sessions');
     Route::get('training-session/{id}', 'TrainingSessionController@show');
-    Route::post('training-session/{id}/score', 'TrainingSessionController@score');
+    Route::post('training-session/{id}/score-student', 'TrainingSessionController@scoreStudent');
     Route::post('training-session/{id}/trainer-status', 'TrainingSessionController@trainerStatus');
 
     Route::get('training/{id}/multiple-enrollments', 'TrainingController@multipleEnrollmentsReport');
@@ -275,7 +283,7 @@ Route::group([
     Route::get('timesheet/thank-you', 'TimesheetController@thankYou');
     Route::get('timesheet/totals', 'TimesheetController@timesheetTotals');
     Route::get('timesheet/unconfirmed-people', 'TimesheetController@unconfirmedPeople');
-    Route::match([ 'GET', 'POST'], 'timesheet/special-teams', 'TimesheetController@specialTeamsReport');
+    Route::match(['GET', 'POST'], 'timesheet/special-teams', 'TimesheetController@specialTeamsReport');
     Route::post('timesheet/{timesheet}/signoff', 'TimesheetController@signoff');
     Route::resource('timesheet', 'TimesheetController');
 

--- a/tests/Feature/IntakeControllerTest.php
+++ b/tests/Feature/IntakeControllerTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Position;
+use App\Models\Slot;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use App\Models\Person;
+use App\Models\PersonStatus;
+use App\Models\PersonIntake;
+use App\Models\PersonIntakeNote;
+use App\Models\TraineeStatus;
+use App\Models\PersonSlot;
+use App\Models\Role;
+use App\Models\PersonMentor;
+
+use App\Lib\Intake;
+
+class IntakeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    /*
+     * have each test have a fresh user that is logged in,
+     */
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->signInUser();
+        $year = $this->year = (int)date('Y');
+    }
+
+    /*
+     * Test index - find all prospectives / alphas in a given year with a rank.
+     */
+
+    public function testIndex()
+    {
+        $this->addRole(Role::INTAKE);
+
+        $personLastYear = factory(Person::class)->create(['status' => Person::ACTIVE]);
+        $personThisYear = factory(Person::class)->create(['status' => Person::ACTIVE]);
+
+        $year = $this->year - 1;
+
+        // Should pick up this person - was a PNV in the requested year.
+        factory(PersonStatus::class)->create([
+            'person_id' => $personLastYear->id,
+            'old_status' => Person::AUDITOR,
+            'new_status' => Person::ALPHA,
+            'reason' => 'intake',
+            'created_at' => "$year-01-01 00:00:00",
+        ]);
+
+        factory(PersonIntake::class)->create([
+            'person_id' => $personLastYear->id,
+            'mentor_rank' => Intake::BELOW_AVERAGE,
+            'year' => $year,
+        ]);
+
+        // Should not pick up this person.. wasn't a PNV in the current year.
+        factory(PersonStatus::class)->create([
+            'person_id' => $personThisYear->id,
+            'old_status' => Person::AUDITOR,
+            'new_status' => Person::ALPHA,
+            'reason' => 'intake',
+            'created_at' => "{$this->year}-01-01 00:00:00",
+        ]);
+
+        factory(PersonIntake::class)->create([
+            'person_id' => $personThisYear->id,
+            'mentor_rank' => Intake::BELOW_AVERAGE,
+            'year' => $this->year,
+        ]);
+
+        $response = $this->json('GET', 'intake', ['year' => $year]);
+        $response->assertStatus(200);
+        $this->assertCount(1, $response->json()['people']);
+        $response->assertJson([
+            'people' => [[
+                'id' => $personLastYear->id,
+                'status' => $personLastYear->status
+            ]]
+        ]);
+    }
+
+    /*
+     * Test person history
+     */
+
+    public function testPersonHistory()
+    {
+        $this->addRole(Role::INTAKE);
+        $year = $this->year;
+
+        $person = factory(Person::class)->create(['status' => Person::ACTIVE]);
+
+        factory(PersonIntake::class)->create([
+            'person_id' => $person->id,
+            'mentor_rank' => Intake::BELOW_AVERAGE,
+            'year' => $year,
+        ]);
+
+        $training = factory(Slot::class)->create(
+            [
+                'begins' => date("$year-01-01 09:45:00"),
+                'ends' => date("$year-01-01 17:45:00"),
+                'position_id' => Position::TRAINING,
+                'description' => 'Training',
+                'signed_up' => 0,
+                'max' => 10,
+                'min' => 0,
+            ]
+        );
+
+        factory(PersonSlot::class)->create([
+            'slot_id' => $training->id,
+            'person_id' => $person->id
+
+        ]);
+
+        factory(TraineeStatus::class)->create([
+            'slot_id' => $training->id,
+            'person_id' => $person->id,
+            'passed' => true,
+            'rank' => Intake::ABOVE_AVERAGE
+        ]);
+
+        $mentor = factory(Person::class)->create();
+        factory(PersonMentor::class)->create([
+            'person_id' => $person->id,
+            'mentor_id' => $mentor->id,
+            'mentor_year' => $year,
+            'status' => PersonMentor::BONK
+        ]);
+
+        $response = $this->json('GET', "intake/{$person->id}/history", ['year' => $year]);
+        $response->assertStatus(200);
+        $response->assertJson([
+            'person' => [
+                'id' => $person->id,
+                'status' => Person::ACTIVE,
+                'pnv_history' => [
+                    $year => [
+                        'mentor_status' => PersonMentor::BONK,
+                        'mentors' => [['id' => $mentor->id, 'callsign' => $mentor->callsign]]
+                    ]
+                ],
+                'mentor_team' => [[
+                    'year' => $year,
+                    'rank' => Intake::BELOW_AVERAGE
+                ]],
+                'trainings' => [[
+                    'slot_id' => $training->id,
+                    'slot_begins' => (string)$training->begins,
+                    'training_rank' => Intake::ABOVE_AVERAGE,
+                    'training_passed' => 1
+                ]]
+            ]
+        ]);
+    }
+
+    /*
+     * Test appending notes and setting ranks
+     */
+
+    public function testAppendNotesAndSetRanks()
+    {
+        $this->addRole(Role::INTAKE);
+
+        $person = factory(Person::class)->create();
+        $year = $this->year;
+        $note = 'Prospectiveses brings us tasty, tasty treats, my precious!';
+
+        $response = $this->json('POST', "intake/{$person->id}/note", [
+            'year' => $year,
+            'type' => 'rrn',
+            'ranking' => Intake::FLAG,
+            'note' => $note
+
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('person_intake', [
+            'person_id' => $person->id,
+            'year' => $year,
+            'rrn_rank' => Intake::FLAG
+        ]);
+
+        $this->assertDatabaseHas('person_intake_note', [
+            'person_id' => $person->id,
+            'year' => $year,
+            'type' => 'rrn',
+            'note' => $note
+        ]);
+    }
+
+    /*
+     * Test setting and clearing black flag
+     */
+
+    public function testSetAndClearBlackFlag() {
+        $this->addAdminRole();
+        $person = factory(Person::class)->create();
+        $year = 2019;
+
+        $response = $this->json('POST', "intake/{$person->id}/black-flag", [
+            'year' => $year,
+            'black_flag' => 1
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('person_intake', [
+            'person_id' => $person->id,
+            'year' => $year,
+            'black_flag' => 1,
+        ]);
+
+        $response = $this->json('POST', "intake/{$person->id}/black-flag", [
+            'year' => 2019,
+            'black_flag' => 0
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('person_intake', [
+            'person_id' => $person->id,
+            'year' => $year,
+            'black_flag' => 0,
+        ]);
+    }
+}

--- a/tests/Feature/PersonScheduleControllerTest.php
+++ b/tests/Feature/PersonScheduleControllerTest.php
@@ -31,7 +31,7 @@ class PersonScheduleControllerTest extends TestCase
      * and a set of positions.
      */
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -47,9 +47,9 @@ class PersonScheduleControllerTest extends TestCase
         // Setup default (real world) positions
         $this->trainingPosition = factory(Position::class)->create(
             [
-                'id'    => Position::TRAINING,
+                'id' => Position::TRAINING,
                 'title' => 'Training',
-                'type'  => 'Training',
+                'type' => 'Training',
                 'slot_full_email' => 'training-academy@example.com',
                 'prevent_multiple_enrollments' => true,
             ]
@@ -57,18 +57,18 @@ class PersonScheduleControllerTest extends TestCase
 
         $this->dirtPosition = factory(Position::class)->create(
             [
-                'id'    => Position::DIRT,
+                'id' => Position::DIRT,
                 'title' => 'Dirt',
-                'type'  => 'Frontline',
+                'type' => 'Frontline',
             ]
         );
 
         // Used for ART training & signups
         $this->greenDotTrainingPosition = factory(Position::class)->create(
             [
-                'id'    => Position::GREEN_DOT_TRAINING,
+                'id' => Position::GREEN_DOT_TRAINING,
                 'title' => 'Green Dot - Training',
-                'type'  => 'Training',
+                'type' => 'Training',
                 'slot_full_email' => 'greendots@example.com',
                 'prevent_multiple_enrollments' => true,
             ]
@@ -76,41 +76,41 @@ class PersonScheduleControllerTest extends TestCase
 
         $this->greenDotDirtPosition = factory(Position::class)->create(
             [
-                'id'                   => Position::DIRT_GREEN_DOT,
-                'title'                => 'Green Dot - Dirt',
-                'type'                 => 'Frontline',
+                'id' => Position::DIRT_GREEN_DOT,
+                'title' => 'Green Dot - Dirt',
+                'type' => 'Frontline',
                 'training_position_id' => $this->greenDotTrainingPosition->id,
             ]
         );
 
         $this->trainingSlots = [];
         for ($i = 0; $i < 3; $i++) {
-            $day                   = (25 + $i);
+            $day = (25 + $i);
             $this->trainingSlots[] = factory(Slot::class)->create(
                 [
-                    'begins'      => date("$year-05-$day 09:45:00"),
-                    'ends'        => date("$year-05-$day 17:45:00"),
+                    'begins' => date("$year-05-$day 09:45:00"),
+                    'ends' => date("$year-05-$day 17:45:00"),
                     'position_id' => Position::TRAINING,
                     'description' => "Training #$i",
-                    'signed_up'   => 0,
-                    'max'         => 10,
-                    'min'         => 0,
+                    'signed_up' => 0,
+                    'max' => 10,
+                    'min' => 0,
                 ]
             );
         }
 
         $this->dirtSlots = [];
         for ($i = 0; $i < 3; $i++) {
-            $day               = (25 + $i);
+            $day = (25 + $i);
             $this->dirtSlots[] = factory(Slot::class)->create(
                 [
-                    'begins'      => date("$year-08-$day 09:45:00"),
-                    'ends'        => date("$year-08-$day 17:45:00"),
+                    'begins' => date("$year-08-$day 09:45:00"),
+                    'ends' => date("$year-08-$day 17:45:00"),
                     'position_id' => Position::DIRT,
                     'description' => "Dirt #$i",
-                    'signed_up'   => 0,
-                    'max'         => 10,
-                    'min'         => 0,
+                    'signed_up' => 0,
+                    'max' => 10,
+                    'min' => 0,
                 ]
             );
         }
@@ -120,32 +120,43 @@ class PersonScheduleControllerTest extends TestCase
             $day = (25 + $i);
             $this->greenDotTrainingSlots[] = factory(Slot::class)->create(
                 [
-                    'begins'      => date("$year-06-$day 09:45:00"),
-                    'ends'        => date("$year-06-$day 17:45:00"),
+                    'begins' => date("$year-06-$day 09:45:00"),
+                    'ends' => date("$year-06-$day 17:45:00"),
                     'position_id' => Position::GREEN_DOT_TRAINING,
                     'description' => "GD Training #$i",
-                    'signed_up'   => 0,
-                    'max'         => 10,
-                    'min'         => 0,
+                    'signed_up' => 0,
+                    'max' => 10,
+                    'min' => 0,
                 ]
             );
         }
 
         $this->greenDotSlots = [];
         for ($i = 0; $i < 3; $i++) {
-            $day                   = (25 + $i);
+            $day = (25 + $i);
             $this->greenDotSlots[] = factory(Slot::class)->create(
                 [
-                    'begins'      => date("$year-08-$day 09:45:00"),
-                    'ends'        => date("$year-08-$day 17:45:00"),
+                    'begins' => date("$year-08-$day 09:45:00"),
+                    'ends' => date("$year-08-$day 17:45:00"),
                     'position_id' => Position::DIRT_GREEN_DOT,
                     'description' => "Green Dot #$i",
-                    'signed_up'   => 0,
-                    'max'         => 10,
-                    'min'         => 0,
+                    'signed_up' => 0,
+                    'max' => 10,
+                    'min' => 0,
                 ]
             );
         }
+    }
+
+    public function createPerson()
+    {
+        $person = factory(Person::class)->create();
+        factory(PersonPosition::class)->create([
+            'person_id' => $person->id,
+            'position_id' => Position::TRAINING
+        ]);
+
+        return $person;
     }
 
 
@@ -165,14 +176,14 @@ class PersonScheduleControllerTest extends TestCase
         factory(PersonSlot::class)->create(
             [
                 'person_id' => $personId,
-                'slot_id'   => $slotId,
+                'slot_id' => $slotId,
             ]
         );
 
-        $response = $this->json('GET', "person/{$this->user->id}/schedule", [ 'year' => $this->year ]);
+        $response = $this->json('GET', "person/{$this->user->id}/schedule", ['year' => $this->year]);
         $response->assertStatus(200);
 
-        $response->assertJsonStructure([ 'schedules' => [ [ 'id' ] ] ]);
+        $response->assertJsonStructure(['schedules' => [['id']]]);
         $this->assertCount(1, $response->json()['schedules']);
         $this->assertEquals($slotId, $response->json()['schedules'][0]['id']);
     }
@@ -194,11 +205,11 @@ class PersonScheduleControllerTest extends TestCase
         factory(PersonSlot::class)->create(
             [
                 'person_id' => $personId,
-                'slot_id'   => $slotId,
+                'slot_id' => $slotId,
             ]
         );
 
-        $response = $this->json('GET', "person/{$this->user->id}/schedule", [ 'year' => $this->year, 'shifts_available' => 1 ]);
+        $response = $this->json('GET', "person/{$this->user->id}/schedule", ['year' => $this->year, 'shifts_available' => 1]);
         $response->assertStatus(200);
 
         // Should match 6 shifts - 3 trainings and 3 dirt shift
@@ -212,9 +223,9 @@ class PersonScheduleControllerTest extends TestCase
 
     public function testDoNotFindAnyShiftsForYear()
     {
-        $response = $this->json('GET', "person/{$this->user->id}/schedule", [ 'year' => $this->year, 'shifts_available' => 1 ]);
+        $response = $this->json('GET', "person/{$this->user->id}/schedule", ['year' => $this->year, 'shifts_available' => 1]);
         $response->assertStatus(200);
-        $response->assertJson([ 'schedules' => []]);
+        $response->assertJson(['schedules' => []]);
     }
 
 
@@ -236,13 +247,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
+        $response->assertJson(['status' => 'success']);
 
         $this->assertDatabaseHas(
             'person_slot',
             [
                 'person_id' => $this->user->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
 
@@ -276,13 +287,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
+        $response->assertJson(['status' => 'success']);
 
         $this->assertDatabaseHas(
             'person_slot',
             [
                 'person_id' => $this->user->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
 
@@ -308,7 +319,7 @@ class PersonScheduleControllerTest extends TestCase
     {
         $this->addPosition(Position::TRAINING);
         $shift = $this->trainingSlots[0];
-        $shift->update([ 'max' => 1]);
+        $shift->update(['max' => 1]);
 
         $response = $this->json(
             'POST',
@@ -319,7 +330,7 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
+        $response->assertJson(['status' => 'success']);
         Mail::assertSent(TrainingSessionFullMail::class);
     }
 
@@ -341,13 +352,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'no-position']);
+        $response->assertJson(['status' => 'no-position']);
 
         $this->assertDatabaseMissing(
             'person_slot',
             [
                 'person_id' => $this->user->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
     }
@@ -361,7 +372,7 @@ class PersonScheduleControllerTest extends TestCase
     {
         $this->addPosition(Position::TRAINING);
         $shift = $this->trainingSlots[0];
-        $shift->update([ 'signed_up' => 1, 'max' => 1 ]);
+        $shift->update(['signed_up' => 1, 'max' => 1]);
 
         $response = $this->json(
             'POST',
@@ -372,13 +383,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'full' ]);
+        $response->assertJson(['status' => 'full']);
 
         $this->assertDatabaseMissing(
             'person_slot',
             [
                 'person_id' => $this->user->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
     }
@@ -390,7 +401,7 @@ class PersonScheduleControllerTest extends TestCase
     public function testPreventSignupForStartedShift()
     {
         $shift = $this->trainingSlots[0];
-        $shift->update([ 'signed_up' => 1, 'max' => 1, 'begins' => date('2000-08-25 12:00:00') ]);
+        $shift->update(['signed_up' => 1, 'max' => 1, 'begins' => date('2000-08-25 12:00:00')]);
         $this->addPosition(Position::TRAINING);
 
         $response = $this->json(
@@ -402,13 +413,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'has-started' ]);
+        $response->assertJson(['status' => 'has-started']);
 
         $this->assertDatabaseMissing(
             'person_slot',
             [
                 'person_id' => $this->user->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
     }
@@ -424,22 +435,22 @@ class PersonScheduleControllerTest extends TestCase
         $person = factory(Person::class)->create();
         $this->addPosition(Position::DIRT, $person);
         $shift = $this->dirtSlots[0];
-        $err = $shift->update([ 'signed_up' => 1, 'max' => 1, 'begins' => date('2000-08-25 12:00:00') ]);
+        $err = $shift->update(['signed_up' => 1, 'max' => 1, 'begins' => date('2000-08-25 12:00:00')]);
 
         $response = $this->json(
             'POST',
             "person/{$person->id}/schedule",
-            [ 'slot_id' => $shift->id, 'force' => 1 ]
+            ['slot_id' => $shift->id, 'force' => 1]
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
+        $response->assertJson(['status' => 'success']);
 
         $this->assertDatabaseHas(
             'person_slot',
             [
                 'person_id' => $person->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
     }
@@ -448,28 +459,30 @@ class PersonScheduleControllerTest extends TestCase
      * Allow a trainer to add a person to past training shift
      */
 
-    public function testAllowSignupForPastShiftForTrainer()
+    public function testDenySignupForPastShiftForTrainer()
     {
-        $this->addPosition([ Position::TRAINING, Position::TRAINER ]);
-        $personId = $this->user->id;
+        $this->addRole(Role::TRAINER);
+
+        $person = $this->createPerson();
+        $personId = $person->id;
 
         $training = $this->trainingSlots[0];
-        $training->update([ 'begins' => date('2010-08-25 10:00:00')]);
+        $training->update(['begins' => date('2010-08-25 10:00:00')]);
 
         $response = $this->json(
             'POST',
             "person/{$personId}/schedule",
-            [ 'slot_id' => $training->id, 'force' => true ]
+            ['slot_id' => $training->id, 'force' => true]
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success', 'started_forced' => true ]);
+        $response->assertJson(['status' => 'has-started' ]);
 
-        $this->assertDatabaseHas(
+        $this->assertDatabaseMissing(
             'person_slot',
             [
                 'person_id' => $personId,
-                'slot_id'   => $training->id,
+                'slot_id' => $training->id,
             ]
         );
     }
@@ -485,7 +498,7 @@ class PersonScheduleControllerTest extends TestCase
         $this->addRole(Role::ADMIN);
 
         $shift = $this->trainingSlots[0];
-        $shift->update([ 'signed_up' => 1, 'max' => 1, ]);
+        $shift->update(['signed_up' => 1, 'max' => 1,]);
 
         $response = $this->json(
             'POST',
@@ -496,13 +509,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'full', 'may_force' => true ]);
+        $response->assertJson(['status' => 'full', 'may_force' => true]);
 
         $this->assertDatabaseMissing(
             'person_slot',
             [
                 'person_id' => $person->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
     }
@@ -518,7 +531,7 @@ class PersonScheduleControllerTest extends TestCase
         $this->addRole(Role::ADMIN);
 
         $shift = $this->trainingSlots[0];
-        $shift->update([ 'signed_up' => 1, 'max' => 1, ]);
+        $shift->update(['signed_up' => 1, 'max' => 1,]);
 
         $response = $this->json(
             'POST',
@@ -530,13 +543,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success', 'full_forced' => true ]);
+        $response->assertJson(['status' => 'success', 'full_forced' => true]);
 
         $this->assertDatabaseHas(
             'person_slot',
             [
                 'person_id' => $person->id,
-                'slot_id'   => $shift->id,
+                'slot_id' => $shift->id,
             ]
         );
     }
@@ -556,7 +569,7 @@ class PersonScheduleControllerTest extends TestCase
         factory(PersonSlot::class)->create(
             [
                 'person_id' => $personId,
-                'slot_id'   => $previousTraining->id,
+                'slot_id' => $previousTraining->id,
             ]
         );
 
@@ -571,13 +584,13 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'multiple-enrollment' ]);
+        $response->assertJson(['status' => 'multiple-enrollment']);
 
         $this->assertDatabaseMissing(
             'person_slot',
             [
                 'person_id' => $personId,
-                'slot_id'   => $attemptedTraining->id,
+                'slot_id' => $attemptedTraining->id,
             ]
         );
     }
@@ -595,39 +608,39 @@ class PersonScheduleControllerTest extends TestCase
 
         $part1 = factory(Slot::class)->create([
             'description' => 'Elysian Fields - Part 1',
-            'position_id' =>  Position::TRAINING,
-            'begins'      => date("$year-08-30 12:00:00"),
-            'ends'        => date("$year-08-30 18:00:00")
+            'position_id' => Position::TRAINING,
+            'begins' => date("$year-08-30 12:00:00"),
+            'ends' => date("$year-08-30 18:00:00")
         ]);
 
         $part2 = factory(Slot::class)->create([
             'description' => 'Elysian Fields - Part 2',
-            'position_id' =>  Position::TRAINING,
-            'begins'      => date("$year-08-31 12:00:00"),
-            'ends'        => date("$year-08-31 18:00:00")
+            'position_id' => Position::TRAINING,
+            'begins' => date("$year-08-31 12:00:00"),
+            'ends' => date("$year-08-31 18:00:00")
         ]);
 
         factory(PersonSlot::class)->create(
             [
                 'person_id' => $personId,
-                'slot_id'   => $part1->id,
+                'slot_id' => $part1->id,
             ]
         );
 
         $response = $this->json(
             'POST',
             "person/{$personId}/schedule",
-            [ 'slot_id' => $part2->id ]
+            ['slot_id' => $part2->id]
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
+        $response->assertJson(['status' => 'success']);
 
         $this->assertDatabaseHas(
             'person_slot',
             [
                 'person_id' => $this->user->id,
-                'slot_id'   => $part2->id,
+                'slot_id' => $part2->id,
             ]
         );
     }
@@ -649,7 +662,7 @@ class PersonScheduleControllerTest extends TestCase
         factory(PersonSlot::class)->create(
             [
                 'person_id' => $personId,
-                'slot_id'   => $previousTraining->id,
+                'slot_id' => $previousTraining->id,
             ]
         );
 
@@ -664,34 +677,35 @@ class PersonScheduleControllerTest extends TestCase
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success', 'multiple_forced' => true ]);
+        $response->assertJson(['status' => 'success', 'multiple_forced' => true]);
 
         $this->assertDatabaseHas(
             'person_slot',
             [
                 'person_id' => $personId,
-                'slot_id'   => $attemptedTraining->id,
+                'slot_id' => $attemptedTraining->id,
             ]
         );
     }
 
 
     /*
-     * Allow a trainer to sign themselves multiple time to a training session.
+     * Deny a trainer to sign some one else up multiple time to a training session.
      */
 
-    public function testAllowMultipleEnrollmentsForTrainingSessionsForTrainers()
+    public function testDenyMultipleEnrollmentsForTrainingSessionsForTrainers()
     {
-        $this->addRole(Role::ADMIN);
-        $this->addPosition([ Position::TRAINING, Position::TRAINER ]);
-        $personId = $this->user->id;
 
+        $this->addRole(Role::TRAINER);
+
+        $person = $this->createPerson();
+        $personId = $person->id;
         $previousTraining = $this->trainingSlots[0];
 
         factory(PersonSlot::class)->create(
             [
                 'person_id' => $personId,
-                'slot_id'   => $previousTraining->id,
+                'slot_id' => $previousTraining->id,
             ]
         );
 
@@ -700,21 +714,20 @@ class PersonScheduleControllerTest extends TestCase
         $response = $this->json(
             'POST',
             "person/{$personId}/schedule",
-            [ 'slot_id' => $attemptedTraining->id ]
+            ['slot_id' => $attemptedTraining->id]
         );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success', 'trainer_forced' => true ]);
+        $response->assertJson(['status' => 'multiple-enrollment']);
 
-        $this->assertDatabaseHas(
+        $this->assertDatabaseMissing(
             'person_slot',
             [
                 'person_id' => $personId,
-                'slot_id'   => $attemptedTraining->id,
+                'slot_id' => $attemptedTraining->id,
             ]
         );
     }
-
 
     /*
      * Remove a signup
@@ -722,11 +735,11 @@ class PersonScheduleControllerTest extends TestCase
 
     public function testDeleteSignupSuccess()
     {
-        $shift      = $this->dirtSlots[0];
-        $personId   = $this->user->id;
+        $shift = $this->dirtSlots[0];
+        $personId = $this->user->id;
         $personSlot = [
             'person_id' => $personId,
-            'slot_id'   => $shift->id,
+            'slot_id' => $shift->id,
         ];
 
         factory(PersonSlot::class)->create($personSlot);
@@ -742,19 +755,19 @@ class PersonScheduleControllerTest extends TestCase
 
     public function testPreventDeleteSignup()
     {
-        $shift      = $this->dirtSlots[0];
-        $shift->update([ 'begins' => date('2000-01-01 12:00:00')]);
-        $personId   = $this->user->id;
+        $shift = $this->dirtSlots[0];
+        $shift->update(['begins' => date('2000-01-01 12:00:00')]);
+        $personId = $this->user->id;
         $personSlot = [
             'person_id' => $personId,
-            'slot_id'   => $shift->id,
+            'slot_id' => $shift->id,
         ];
 
         factory(PersonSlot::class)->create($personSlot);
 
         $response = $this->json('DELETE', "person/{$personId}/schedule/{$shift->id}");
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'has-started' ]);
+        $response->assertJson(['status' => 'has-started']);
         $this->assertDatabaseHas('person_slot', $personSlot);
     }
 
@@ -764,12 +777,12 @@ class PersonScheduleControllerTest extends TestCase
 
     public function testAllowDeleteSignupIfAdmin()
     {
-        $shift      = $this->dirtSlots[0];
-        $shift->update([ 'begins' => date('2000-01-01 12:00:00')]);
-        $personId   = $this->user->id;
+        $shift = $this->dirtSlots[0];
+        $shift->update(['begins' => date('2000-01-01 12:00:00')]);
+        $personId = $this->user->id;
         $personSlot = [
             'person_id' => $personId,
-            'slot_id'   => $shift->id,
+            'slot_id' => $shift->id,
         ];
 
         factory(PersonSlot::class)->create($personSlot);
@@ -778,7 +791,7 @@ class PersonScheduleControllerTest extends TestCase
 
         $response = $this->json('DELETE', "person/{$personId}/schedule/{$shift->id}");
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
+        $response->assertJson(['status' => 'success']);
         $this->assertDatabaseMissing('person_slot', $personSlot);
     }
 
@@ -788,7 +801,7 @@ class PersonScheduleControllerTest extends TestCase
 
     public function testFailWhenDeletingNonExistentSignup()
     {
-        $shift    = $this->dirtSlots[0];
+        $shift = $this->dirtSlots[0];
         $personId = $this->user->id;
 
         $response = $this->json('DELETE', "person/{$personId}/schedule/{$shift->id}");
@@ -799,7 +812,7 @@ class PersonScheduleControllerTest extends TestCase
     {
         $photo = factory(PersonPhoto::class)->create([
             'person_id' => $this->user->id,
-            'status'    => $status,
+            'status' => $status,
         ]);
 
         $this->user->person_photo_id = $photo->id;
@@ -824,17 +837,17 @@ class PersonScheduleControllerTest extends TestCase
         $mrMock = $this->mockManualReviewPass(true);
 
         $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
-             'year' => $this->year
-         ]);
+            'year' => $this->year
+        ]);
 
         $response->assertStatus(200);
         $response->assertJson([
-             'permission'   => [
-                 'signup_allowed'       => true,
-                 'callsign_approved'    => true,
-                 'manual_review_passed' => true,
-             ]
-         ]);
+            'permission' => [
+                'signup_allowed' => true,
+                'callsign_approved' => true,
+                'manual_review_passed' => true,
+            ]
+        ]);
     }
 
     /*
@@ -846,18 +859,18 @@ class PersonScheduleControllerTest extends TestCase
         $mrMock = $this->mockManualReviewPass(true);
 
         $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
-              'year' => $this->year
-          ]);
+            'year' => $this->year
+        ]);
 
         $response->assertStatus(200);
         $response->assertJson([
-              'permission'   => [
-                  'signup_allowed'       => false,
-                  'callsign_approved'    => true,
-                  'manual_review_passed' => true,
-                  'photo_status'         => 'missing',
-              ]
-          ]);
+            'permission' => [
+                'signup_allowed' => false,
+                'callsign_approved' => true,
+                'manual_review_passed' => true,
+                'photo_status' => 'missing',
+            ]
+        ]);
     }
 
     /*
@@ -870,43 +883,43 @@ class PersonScheduleControllerTest extends TestCase
         $mrMock = $this->mockManualReviewPass(false);
 
         $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
-               'year' => $this->year
-           ]);
+            'year' => $this->year
+        ]);
 
         $response->assertStatus(200);
         $response->assertJson([
-               'permission'   => [
-                   'signup_allowed'       => false,
-                   'callsign_approved'    => true,
-                   'manual_review_passed' => false,
-                   'photo_status'         => 'approved',
-               ]
-           ]);
+            'permission' => [
+                'signup_allowed' => false,
+                'callsign_approved' => true,
+                'manual_review_passed' => false,
+                'photo_status' => 'approved',
+            ]
+        ]);
     }
 
     /*
      * Deny an active who did not sign the behavioral standards agreement
      */
 
-/*
-    public function testDenyActiveWhoDidNotSignBehavioralAgreement()
-    {
-        $photoMock = $this->setupPhotoStatus('approved');
-        $mrMock = $this->mockManualReviewPass(true);
-        $this->user->update([ 'behavioral_agreement' => false ]);
-        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
-               'year' => $this->year
-           ]);
+    /*
+        public function testDenyActiveWhoDidNotSignBehavioralAgreement()
+        {
+            $photoMock = $this->setupPhotoStatus('approved');
+            $mrMock = $this->mockManualReviewPass(true);
+            $this->user->update([ 'behavioral_agreement' => false ]);
+            $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
+                   'year' => $this->year
+               ]);
 
-        $response->assertStatus(200);
-        $response->assertJson([
-               'permission'   => [
-                   'signup_allowed'       => false,
-                   'missing_behavioral_agreement' => true,
-               ]
-           ]);
-    }
-    */
+            $response->assertStatus(200);
+            $response->assertJson([
+                   'permission'   => [
+                       'signup_allowed'       => false,
+                       'missing_behavioral_agreement' => true,
+                   ]
+               ]);
+        }
+        */
 
     /*
      * Warn user the behavioral agreement was not agreed to but allow sign ups.
@@ -916,18 +929,18 @@ class PersonScheduleControllerTest extends TestCase
     {
         $photoMock = $this->setupPhotoStatus('approved');
         $mrMock = $this->mockManualReviewPass(true);
-        $this->user->update([ 'behavioral_agreement' => false ]);
+        $this->user->update(['behavioral_agreement' => false]);
         $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
-               'year' => $this->year
-           ]);
+            'year' => $this->year
+        ]);
 
         $response->assertStatus(200);
         $response->assertJson([
-               'permission'   => [
-                   'signup_allowed'       => true,
-                   'missing_behavioral_agreement' => true,
-               ]
-           ]);
+            'permission' => [
+                'signup_allowed' => true,
+                'missing_behavioral_agreement' => true,
+            ]
+        ]);
     }
 
     /*
@@ -936,53 +949,22 @@ class PersonScheduleControllerTest extends TestCase
 
     public function testAllowAuditorWithNoPhotoAndPassedManualReview()
     {
-        $this->user->update([ 'status' => 'auditor' ]);
+        $this->user->update(['status' => 'auditor']);
 
         $mrMock = $this->mockManualReviewPass(true);
 
         $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
-              'year' => $this->year
-          ]);
+            'year' => $this->year
+        ]);
 
         $response->assertStatus(200);
         $response->assertJson([
-              'permission'   => [
-                  'signup_allowed'       => true,
-                  'callsign_approved'    => true,
-                  'manual_review_passed' => true,
-              ]
-          ]);
-    }
-
-    /*
-     * Deny an prospective who missed the manual review window
-     */
-
-    public function testDenyProspectiveWhoMissedManualReviewWindow()
-    {
-        $this->user->update([ 'status' => 'prospective' ]);
-
-        $photoMock = $this->setupPhotoStatus('approved');
-
-        $mrMock = $this->mockManualReviewPass(true);
-        $mrMock->shouldReceive('prospectiveOrAlphaRankForYear')->andReturn(99);
-        $mrMock->shouldReceive('countPassedProspectivesAndAlphasForYear')->andReturn(100);
-
-        $this->setting('ManualReviewProspectiveAlphaLimit', 50);
-
-        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [
-               'year' => $this->year
-           ]);
-
-        $response->assertStatus(200);
-        $response->assertJson([
-               'permission'   => [
-                   'signup_allowed'       => false,
-                   'callsign_approved'    => true,
-                   'manual_review_passed' => true,
-                   'manual_review_window_missed' => true,
-               ]
-           ]);
+            'permission' => [
+                'signup_allowed' => true,
+                'callsign_approved' => true,
+                'manual_review_passed' => true,
+            ]
+        ]);
     }
 
     /*
@@ -996,42 +978,42 @@ class PersonScheduleControllerTest extends TestCase
 
         $shift = $this->trainingSlots[0];
         $trainerSlot = factory(Slot::class)->create(
-             [
-                 'begins'      => date($shift->begins),
-                 'ends'        => date($shift->ends),
-                 'position_id' => Position::TRAINER,
-                 'description' => "Trainers",
-                 'signed_up'   => 2,
-                 'max'         => 2,
-                 'min'         => 0,
-             ]
-         );
+            [
+                'begins' => date($shift->begins),
+                'ends' => date($shift->ends),
+                'position_id' => Position::TRAINER,
+                'description' => "Trainers",
+                'signed_up' => 2,
+                'max' => 2,
+                'min' => 0,
+            ]
+        );
 
         $trainer1 = factory(Person::class)->create();
-        factory(PersonSlot::class)->create([ 'person_id' => $trainer1->id, 'slot_id' => $trainerSlot->id]);
+        factory(PersonSlot::class)->create(['person_id' => $trainer1->id, 'slot_id' => $trainerSlot->id]);
         $trainer2 = factory(Person::class)->create();
-        factory(PersonSlot::class)->create([ 'person_id' => $trainer2->id, 'slot_id' => $trainerSlot->id]);
+        factory(PersonSlot::class)->create(['person_id' => $trainer2->id, 'slot_id' => $trainerSlot->id]);
 
-        $shift->update([ 'signed_up' => 1, 'max' => 1, 'trainer_slot_id' => $trainerSlot->id ]);
+        $shift->update(['signed_up' => 1, 'max' => 1, 'trainer_slot_id' => $trainerSlot->id]);
 
         $response = $this->json(
-             'POST',
-             "person/{$this->user->id}/schedule",
-             [
-                 'slot_id' => $shift->id,
-             ]
-         );
+            'POST',
+            "person/{$this->user->id}/schedule",
+            [
+                'slot_id' => $shift->id,
+            ]
+        );
 
         $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
+        $response->assertJson(['status' => 'success']);
 
         $this->assertDatabaseHas(
-             'person_slot',
-             [
-                 'person_id' => $this->user->id,
-                 'slot_id'   => $shift->id,
-             ]
-         );
+            'person_slot',
+            [
+                'person_id' => $this->user->id,
+                'slot_id' => $shift->id,
+            ]
+        );
     }
 
     /*
@@ -1048,20 +1030,20 @@ class PersonScheduleControllerTest extends TestCase
         $this->setting('BurnWeekendSignUpMotivationPeriod', "$year-08-25 18:00/$year-08-26 18:00:00");
 
         // Check for scheduling
-        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [ 'year' => $year ]);
+        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", ['year' => $year]);
 
         $response->assertStatus(200);
         $response->assertJson([
-                'permission'   => [
-                    'recommend_burn_weekend_shift' => true
-                ]
-            ]);
+            'permission' => [
+                'recommend_burn_weekend_shift' => true
+            ]
+        ]);
 
         // And the HQ interface
         $response = $this->json('GET', "person/{$this->user->id}/schedule/recommendations");
 
         $response->assertStatus(200);
-        $response->assertJson([ 'burn_weekend_shift' => true ]);
+        $response->assertJson(['burn_weekend_shift' => true]);
     }
 
     /*
@@ -1073,25 +1055,25 @@ class PersonScheduleControllerTest extends TestCase
         $year = $this->year;
 
         $photoMock = $this->setupPhotoStatus('approved');
-        $this->user->update([ 'status' => Person::NON_RANGER ]);
+        $this->user->update(['status' => Person::NON_RANGER]);
 
         $this->setting('BurnWeekendSignUpMotivationPeriod', "$year-08-25 18:00/$year-08-26 18:00:00");
 
         // Check for scheduling
-        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [ 'year' => $year ]);
+        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", ['year' => $year]);
 
         $response->assertStatus(200);
         $response->assertJson([
-                'permission'   => [
-                    'recommend_burn_weekend_shift' => false
-                ]
-            ]);
+            'permission' => [
+                'recommend_burn_weekend_shift' => false
+            ]
+        ]);
 
         // And the HQ interface
         $response = $this->json('GET', "person/{$this->user->id}/schedule/recommendations");
 
         $response->assertStatus(200);
-        $response->assertJson([ 'burn_weekend_shift' => false ]);
+        $response->assertJson(['burn_weekend_shift' => false]);
     }
 
     /*
@@ -1108,36 +1090,36 @@ class PersonScheduleControllerTest extends TestCase
         $this->setting('BurnWeekendSignUpMotivationPeriod', "$year-08-25 18:00/$year-08-26 18:00:00");
 
         $shift = factory(Slot::class)->create(
-             [
-                 'begins'      => date("$year-08-25 18:45:00"),
-                 'ends'        => date("$year-08-25 23:45:00"),
-                 'position_id' => Position::DIRT,
-                 'description' => "BURN WEEKEND BABY!",
-                 'signed_up'   => 0,
-                 'max'         => 10,
-                 'min'         => 0,
-             ]
-         );
+            [
+                'begins' => date("$year-08-25 18:45:00"),
+                'ends' => date("$year-08-25 23:45:00"),
+                'position_id' => Position::DIRT,
+                'description' => "BURN WEEKEND BABY!",
+                'signed_up' => 0,
+                'max' => 10,
+                'min' => 0,
+            ]
+        );
 
         factory(PersonSlot::class)->create([
-             'person_id' => $this->user->id,
-             'slot_id'   => $shift->id
-         ]);
+            'person_id' => $this->user->id,
+            'slot_id' => $shift->id
+        ]);
 
         // Check for scheduling
-        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", [ 'year' => $year ]);
+        $response = $this->json('GET', "person/{$this->user->id}/schedule/permission", ['year' => $year]);
 
         $response->assertStatus(200);
         $response->assertJson([
-                'permission'   => [
-                    'recommend_burn_weekend_shift' => false
-                ]
-            ]);
+            'permission' => [
+                'recommend_burn_weekend_shift' => false
+            ]
+        ]);
 
         // And check the HQ interface
         $response = $this->json('GET', "person/{$this->user->id}/schedule/recommendations");
 
         $response->assertStatus(200);
-        $response->assertJson([ 'burn_weekend_shift' => false ]);
+        $response->assertJson(['burn_weekend_shift' => false]);
     }
 }


### PR DESCRIPTION
- Mentor notes / flags relocated into person_intake & person_intake_notes
- Added trainee_status.feedback_delivered column
- New Intake Role to support UFV
- Relocated trainee_status.note into trainee_note table. (training notes are logged w/timestamp & person)
- Only Clubhouse admins are allowed to manual add students to a training session (ART is uneffected)
- Converted TrainingSession::score to TrainingSession::scoreStudent - no longer bulk scores student. (supports UI change)
- New person.{known_rangers,known_pnvs} columns. (todo: populate columns during Salesforce import)
- Start of mentor changes to support UFV. (will need to cycle back to this.)