### PR TITLE
DRY'ed up auditing. Random cleanups.

### DIFF
--- a/app/Helpers/GlobalHelpers.php
+++ b/app/Helpers/GlobalHelpers.php
@@ -16,7 +16,7 @@ if (!function_exists('setting')) {
      * Retrieve a configuration variable possibly stored in the database.
      * Alias for Setting::get().
      *
-     * @param string $name - setting name
+     * @param mixed $name - setting name
      * @param bool $throwOnEmpty - throw an exception if the value is empty. (false is ignored.)
      * @return mixed setting value
      */

--- a/app/Http/Controllers/AccessDocumentDeliveryController.php
+++ b/app/Http/Controllers/AccessDocumentDeliveryController.php
@@ -31,9 +31,12 @@ class AccessDocumentDeliveryController extends ApiController
 
     /**
      * Show a single Access Document Delivery
+     *
+     * @param AccessDocumentDelivery $add
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-
-   public function show(AccessDocumentDelivery $add)
+    public function show(AccessDocumentDelivery $add)
    {
        $this->authorize('show', $add);
 
@@ -64,7 +67,7 @@ class AccessDocumentDeliveryController extends ApiController
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  \App\AccessDocumentDelivery  $accessDocumentDelivery
+     * @param  \App\Models\AccessDocumentDelivery  $accessDocumentDelivery
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, AccessDocumentDelivery $add)
@@ -83,7 +86,7 @@ class AccessDocumentDeliveryController extends ApiController
     /**
      * Remove the specified resource from storage.
      *
-     * @param  \App\AccessDocumentDelivery  $accessDocumentDelivery
+     * @param  \App\Models\AccessDocumentDelivery  $accessDocumentDelivery
      * @return \Illuminate\Http\Response
      */
     public function destroy(AccessDocumentDelivery $add)

--- a/app/Http/Controllers/AssetAttachmentController.php
+++ b/app/Http/Controllers/AssetAttachmentController.php
@@ -66,7 +66,6 @@ class AssetAttachmentController extends ApiController
     {
         $this->authorize('delete', $asset_attachment);
         $asset->delete();
-        $this->log('asset-attachment-delete', 'Asset Attachment Deleted', [ 'id' => $asset_attachment->id]);
         return $this->restDeleteSuccess();
     }
 }

--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -7,45 +7,48 @@ use App\Http\Controllers\ApiController;
 use App\Models\AssetPerson;
 use App\Helpers\SqlHelper;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 
 class AssetController extends ApiController
 {
-    /*
-     * Display a listing of the resource.
+    /**
+     * Display assets based on criteria
      *
-     * @return \Illuminate\Http\Response
+     * @return JsonResponse
+     * @throws AuthorizationException
      */
     public function index()
     {
         $this->authorize('index', Asset::class);
 
         $query = request()->validate([
-            'barcode'         => 'sometimes|string',    // specific barcode to find
+            'barcode' => 'sometimes|string',    // specific barcode to find
             'include_history' => 'sometimes|boolean',   // include checkout history
-            'checked_out'     => 'sometimes|boolean',   // find only outstanding assets
-            'type'            => 'sometimes|string',    // find for a type (aka description)
-            'exclude'         => 'sometimes|string',    // exclude a type (aka description)
-            'year'            => 'sometimes|integer',   // year to go searching in
+            'checked_out' => 'sometimes|boolean',   // find only outstanding assets
+            'type' => 'sometimes|string',    // find for a type (aka description)
+            'exclude' => 'sometimes|string',    // exclude a type (aka description)
+            'year' => 'sometimes|integer',   // year to go searching in
         ]);
 
         $assets = Asset::findForQuery($query);
         return $this->success($assets, null, 'asset');
     }
 
-    /*
+    /**
      * Store a newly created resource in storage.
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException
      */
-    public function store(Request $request)
+    public function store()
     {
         $this->authorize('store', Asset::class);
 
         $asset = new Asset;
         $this->fromRest($asset);
-
-        if (!$asset->isBarcodeUnique()) {
-            throw new \InvalidArgumentException("Barcode already exists for current year");
-        }
 
         if ($asset->save()) {
             return $this->success($asset);
@@ -54,27 +57,30 @@ class AssetController extends ApiController
         return $this->restError($asset);
     }
 
-    /*
+    /**
      * Display the specified resource.
+     * @param Asset $asset
+     * @return JsonResponse
+     * @throws AuthorizationException
      */
+
     public function show(Asset $asset)
     {
         $this->authorize('show', $asset);
         return $this->success($asset);
     }
 
-    /*
+    /**
      * Update the specified resource in storage.
+     * @param Asset $asset
+     * @return JsonResponse
+     * @throws AuthorizationException
      */
 
-    public function update(Request $request, Asset $asset)
+    public function update(Asset $asset)
     {
         $this->authorize('update', $asset);
         $this->fromRest($asset);
-
-        if ($asset->isDirty('barcode') && !$asset->isBarcodeUnique()) {
-            throw new \InvalidArgumentException('Barcode already exists for year');
-        }
 
         if ($asset->save()) {
             return $this->success($asset);
@@ -90,90 +96,96 @@ class AssetController extends ApiController
     {
         $this->authorize('delete', $asset);
         $asset->delete();
-        $this->log('asset-delete', 'Asset Deleted', [ 'id' => $asset->id]);
         AssetPerson::where('asset_id', $asset->id)->delete();
 
         return $this->restDeleteSuccess();
     }
 
-    /*
+    /**
      * Retrieve the asset history
+     *
+     * @param Asset $asset
+     * @return JsonResponse
+     * @throws AuthorizationException
      */
 
     public function history(Asset $asset)
     {
         $this->authorize('history', $asset);
-
-        return response()->json([ 'asset_history' => AssetPerson::retrieveHistory($asset->id) ]);
+        return response()->json(['asset_history' => AssetPerson::retrieveHistory($asset->id)]);
     }
 
-    /*
+    /**
      * Checkout Asset
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException
+     */
+    public function checkout()
+    {
+        $this->authorize('checkout', [Asset::class]);
+
+        $params = request()->validate([
+            'barcode' => 'required|string',
+            'person_id' => 'required|integer',
+            'year' => 'sometimes|integer',
+            'attachment_id' => 'sometimes|integer|nullable|exists:asset_attachment,id',
+        ]);
+
+        $year = $params['year'] ?? current_year();
+
+        $asset = Asset::findByBarcodeYear($params['barcode'], $year);
+
+        if ($asset == null) {
+            return response()->json(['status' => 'not-found']);
+        }
+
+        $asset_person = AssetPerson::findCheckedOutPerson($asset->id);
+        if ($asset_person) {
+            return response()->json([
+                'status' => 'checked-out',
+                'asset_id' => $asset->id,
+                'person_id' => $asset_person->person_id,
+                'callsign' => $asset_person->person ? $asset_person->person->callsign : "Deleted #{$asset_person->person_id}",
+                'checked_out' => (string)$asset_person->checked_out
+            ]);
+        }
+
+        $row = new AssetPerson([
+            'asset_id' => $asset->id,
+            'attachment_id' => $params['attachment_id'] ?? null,
+            'checked_out' => SqlHelper::now(),
+            'person_id' => $params['person_id'],
+        ]);
+
+        if (!$row->save()) {
+            return $this->restError($row);
+        }
+
+        return response()->json(['status' => 'success']);
+    }
+
+    /**
+     * Check in an asset
+     * @param Asset $asset
+     * @return JsonResponse
+     * @throws AuthorizationException
      */
 
-     public function checkout()
-     {
-         $this->authorize('checkout', [ Asset::class ]);
+    public function checkin(Asset $asset)
+    {
+        $this->authorize('checkin', [Asset::class]);
+        $asset_person = AssetPerson::findCheckedOutPerson($asset->id);
+        if (!$asset_person) {
+            throw new InvalidArgumentException("Asset is not checked out");
+        }
 
-         $params = request()->validate([
-             'barcode'       => 'required|string',
-             'person_id'     => 'required|integer',
-             'year'          => 'sometimes|integer',
-             'attachment_id' => 'sometimes|integer|nullable|exists:asset_attachment,id',
-         ]);
+        $asset_person->checked_in = now();
 
-         $year = $params['year'] ?? current_year();
+        if (!$asset_person->save()) {
+            return $this->restError($asset);
+        }
 
-         $asset = Asset::findByBarcodeYear($params['barcode'], $year);
-
-         if ($asset == null) {
-             return response()->json([ 'status' => 'not-found' ]);
-         }
-
-         $asset_person = AssetPerson::findCheckedOutPerson($asset->id);
-         if ($asset_person) {
-             return response()->json([
-                'status'    => 'checked-out',
-                'asset_id'  => $asset->id,
-                'person_id' => $asset_person->person_id,
-                'callsign'  => $asset_person->person ? $asset_person->person->callsign : "Deleted #{$asset_person->person_id}",
-                'checked_out' => (string) $asset_person->checked_out
-            ]);
-         }
-
-         $row = new AssetPerson([
-             'asset_id'     => $asset->id,
-             'attachment_id' => $params['attachment_id'] ?? null,
-             'checked_out'  => SqlHelper::now(),
-             'person_id'    => $params['person_id'],
-         ]);
-
-         if (!$row->save()) {
-             throw new \InvalidArgumentException("Unknown error trying to create checkout record. ".$row->getErrors());
-         }
-
-         return response()->json([ 'status' => 'success' ]);
-     }
-
-     /*
-      * Check in an asset
-      */
-
-      public function checkin(Asset $asset) {
-          $this->authorize('checkin', [ Asset::class ]);
-
-          $asset_person = AssetPerson::findCheckedOutPerson($asset->id);
-
-          if (!$asset_person) {
-              throw new \InvalidArgumentException("Asset is not checked out");
-          }
-
-          $asset_person->checked_in = SqlHelper::now();
-
-          if (!$asset_person->save()) {
-              throw new \InvalidArgumentException("Cannot check asset in");
-          }
-
-          return response()->json([ 'status' => 'success', 'checked_in' => (string) $asset_person->checked_in ]);
-      }
+        return response()->json(['status' => 'success', 'checked_in' => (string)$asset_person->checked_in]);
+    }
 }

--- a/app/Http/Controllers/BulkUploadController.php
+++ b/app/Http/Controllers/BulkUploadController.php
@@ -217,14 +217,11 @@ class BulkUploadController extends ApiController
             }
 
             $oldValue = $person->$action;
-            $newValue = $person->$action = 1;
+            $person->$action = 1;
             $record->status = 'success';
 
             if ($commit) {
-                $changes = $person->getChangedValues();
-                if ($this->saveModel($person, $record)) {
-                    $this->log('person-update', $reason, $changes, $person->id);
-                } else {
+                if (!$this->saveModel($person, $record)) {
                     continue;
                 }
             }
@@ -294,19 +291,7 @@ class BulkUploadController extends ApiController
 
             $record->status = 'success';
             if ($commit) {
-                $exists = $bmid->exists;
-                if ($exists) {
-                    $changes = $bmid->getChangedValues();
-                }
                 $this->saveModel($bmid, $record);
-                if ($record->status == 'success') {
-                    if ($exists) {
-                        $changes['id'] = $bmid->id;
-                        $this->log('bmid-update', $reason, $changes, $bmid->person_id);
-                    } else {
-                        $this->log('bmid-create', $reason, $bmid->getAttributes(), $bmid->person_id);
-                    }
-                }
             }
 
             $record->changes = [ $oldValue, $newValue ];

--- a/app/Http/Controllers/HandleController.php
+++ b/app/Http/Controllers/HandleController.php
@@ -1,13 +1,15 @@
 <?php
 namespace App\Http\Controllers;
 
-use App\Helpers\ReservedCallsigns;
+use App\Lib\ReservedCallsigns;
 use Illuminate\Support\Facades\DB;
+use App\Models\Person;
 
 /** HTTP controller for handles (person callsigns and reserved words), used by the handle checker. */
 class HandleController extends ApiController
 {
-    const EXCLUDE_STATUSES = ['past prospective', 'auditor'];
+    const EXCLUDE_STATUSES = [ Person::PAST_PROSPECTIVE, Person::AUDITOR ];
+
     /**
      * List all handles.
      * @return \Illuminate\Http\Response
@@ -27,22 +29,22 @@ class HandleController extends ApiController
                 ['id' => $ranger->id, 'status' => $ranger->status, 'vintage' => $ranger->vintage]
             );
         }
-        foreach (ReservedCallsigns::$PHONETIC as $handle) {
+        foreach (ReservedCallsigns::PHONETIC as $handle) {
             $result[] = $this->jsonHandle($handle, 'phonetic-alphabet');
         }
-        foreach (ReservedCallsigns::$LOCATIONS as $handle) {
+        foreach (ReservedCallsigns::LOCATIONS as $handle) {
             $result[] = $this->jsonHandle($handle, 'location');
         }
-        foreach (ReservedCallsigns::$RADIO_JARGON as $handle) {
+        foreach (ReservedCallsigns::RADIO_JARGON as $handle) {
             $result[] = $this->jsonHandle($handle, 'jargon');
         }
-        foreach (ReservedCallsigns::$RANGER_JARGON as $handle) {
+        foreach (ReservedCallsigns::RANGER_JARGON as $handle) {
             $result[] = $this->jsonHandle($handle, 'jargon');
         }
         foreach (ReservedCallsigns::twiiVips() as $handle) {
             $result[] = $this->jsonHandle($handle, 'VIP');
         }
-        foreach (ReservedCallsigns::$RESERVED as $handle) {
+        foreach (ReservedCallsigns::RESERVED as $handle) {
             $result[] = $this->jsonHandle($handle, 'reserved');
         }
         return response()->json(['data' => $result]);

--- a/app/Http/Controllers/HelpController.php
+++ b/app/Http/Controllers/HelpController.php
@@ -13,20 +13,20 @@ class HelpController extends ApiController
     /**
      * Display a listing of the helps.
      *
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function index()
     {
         return $this->success(Help::findAll(), null, 'help');
     }
 
-    /**
+    /***
      * Store a newly created help in storage.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
-    public function store(Request $request)
+
+    public function store()
     {
         $this->authorize('store', [ Help::class ]);
         $help = new Help;
@@ -41,9 +41,8 @@ class HelpController extends ApiController
 
     /**
      * Display the specified help.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
+     * @param Help $help
+     * @return \Illuminate\Http\JsonResponse
      */
     public function show(Help $help)
     {
@@ -56,6 +55,9 @@ class HelpController extends ApiController
     /**
      * Update the specified help in storage.
      *
+     * @param Help $help
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
     public function update(Help $help)
     {
@@ -70,11 +72,11 @@ class HelpController extends ApiController
     }
 
     /**
-     * Remove the specified help from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
+     * @param Help $help
+     * @return \Illuminate\Http\JsonResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
      */
+
     public function destroy(Help $help)
     {
         $this->authorize('destroy', $help);

--- a/app/Http/Controllers/IntakeController.php
+++ b/app/Http/Controllers/IntakeController.php
@@ -140,26 +140,4 @@ class IntakeController extends ApiController
             $this->notPermitted('Must have the Intake role');
         }
     }
-
-    /**
-     * Log any changes to an intake record
-     *
-     * @param Person $person person to log
-     * @param array $changes the changes to record
-     * @param bool $isNew true if the intake record was created
-     * @param PersonIntake $intake record itself
-     */
-
-    private function logIntakeChanges(Person $person, array $changes, bool $isNew, PersonIntake $intake)
-    {
-        if (empty($changes)) {
-            return;
-        }
-
-        if (!$isNew) {
-            $changes['id'] = $intake->id;
-        }
-
-        $this->log($isNew ? 'person-intake-create' : 'person-intake-update', '', $isNew ? $intake : $changes, $person->id);
-    }
 }

--- a/app/Http/Controllers/MentorController.php
+++ b/app/Http/Controllers/MentorController.php
@@ -67,13 +67,8 @@ class MentorController extends ApiController
             $person->mentors_flag = $potential['mentors_flag'];
             $person->mentors_flag_note = $potential['mentors_flag_note'] ?? '';
             $person->mentors_notes = $potential['mentors_notes'] ?? '';
-            $changes = $person->getChangedValues();
-
-            if (!empty($changes)) {
-                // Track changes
-                $person->saveWithoutValidation();
-                $this->log('person-update', 'mentor update', $changes, $person->id);
-            }
+            $person->auditReason = 'mentor update';
+            $person->saveWithoutValidation();
         }
 
         return $this->success();
@@ -230,8 +225,8 @@ class MentorController extends ApiController
             if ($person->status != $status) {
                 $oldStatus = $person->status;
                 $person->status = $status;
+                $person->reason = 'mentor conversion';
                 $person->saveWithoutValidation();
-                $this->log('person-update', 'mentor conversion', [ 'status' => [ $oldStatus, $status ]], $person->id);
                 $person->changeStatus($status, $oldStatus, 'mentor conversion');
             }
 

--- a/app/Http/Controllers/PersonScheduleController.php
+++ b/app/Http/Controllers/PersonScheduleController.php
@@ -222,7 +222,7 @@ class PersonScheduleController extends ApiController
      *
      * @param int $personId slot to delete for person
      * @param int $slotId to delete
-     * @return Response
+     * @return \Illuminate\Http\JsonResponse
      */
 
     public function destroy(Person $person, $slotId)

--- a/app/Http/Controllers/PositionController.php
+++ b/app/Http/Controllers/PositionController.php
@@ -31,7 +31,7 @@ class PositionController extends ApiController
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function store(Request $request)
     {
@@ -41,7 +41,6 @@ class PositionController extends ApiController
         $this->fromRest($position);
 
         if ($position->save()) {
-            $this->log('position-create', 'position create', [ 'position' => $position ]);
             return $this->success($position);
         }
 
@@ -52,7 +51,7 @@ class PositionController extends ApiController
      * Display the specified resource.
      *
      * @param  \App\Models\Position  $position
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function show(Position $position)
     {
@@ -64,19 +63,14 @@ class PositionController extends ApiController
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \App\Models\Position  $position
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function update(Request $request, Position $position)
     {
         $this->authorize('update', Position::class);
         $this->fromRest($position);
 
-        $changes = $position->getChangedValues();
         if ($position->save()) {
-            if (!empty($changes)) {
-                $changes['position_id'] = $position->id;
-                $this->log('position-update', 'position update', $changes);
-            }
             return $this->success($position);
         }
 
@@ -87,13 +81,12 @@ class PositionController extends ApiController
      * Remove the specified resource from storage.
      *
      * @param  \App\Models\Position  $position
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function destroy(Position $position)
     {
         $this->authorize('delete', Position::class);
         $position->delete();
-        $this->log('position-delete', 'position delete', [ 'position' => $position ]);
         return $this->restDeleteSuccess();
     }
 

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -24,13 +24,13 @@ class RoleController extends ApiController
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function store(Request $request)
     {
         $this->authorize('store', Role::class);
 
-        $role = new \App\Models\Role;
+        $role = new Role;
         $this->fromRest($role);
 
         if ($role->save()) {
@@ -44,7 +44,7 @@ class RoleController extends ApiController
      * Display the specified resource.
      *
      * @param  \App\Models\Role  $role
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function show(Role $role)
     {
@@ -56,7 +56,7 @@ class RoleController extends ApiController
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \App\Models\Role  $role
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function update(Request $request, Role $role)
     {
@@ -74,13 +74,12 @@ class RoleController extends ApiController
      * Remove the specified resource from storage.
      *
      * @param  \App\Models\Role  $role
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\JsonResponse
      */
     public function destroy(Role $role)
     {
         $this->authorize('delete', Role::class);
         $role->delete();
-        $this->log('role-delete', 'Role Deleted', [ 'id' => $role->id]);
         return $this->restDeleteSuccess();
     }
 }

--- a/app/Http/Controllers/SalesforceController.php
+++ b/app/Http/Controllers/SalesforceController.php
@@ -181,12 +181,11 @@ class SalesforceController extends ApiController
         if ($isNew) {
             $person->password = 'abcdef';
         } else {
-            $changes = $person->getChangedValues();
-            $changes['id'] = $person->id;
             $oldStatus = $person->status;
         }
 
         $person->status = Person::PROSPECTIVE;
+        $person->auditReason = 'salesforce import';
 
         try {
             if (!$person->save()) {
@@ -208,8 +207,6 @@ class SalesforceController extends ApiController
             ErrorLog::recordException($e, 'salesforce-import-fail', [ 'person' => $person ]);
             return false;
         }
-
-        $this->log($isNew ? 'person-create' : 'person-update', 'salesforce import', $isNew ? $person : $changes, $person->id);
 
         if ($isNew) {
             // Record the initial status for tracking through the Unified Flagging View

--- a/app/Http/Controllers/SmsController.php
+++ b/app/Http/Controllers/SmsController.php
@@ -252,7 +252,7 @@ class SmsController extends ApiController
     {
         try {
             $incoming = SMSService::processIncoming(request());
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             ErrorLog::recordException($e, 'sms-inbound-exception');
             return response()->json([ 'status' => 'error' ], 500);
         }

--- a/app/Http/Controllers/TicketingController.php
+++ b/app/Http/Controllers/TicketingController.php
@@ -248,10 +248,6 @@ class TicketingController extends ApiController
             }
         }
 
-        if (!empty($documents)) {
-            $this->log('access-document-wap-so', 'Updated list', $documents, $personId);
-        }
-
         $rows = AccessDocument::findSOWAPsForPerson($personId, $year);
         // Send back the updated list
         return response()->json([ 'names' => $rows->map(function ($row) { return $this->buildSOWAPEntry($row); }) ]);

--- a/app/Lib/PotentialClubhouseAccountFromSalesforce.php
+++ b/app/Lib/PotentialClubhouseAccountFromSalesforce.php
@@ -5,7 +5,7 @@
 namespace App\Lib;
 
 use App\Models\Person;
-use App\Helpers\ReservedCallsigns;
+use App\Lib\ReservedCallsigns;
 
 class PotentialClubhouseAccountFromSalesforce
 {
@@ -352,11 +352,11 @@ class PotentialClubhouseAccountFromSalesforce
     public static function getReservedCallsigns($style = "raw")
     {
         $reservedCallsigns = array_merge(
-            ReservedCallsigns::$LOCATIONS,
-            ReservedCallsigns::$RADIO_JARGON,
-            ReservedCallsigns::$RANGER_JARGON,
+            ReservedCallsigns::LOCATIONS,
+            ReservedCallsigns::RADIO_JARGON,
+            ReservedCallsigns::RANGER_JARGON,
             ReservedCallsigns::twiiVips(),
-            ReservedCallsigns::$RESERVED
+            ReservedCallsigns::RESERVED
         );
         if ($style == 'cooked') {
             $reservedCallsigns = array_map(function ($callsign) {

--- a/app/Lib/ReservedCallsigns.php
+++ b/app/Lib/ReservedCallsigns.php
@@ -1,5 +1,5 @@
 <?php
-namespace App\Helpers;
+namespace App\Lib;
 
 /**
  * This here is your master list of reserved callsigns.  They come in several
@@ -27,7 +27,7 @@ namespace App\Helpers;
 class ReservedCallsigns
 {
     /** NATO phonetic alphabet */
-    public static $PHONETIC = array(
+    const PHONETIC = array(
         'Alfa',
         'Bravo',
         'Charlie',
@@ -58,7 +58,7 @@ class ReservedCallsigns
     /**
      * Places, camps, locations
      */
-    public static $LOCATIONS = array(
+    const LOCATIONS = array(
         'Arctica',
         'Artery',
         'Berlin',
@@ -94,7 +94,7 @@ class ReservedCallsigns
     /**
      * Radio terms
      */
-    public static $RADIO_JARGON = array(
+    const RADIO_JARGON = array(
         'Affirmative',
         'Affirm',
         'Allcom',
@@ -126,7 +126,7 @@ class ReservedCallsigns
     /**
      * Other Burning Man or Ranger terms
      */
-    public static $RANGER_JARGON = array(
+    const RANGER_JARGON = array(
         '007',
         'Alpha',
         'BLM',
@@ -178,7 +178,7 @@ class ReservedCallsigns
     /**
      * Callsigns from the 2017 TWII Radio Directory.  Remove when adding 2020 TWII handles.
      */
-    public static $TWII_2017 = array(
+    const TWII_2017 = array(
         'Alipato',
         'Alpha1',
         'Athibat',
@@ -327,7 +327,7 @@ class ReservedCallsigns
     /**
      * Callsigns from the 2018 TWII Radio Directory.  Remove when adding 2021 TWII handles.
      */
-    public static $TWII_2018 = array(
+    const TWII_2018 = array(
         'Admin 10',
         'Alipato',
         'Alpha1',
@@ -471,7 +471,7 @@ class ReservedCallsigns
      * sort.
      */
     public static function twiiVips() {
-        $result = array_merge(ReservedCallsigns::$TWII_2018, ReservedCallsigns::$TWII_2017);
+        $result = array_merge(ReservedCallsigns::TWII_2018, ReservedCallsigns::TWII_2017);
         sort($result);
         return array_unique($result);
     }
@@ -481,7 +481,7 @@ class ReservedCallsigns
      * department (e.g., Gate, ESD) or who were involved in an incident of
      * some sort long ago and thus their handle is bad juju in some way.
      */
-    public static $RESERVED = array(
+    const RESERVED = array(
         'Joshua', // Crow  9/2015: Moved to ESD
         'Golddust', // Gone to Gate
         'Mr. E', 'Mister E', // Crow  9/2015: Bad handle / incident

--- a/app/Models/AccessDocument.php
+++ b/app/Models/AccessDocument.php
@@ -16,6 +16,7 @@ use Carbon\Carbon;
 class AccessDocument extends ApiModel
 {
     protected $table = 'access_document';
+    protected $auditModel = true;
 
     const ACTIVE_STATUSES = [
         'qualified',

--- a/app/Models/AccessDocumentDelivery.php
+++ b/app/Models/AccessDocumentDelivery.php
@@ -12,6 +12,7 @@ class AccessDocumentDelivery extends ApiModel
     use HasCompositePrimaryKey;
 
     protected $table = 'access_document_delivery';
+    protected $auditModel = true;
 
     protected $primaryKey = [ 'person_id', 'year' ];
 
@@ -90,15 +91,4 @@ class AccessDocumentDelivery extends ApiModel
                     'year'      => $year,
                 ]);
     }
-
-    public function save($options = [])
-    {
-        /*if ($this->method == 'mail' && !$this->validate($this->mailRules)) {
-            return false;
-        }*/
-
-        return parent::save($options);
-    }
-
-
 }

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -7,6 +7,7 @@ use App\Models\ApiModel;
 class Alert extends ApiModel
 {
     protected $table = 'alert';
+    protected $auditModel = true;
 
     const SHIFT_CHANGE               = 1;
     const SHIFT_MUSTER               = 2;

--- a/app/Models/AssetAttachment.php
+++ b/app/Models/AssetAttachment.php
@@ -4,12 +4,10 @@ namespace App\Models;
 
 use App\Models\ApiModel;
 
-use App\Models\Person;
-use App\Models\AssetAttachment;
-
 class AssetAttachment extends ApiModel
 {
     protected $table = 'asset_attachment';
+    protected $auditModel = true;
 
     protected $fillable = [
         'parent_type',
@@ -20,6 +18,7 @@ class AssetAttachment extends ApiModel
         'parent_type' => 'required|string',
         'description'  => 'required|string',
     ];
+
 
     public static function findAll()
     {

--- a/app/Models/Bmid.php
+++ b/app/Models/Bmid.php
@@ -12,6 +12,7 @@ use App\Helpers\SqlHelper;
 class Bmid extends ApiModel
 {
     protected $table = 'bmid';
+    protected $auditModel = true;
 
     const MEALS_TYPES = [
         'all',

--- a/app/Models/EventDate.php
+++ b/app/Models/EventDate.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 class EventDate extends ApiModel
 {
     protected $table = 'event_dates';
+    protected $auditModel = true;
 
     // All other table names are singular, and this one had to be pural. deal with it.
     protected $resourceSingle = 'event_date';

--- a/app/Models/Help.php
+++ b/app/Models/Help.php
@@ -7,6 +7,7 @@ use App\Models\ApiModel;
 class Help extends ApiModel
 {
     protected $table = 'help';
+    protected $auditModel = true;
 
     protected $fillable = [
         'slug',

--- a/app/Models/Motd.php
+++ b/app/Models/Motd.php
@@ -8,6 +8,7 @@ use App\Models\Person;
 class Motd extends ApiModel
 {
     protected $table = 'motd';
+    protected $auditModel = true;
     public $timestamps = true;
 
     protected $guarded = [

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -125,6 +125,9 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
      * @var string
      */
     protected $table = 'person';
+    protected $auditModel = true;
+
+    public $auditExclude = [ 'password', 'tpassword', 'tpassword_expire' ];
 
     /**
      * The attributes excluded from the model's JSON form.

--- a/app/Models/PersonPhoto.php
+++ b/app/Models/PersonPhoto.php
@@ -30,6 +30,7 @@ class PersonPhoto extends ApiModel
 {
     protected $table = 'person_photo';
     public $timestamps = true;
+    protected $auditModel = true;
 
     const STORAGE_DIR = 'photos/';
     const STORAGE_STAGING_DIR = 'staging/';

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -8,6 +8,9 @@ use Illuminate\Support\Facades\DB;
 
 class Position extends ApiModel
 {
+    protected $table = 'position';
+    protected $auditModel = true;
+
     const ALPHA = 1;
 
     const DIRT = 2;
@@ -181,7 +184,6 @@ class Position extends ApiModel
         Position::HOT_SPRINGS_PATROL_DRIVER => 15,
     ];
 
-    protected $table = 'position';
 
     protected $fillable = [
         'all_rangers',

--- a/app/Models/PositionCredit.php
+++ b/app/Models/PositionCredit.php
@@ -12,6 +12,7 @@ use DB;
 class PositionCredit extends ApiModel
 {
     protected $table = 'position_credit';
+    protected $auditModel = true;
 
     protected $fillable = [
         'position_id',

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -8,6 +8,7 @@ use App\Models\PersonRole;
 class Role extends ApiModel
 {
     protected $table = 'role';
+    protected $auditModel = true;
 
     const ADMIN            = 1;   // Super user! Change anything
     const VIEW_PII         = 2;   // See email, address, phone

--- a/app/Models/Slot.php
+++ b/app/Models/Slot.php
@@ -16,6 +16,7 @@ use Carbon\Carbon;
 class Slot extends ApiModel
 {
     protected $table = 'slot';
+    protected $auditModel = true;
 
     protected $fillable = [
         'active',

--- a/app/Models/Survey.php
+++ b/app/Models/Survey.php
@@ -14,11 +14,14 @@ use Illuminate\Support\Facades\DB;
 
 class Survey extends ApiModel
 {
+    protected $table = 'survey';
+    protected $auditModel = true;
+    public $timestamps = true;
+
     const TRAINER = 'trainer';
     const TRAINING = 'training';
     const SLOT = 'slot';
-    public $timestamps = true;
-    protected $table = 'survey';
+
     protected $fillable = [
         'year',
         'type',

--- a/app/Models/SurveyGroup.php
+++ b/app/Models/SurveyGroup.php
@@ -8,6 +8,7 @@ use App\Models\SurveyQuestion;
 class SurveyGroup extends ApiModel
 {
     protected $table = 'survey_group';
+    protected $auditModel = true;
     public $timestamps = true;
 
     protected $fillable = [

--- a/app/Models/SurveyQuestion.php
+++ b/app/Models/SurveyQuestion.php
@@ -7,6 +7,7 @@ use App\Models\ApiModel;
 class SurveyQuestion extends ApiModel
 {
     protected $table = 'survey_question';
+    protected $auditModel = true;
     public $timestamps = true;
 
     protected $fillable = [

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -21,6 +21,9 @@ use App\Models\Slot;
 
 class Timesheet extends ApiModel
 {
+    protected $table = 'timesheet';
+    protected $auditModel = true;
+
     const STATUS_PENDING = 'pending';
     const STATUS_APPROVED = 'approved';
     const STATUS_REJECTED = 'rejected';
@@ -29,8 +32,6 @@ class Timesheet extends ApiModel
       Position::ALPHA,
       Position::TRAINING,
     ];
-
-    protected $table = 'timesheet';
 
     protected $fillable = [
         'notes',

--- a/app/Models/TimesheetMissing.php
+++ b/app/Models/TimesheetMissing.php
@@ -12,6 +12,7 @@ use App\Models\Timesheet;
 class TimesheetMissing extends ApiModel
 {
     protected $table = "timesheet_missing";
+    protected $auditModel = true;
 
     protected $fillable = [
         'notes',

--- a/app/Models/TraineeStatus.php
+++ b/app/Models/TraineeStatus.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\DB;
 class TraineeStatus extends ApiModel
 {
     protected $table = 'trainee_status';
+    protected $auditModel = true;
 
     protected $fillable = [
         'person_id',

--- a/app/Models/TrainerStatus.php
+++ b/app/Models/TrainerStatus.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 class TrainerStatus extends ApiModel
 {
     protected $table = 'trainer_status';
+    protected $auditModel = true;
     public $timestamps = true;
 
     const ATTENDED = 'attended';


### PR DESCRIPTION
- ApiModel handles record auditing and controlled thru the $auditModel member. Turned on for most models.
- Removed most, but not all, auditing code from the controllers.
- move ReservedCallsigns from App/Helpers to App/Lib (file does not qualify as a method helper.)