### PR TITLE
Removed TimesheetCorrectionYear setting.

### DIFF
--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -411,7 +411,7 @@ class TimesheetController extends ApiController
 
         return response()->json([
              'info' => [
-                 'correction_year'     => setting('TimesheetCorrectionYear'),
+                 'correction_year'     => current_year(),
                  'correction_enabled'  => setting('TimesheetCorrectionEnable'),
                  'timesheet_confirmed' => (int) $person->timesheet_confirmed,
                  'timesheet_confirmed_at' => ($person->timesheet_confirmed ? (string) $person->timesheet_confirmed_at : null),

--- a/app/Lib/RedactDatabase.php
+++ b/app/Lib/RedactDatabase.php
@@ -97,7 +97,6 @@ class RedactDatabase {
             'RadioInfoAvailable'               => 'true',
             'TicketingPeriod'                  => 'offseason',
             'TimesheetCorrectionEnable'        => 'true',
-            'TimesheetCorrectionYear'          => $year,
         ];
 
         foreach ($settings as $name => $value) {

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -511,11 +511,6 @@ class Setting extends ApiModel
             'type' => 'bool',
         ],
 
-        'TimesheetCorrectionYear' => [
-            'description' => 'Timesheet Corrections for year',
-            'type' => 'string',
-        ],
-
         'TrainingAcademyEmail' => [
             'description' => 'Training Academy Email',
             'type' => 'email',

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -71,9 +71,7 @@ class Timesheet extends ApiModel
         'verified' => 'boolean',
         'is_incorrect' => 'boolean'
     ];
-
-    public $_is_incorrect;
-
+    
     const RELATIONSHIPS = [ 'reviewer_person:id,callsign', 'verified_person:id,callsign', 'position:id,title,count_hours' ];
 
     public function person()

--- a/database/seeds/SettingTableSeeder.php
+++ b/database/seeds/SettingTableSeeder.php
@@ -49,14 +49,6 @@ class SettingTableSeeder extends Seeder
                     'created_at' => NULL,
                     'updated_at' => NULL,
                 ),
-            6 =>
-                array(
-                    'id' => 14,
-                    'name' => 'TimesheetCorrectionYear',
-                    'value' => '2019',
-                    'created_at' => NULL,
-                    'updated_at' => NULL,
-                ),
             7 =>
                 array(
                     'id' => 15,

--- a/php-inis/xdebug.ini
+++ b/php-inis/xdebug.ini
@@ -13,8 +13,9 @@
 zend_extension=/usr/local/Cellar/php/7.3.11/pecl/20180731/xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_host=127.0.0.1
-xdebug.remote_connect_back=1    # Not safe for production servers
+xdebug.remote_connect_back=0    # Not safe for production servers
 xdebug.remote_port=9000
 xdebug.remote_handler=dbgp
 xdebug.remote_mode=req
 xdebug.remote_autostart=true
+xdebug.idekey=PHPSTORM

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -419,7 +419,7 @@ class TimesheetControllerTest extends TestCase
         $response->assertStatus(200);
         $response->assertJson([
              'info' => [
-                 'correction_year'  => 2010,
+                 'correction_year'  => current_year(),
                  'correction_enabled' => true,
                  'timesheet_confirmed'  => true,
                  'timesheet_confirmed_at' => $now


### PR DESCRIPTION
People are only allowed to submit corrections until mid-to-late fall and
does not spill over into the new year.