### PR TITLE
MOTD enhancements, Ranger dashboard prep work, timesheet fixups.

### DIFF
--- a/app/Http/Filters/PersonEventFilter.php
+++ b/app/Http/Filters/PersonEventFilter.php
@@ -26,6 +26,9 @@ class PersonEventFilter
     const AGREEMENT_FIELDS = [
         'signed_motorpool_agreement',
         'signed_personal_vehicle_agreement',
+    ];
+
+    const TIMESHEET_FIELDS = [
         'timesheet_confirmed',
     ];
 
@@ -48,12 +51,14 @@ class PersonEventFilter
         [self::AGREEMENT_FIELDS],
         [self::READONLY_FIELDS],
         [self::HQ_FIELDS],
+        [self::TIMESHEET_FIELDS],
     ];
     const FIELDS_DESERIALIZE = [
         [self::ADMIN_FIELDS, false, [Role::ADMIN]],
         [self::AGREEMENT_FIELDS, true, [Role::ADMIN, Role::MANAGE, Role::VC, Role::TRAINER, Role::MENTOR]],
         [self::READONLY_FIELDS, false, [Role::ADMIN]],
         [self::HQ_FIELDS, false, [Role::ADMIN, Role::MANAGE, Role::VC, Role::TRAINER, Role::MENTOR]],
+        [self::TIMESHEET_FIELDS, true, [ Role::ADMIN, Role::TIMESHEET_MANAGEMENT]]
     ];
 
     protected $record;

--- a/app/Http/Filters/PersonFilter.php
+++ b/app/Http/Filters/PersonFilter.php
@@ -128,11 +128,6 @@ class PersonFilter
         'sms_off_playa_code',
     ];
 
-    const TIMESHEET_FIELDS = [
-        'timesheet_confirmed',
-        'timesheet_confirmed_at'
-    ];
-
     const MESSAGE_FIELDS = [
         'message',
         'message_updated_at'
@@ -170,7 +165,6 @@ class PersonFilter
         [ self::SMS_ADMIN_FIELDS, true, [ Role::ADMIN ]],
         [ self::RANGER_ADMIN_FIELDS ],
         [ self::PERSONNEL_FIELDS, false, [ Role::ADMIN ]],
-        [ self::TIMESHEET_FIELDS ],
     ];
 
     const FIELDS_DESERIALIZE = [
@@ -193,7 +187,6 @@ class PersonFilter
         [ self::SMS_ADMIN_FIELDS, false, [ Role::ADMIN ]],
         [ self::PERSONNEL_FIELDS, false, [ Role::ADMIN ]],
         [ self::RANGER_ADMIN_FIELDS, false, [ Role::ADMIN ]],
-        [ self::TIMESHEET_FIELDS, true, [ Role::ADMIN, Role::TIMESHEET_MANAGEMENT ]],
     ];
 
     public function buildFields(array $fieldGroups, $authorizedUser): array

--- a/app/Lib/RedactDatabase.php
+++ b/app/Lib/RedactDatabase.php
@@ -30,7 +30,6 @@ class RedactDatabase {
             'street1' => '123 Any St.',
             'street2' => '',
             'email' => DB::raw("concat(replace(callsign, ' ', ''), '@nomail.none')"),
-            'timesheet_confirmed' => false,
             'behavioral_agreement' => false,
             'message'   => '',
             'bpguid' => 'DEAD-BEEF',

--- a/app/Models/ApiModel.php
+++ b/app/Models/ApiModel.php
@@ -287,4 +287,8 @@ abstract class ApiModel extends Model
     {
         return $date->format('Y-m-d H:i:s');
     }
+
+    public function setAuditModel($audit) {
+        $this->auditModel = $audit;
+    }
 }

--- a/app/Models/Motd.php
+++ b/app/Models/Motd.php
@@ -5,6 +5,9 @@ namespace App\Models;
 use App\Models\ApiModel;
 use App\Models\Person;
 
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
 class Motd extends ApiModel
 {
     protected $table = 'motd';
@@ -18,36 +21,169 @@ class Motd extends ApiModel
     ];
 
     protected $rules = [
+        'subject' => 'required|string',
         'message' => 'required|string',
-        'is_alert' => 'sometimes|boolean'
+        'expires_at' => 'required|date',
     ];
 
-    public function person() {
+    protected $dates = [
+        'created_at',
+        'updated_at',
+        'expires_at'
+    ];
+
+    protected $appends = [
+        'has_expired',
+        'has_read'
+    ];
+
+
+    public function person()
+    {
         return $this->belongsTo(Person::class);
     }
 
-    public static function findAll()
+    public static function findForQuery(array $query): array
     {
-        return self::orderBy('created_at')->with('person:id,callsign')->get();
-    }
+        $audience = $query['audience'] ?? 'all';
+        $type = $query['type'] ?? null;
+        $page = $query['page'] ?? 1;
+        $pageSize = $query['page_size'] ?? 20;
+        $sort = $query['sort'] ?? 'desc';
 
-    public static function findForStatus($status) {
-        switch ($status) {
-            case Person::AUDITOR:
-                $type = 'for_auditors';
+        $sql = self::query();
+
+        switch ($audience) {
+            case 'auditors':
+            case 'pnvs':
+            case 'rangers':
+                $sql->where('for_' . $audience, 1);
                 break;
-            case Person::PROSPECTIVE:
-            case Person::ALPHA:
-                $type = 'for_pnvs';
+            case 'all':
                 break;
             default:
-                if (in_array($status, Person::NO_MESSAGES_STATUSES)) {
-                    return [];
-                }
-                $type = 'for_rangers';
+                throw new InvalidArgumentException("Unknown audience value");
+        }
+
+        switch ($type) {
+            case 'expired':
+                $sql->where('expires_at', '>', now());
+                break;
+            case 'active':
+                $sql->where(function ($q) {
+                    $q->where('expires_at', '<', now());
+                    $q->orWhereNull('expires_at');
+                });
                 break;
         }
 
-        return self::where($type, 1)->orderBy('created_at')->get();
+        $total = $sql->count();
+        $page = $page - 1;
+        if ($page < 0) {
+            $page = 0;
+        }
+
+        $sql->offset($page * $pageSize)->limit($pageSize);
+        $sql->orderBy('expires_at', ($sort == 'asc' ? 'asc' : 'desc'));
+
+        return [
+            'motd' => $sql->with('person:id,callsign')->get(),
+            'meta' => [
+                'total' => $total,
+                'total_pages' => (int)(($total + ($pageSize - 1)) / $pageSize),
+                'page_size' => $pageSize,
+                'page' => $page + 1,
+                'table_count' => self::query()->count()
+            ]
+        ];
+
+    }
+
+    public static function findForBulletin(int $personId, string $status, array $params): array
+    {
+        $type = $params['type'] ?? 'all';
+        $page = $params['page'] ?? 1;
+        $pageSize = $params['page_size'] ?? 20;
+
+        switch ($status) {
+            case Person::AUDITOR:
+                $audience = 'for_auditors';
+                break;
+            case Person::PROSPECTIVE:
+            case Person::ALPHA:
+                $audience = 'for_pnvs';
+                break;
+            default:
+                if (in_array($status, Person::NO_MESSAGES_STATUSES)) {
+                    return [
+                        'motd' => [],
+                        'meta' => [
+                            'total' => 0,
+                            'total_pages' => 0,
+                            'page_size' => $pageSize,
+                            'page' => 1,
+                        ]
+                    ];
+                }
+                $audience = 'for_rangers';
+                break;
+        }
+
+        $sql = self::where($audience, 1);
+        $sql->leftJoin('person_motd', function ($j) use ($personId) {
+            $j->on('person_motd.motd_id', 'motd.id');
+            $j->where('person_motd.person_id', $personId);
+        });
+
+        switch ($type) {
+            case 'expired':
+                $sql->where('expires_at', '<', now());
+                break;
+
+            case 'visible':
+                $sql->where('expires_at', '>', now());
+                $sql->whereNull('person_motd.read_at');
+                break;
+
+            default:
+                $sql->where('expires_at', '>', now());
+                break;
+        }
+
+        $total = $sql->count();
+
+        $sql->select('motd.*', DB::raw('IFNULL(person_motd.read_at, FALSE) as has_read'));
+        // Figure out pagination
+        $page = $page - 1;
+        if ($page < 0) {
+            $page = 0;
+        }
+
+        $sql->offset($page * $pageSize)->limit($pageSize);
+
+        return [
+            'motd' => $sql->orderBy('created_at')->get(),
+            'meta' => [
+                'total' => $total,
+                'total_pages' => (int)(($total + ($pageSize - 1)) / $pageSize),
+                'page_size' => $pageSize,
+                'page' => $page + 1,
+            ]
+        ];
+    }
+
+    public function setExpiresAtAttribute($value)
+    {
+        $this->attributes['expires_at'] = empty($value) ? null : $value;
+    }
+
+    public function getHasReadAttribute()
+    {
+        return (bool)($this->attributes['has_read'] ?? false);
+    }
+
+    public function getHasExpiredAttribute()
+    {
+        return $this->expires_at ? $this->expires_at->lt(now()) : false;
     }
 }

--- a/app/Models/PersonMotd.php
+++ b/app/Models/PersonMotd.php
@@ -1,0 +1,28 @@
+<?php
+namespace App\Models;
+
+use App\Models\ApiModel;
+
+use App\Models\Person;
+use App\Models\Motd;
+
+use Illuminate\Support\Facades\DB;
+
+class PersonMotd extends ApiModel
+{
+    protected $table = 'person_motd';
+    protected $guarded = [];    // table is not directly accessible, allow anything
+
+    public function person() {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function motd() {
+        return $this->belongsTo(Motd::class);
+    }
+
+    public static function markAsRead($personId, $motdId)
+    {
+        self::updateOrCreate([ 'person_id' => $personId, 'motd_id' => $motdId],  [ 'read_at' => now() ]);
+    }
+}

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -27,6 +27,9 @@ class Position extends ApiModel
     const MENTOR_KHAKI = 86;
     const MENTOR_RADIO_TRAINER = 72;
 
+    const CHEETAH = 45;
+    const CHEETAH_CUB = 46;
+
     const DIRT_GREEN_DOT = 4;
     const GREEN_DOT_LEAD = 14;
     const GREEN_DOT_LEAD_INTERN = 126;

--- a/app/Policies/MotdPolicy.php
+++ b/app/Policies/MotdPolicy.php
@@ -13,7 +13,7 @@ class MotdPolicy
     use HandlesAuthorization;
 
     public function before(Person $user) {
-        if ($user->hasRole(Role::ADMIN)) {
+        if ($user->hasRole([ Role::ADMIN, Role::MEGAPHONE ])) {
             return true;
         }
     }

--- a/app/Policies/PersonPolicy.php
+++ b/app/Policies/PersonPolicy.php
@@ -122,10 +122,6 @@ class PersonPolicy
         return $user->hasRole([ Role::ADMIN, Role::VC ]);
     }
 
-    public function vehiclePaperwork(Person $user) {
-        return $user->hasRole([ Role::ADMIN, Role::MANAGE ]);
-    }
-
     public function peopleByLocation(Person $user) {
         return $user->hasRole([ Role::ADMIN, Role::VIEW_PII, Role::MANAGE ]);
     }

--- a/app/Policies/VehiclePolicy.php
+++ b/app/Policies/VehiclePolicy.php
@@ -77,4 +77,8 @@ class VehiclePolicy
     {
         return ($vehicle->person_id == $user->id && $vehicle->status == Vehicle::PENDING);
     }
- }
+
+    public function paperwork(Person $user) {
+        return $user->hasRole([ Role::ADMIN, Role::MANAGE ]);
+    }
+}

--- a/database/migrations/2020_07_24_155418_enhance_motd.php
+++ b/database/migrations/2020_07_24_155418_enhance_motd.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class EnhanceMotd extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('motd', function (Blueprint $table) {
+           $table->dateTime('expires_at')->nullable(false);
+           $table->string('subject')->nullable(false);
+           $table->index(['expires_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('motd', function (Blueprint $table) {
+            $table->dropColumn([ 'expires_at', 'subject' ]);
+        });
+    }
+}

--- a/database/migrations/2020_07_24_155438_create_person_motd_table.php
+++ b/database/migrations/2020_07_24_155438_create_person_motd_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePersonMotdTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('person_motd', function (Blueprint $table) {
+            $table->bigInteger('person_id')->nullable(false);
+            $table->bigInteger('motd_id')->nullable(false);
+            $table->dateTime('read_at')->nullable(false);
+            $table->index([ 'person_id', 'motd_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('person_motd');
+    }
+}

--- a/database/migrations/2020_07_29_134241_convert_ts_confirmation_to_person_event.php
+++ b/database/migrations/2020_07_29_134241_convert_ts_confirmation_to_person_event.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use App\Models\Person;
+use App\Models\PersonEvent;
+
+class ConvertTsConfirmationToPersonEvent extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        foreach (Person::where('timesheet_confirmed',true)->cursor() as $person ) {
+            $event = PersonEvent::firstOrNewForPersonYear($person->id, 2019);
+            $event->setAuditModel(false);
+            $event->timesheet_confirmed = true;
+            $event->timesheet_confirmed_at = $person->timesheet_confirmed_at;
+            $event->saveWithoutValidation();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -151,6 +151,7 @@ Route::group([
     Route::get('mentor/verdicts', 'MentorController@verdicts');
 
     Route::get('motd/bulletin', 'MotdController@bulletin');
+    Route::post('motd/{motd}/markread', 'MotdController@markRead');
     Route::resource('motd', 'MotdController');
 
     Route::get('person/alpha-shirts', 'PersonController@alphaShirts');
@@ -159,7 +160,6 @@ Route::group([
     Route::get('person/by-role', 'PersonController@peopleByRole');
     Route::get('person/by-status', 'PersonController@peopleByStatus');
     Route::get('person/by-status-change', 'PersonController@peopleByStatusChange');
-    Route::get('person/vehicle-paperwork', 'PersonController@vehiclePaperwork');
 
     Route::get('person/{person}/alerts', 'AlertPersonController@index');
     Route::patch('person/{person}/alerts', 'AlertPersonController@update');
@@ -201,6 +201,7 @@ Route::group([
     Route::get('person-photo/{person_photo}/reject-preview', 'PersonPhotoController@rejectPreview');
     Route::resource('person-photo', 'PersonPhotoController');
 
+    Route::get('vehicle/paperwork', 'VehicleController@paperwork');
     Route::resource('vehicle', 'VehicleController');
 
     Route::post('position-credit/copy', 'PositionCreditController@copy');


### PR DESCRIPTION
- Added subject, expires_at columns to motd
- Added person_motd to track who read a motd.
- Added query parameters to motd/{index,bullentin}
- person/milestones: check for cheetah cub signups for inactive extensions & retirees.
- person/milestones: return vehicle requests if person is allowed vehicle stickers
- relocated person/vehicle-paperwork to  vehicle/paperwork
- Only un-confirm a timesheet if the entry is for the current year.
- converted the last of person.timesheet_confirm* to person_event.timesheet_confirm*
- setup person_event.timesheet_confirm for 2019.