### PR TITLE
Addressed {SqlHelper,SQL,Carbon}::now() usage. Minor tweaks.

### DIFF
--- a/app/Console/Commands/ClubhouseDailyReportCommand.php
+++ b/app/Console/Commands/ClubhouseDailyReportCommand.php
@@ -50,7 +50,7 @@ class ClubhouseDailyReportCommand extends Command
         $errorLogs = ErrorLog::findForQuery(['lastday' => true, 'page_size' => 20])['error_logs'];
 
         $roleLogs = ActionLog::findForQuery(['lastday' => 'true', 'page_size' => 1000, 'events' => ['person-role-add', 'person-role-remove']], false)['action_logs'];
-        $statusLogs = PersonStatus::where('created_at', '>=', DB::raw('DATE_SUB(NOW(), INTERVAL 25 HOUR)'))->with(['person:id,callsign', 'person_source:id,callsign'])->get();
+        $statusLogs = PersonStatus::whereRaw('created_at >= DATE_SUB(?, INTERVAL 1 DAY)',[now()])->with(['person:id,callsign', 'person_source:id,callsign'])->get();
 
         $settings = setting([
             'OnlineTrainingEnabled',

--- a/app/Helpers/GlobalHelpers.php
+++ b/app/Helpers/GlobalHelpers.php
@@ -83,7 +83,7 @@ if (!function_exists('current_year')) {
                 return $year;
             }
 
-            $year = SqlHelper::now()->year;
+            $year = now()->year;
             return $year;
         }
         return date('Y');

--- a/app/Helpers/SqlHelper.php
+++ b/app/Helpers/SqlHelper.php
@@ -8,16 +8,6 @@ use Illuminate\Support\Facades\DB;
 class SqlHelper
 {
     /*
-     * Grab the current timestamp from the database server
-     */
-
-    public static function now()
-    {
-        $result = DB::select("SELECT NOW() as tod");
-        return Carbon::parse($result[0]->tod);
-    }
-
-    /*
      * Quote a value for use in raw SQL statements
      */
 
@@ -25,4 +15,5 @@ class SqlHelper
     {
         return DB::getPdo()->quote($value);
     }
+
 }

--- a/app/Http/Controllers/AccessDocumentController.php
+++ b/app/Http/Controllers/AccessDocumentController.php
@@ -120,7 +120,7 @@ class AccessDocumentController extends ApiController
             $accessDocument->person_id = $this->user->id;
         }
 
-        $accessDocument->create_date = $accessDocument->modified_date = SqlHelper::now();
+        $accessDocument->create_date = $accessDocument->modified_date = now();
         if (!$accessDocument->save()) {
             return $this->restError($accessDocument);
         }
@@ -531,7 +531,7 @@ class AccessDocumentController extends ApiController
         $user = $this->user->callsign;
 
         $rows = AccessDocument::whereIn('status', [ 'banked', 'claimed', 'qualified' ])
-                ->whereRaw('expiry_date < NOW()')
+                ->whereRaw('expiry_date < ?', [now()])
                 ->with('person:id,callsign,status,email')
                 ->get();
 

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -34,7 +34,7 @@ class ApiController extends Controller
             }
 
             $this->user->retrieveRoles();
-            DB::select("UPDATE person SET last_seen_at=NOW() WHERE id=?", [ $this->user->id ]);
+            DB::select("UPDATE person SET last_seen_at=? WHERE id=?", [ now(), $this->user->id ]);
         }
     }
 

--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -154,7 +154,7 @@ class AssetController extends ApiController
         $row = new AssetPerson([
             'asset_id' => $asset->id,
             'attachment_id' => $params['attachment_id'] ?? null,
-            'checked_out' => SqlHelper::now(),
+            'checked_out' => now(),
             'person_id' => $params['person_id'],
         ]);
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -104,7 +104,7 @@ class AuthController extends Controller
         }
 
         $lastLoggedIn = $person->logged_in_at;
-        $person->logged_in_at = SqlHelper::now();
+        $person->logged_in_at = now();
         $person->saveWithoutValidation();
 
         ActionLog::record($person, 'auth-login', 'User login', $actionData);

--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -36,7 +36,7 @@ class ConfigController extends Controller
         $configs = setting(self::CLIENT_CONFIGS);
 
         if (config('clubhouse.GroundhogDayServer')) {
-            $configs['GroundhogDayTime'] = (string) SqlHelper::now();
+            $configs['GroundhogDayTime'] = (string) now();
         }
 
         $configs['DeploymentEnvironment'] = config('clubhouse.DeploymentEnvironment');

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -446,6 +446,20 @@ class PersonController extends ApiController
 
         $event = PersonEvent::firstOrNewForPersonYear($person->id, current_year());
 
+        $timesheet = Timesheet::findPersonOnDuty($person->id);
+        if ($timesheet) {
+            $positionId = $timesheet->position_id;
+            $onduty = [
+                'id' => $timesheet->position_id,
+                'title' => $timesheet->position->title,
+                'type' => $timesheet->position->type,
+                'subtype' => $timesheet->position->subtype,
+            ];
+        } else {
+            $onduty = null;
+            $positionId = 0;
+        }
+
         $data = [
             'teacher' => [
                 'is_trainer' => $person->hasRole([Role::ADMIN, Role::TRAINER]),
@@ -457,9 +471,9 @@ class PersonController extends ApiController
             'unread_message_count' => PersonMessage::countUnread($person->id),
             'years' => Timesheet::years($person->id),
             'all_years' => Timesheet::years($person->id, true),
-            'has_hq_window' => PersonPosition::havePosition($person->id, Position::HQ_WINDOW),
-            'is_on_duty_at_hq' => Timesheet::isPersonSignIn($person->id, [Position::HQ_WINDOW_PRE_EVENT, Position::HQ_LEAD_PRE_EVENT, Position::HQ_WINDOW, Position::HQ_SHORT, Position::HQ_LEAD]),
-            'may_request_stickers' => $event->may_request_stickers
+            'has_hq_window' => PersonPosition::havePosition($person->id, Position::HQ_WORKERS),
+            'may_request_stickers' => $event->may_request_stickers,
+            'onduty_position' => $onduty
         ];
 
         /*

--- a/app/Http/Controllers/PersonPhotoController.php
+++ b/app/Http/Controllers/PersonPhotoController.php
@@ -117,7 +117,7 @@ class PersonPhotoController extends ApiController
         $reviewed = false;
         if ($personPhoto->isDirty('status')) {
             // Setting the status means the record has been reviewed.
-            $personPhoto->reviewed_at = SqlHelper::now();
+            $personPhoto->reviewed_at = now();
             $personPhoto->review_person_id = $this->user->id;
             $reviewed = true;
         }
@@ -161,7 +161,7 @@ class PersonPhotoController extends ApiController
         list ($image, $width, $height) = $this->processImage($params['image'], $personPhoto->person_id);
 
         $personPhoto->edit_person_id = $this->user->id;
-        $personPhoto->edited_at = SqlHelper::now();
+        $personPhoto->edited_at = now();
         $personPhoto->width = $width;
         $personPhoto->height = $height;
 
@@ -291,7 +291,7 @@ class PersonPhotoController extends ApiController
         $photo = new PersonPhoto;
         $photo->person_id = $personId;
         $photo->status = PersonPhoto::SUBMITTED;
-        $photo->uploaded_at = SqlHelper::now();
+        $photo->uploaded_at = now();
         $photo->upload_person_id = $this->user->id;
 
         $photo->width = $imageWidth;

--- a/app/Http/Controllers/PersonScheduleController.php
+++ b/app/Http/Controllers/PersonScheduleController.php
@@ -230,7 +230,7 @@ class PersonScheduleController extends ApiController
         $this->authorize('delete', [Schedule::class, $person]);
 
         $slot = Slot::findOrFail($slotId);
-        $now = SqlHelper::now();
+        $now = now();
 
         list($canForce, $isTrainer) = $this->canForceScheduleChange($slot, false);
 
@@ -415,7 +415,7 @@ class PersonScheduleController extends ApiController
     {
         $this->authorize('view', [Schedule::class, $person]);
 
-        $now = SqlHelper::now();
+        $now = now();
         $year = current_year();
 
         $rows = Schedule::findForQuery([

--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -411,7 +411,7 @@ class SlotController extends ApiController
             'date'  => 'sometimes|date'
         ]);
 
-        $date = $params['date'] ?? SqlHelper::now();
+        $date = $params['date'] ?? now();
 
         return response()->json([
             'positions' => ShiftReporting::retrieveFlakeReport($date),

--- a/app/Http/Controllers/SmsController.php
+++ b/app/Http/Controllers/SmsController.php
@@ -324,7 +324,7 @@ class SmsController extends ApiController
             $isAdmin = $person->hasRole(Role::ADMIN);
             if ($isAdmin) {
                 $status = Broadcast::STATUS_STATS;
-                $rows = Broadcast::whereRaw("created_at >= DATE_SUB(NOW(), INTERVAL 1 DAY)")->get();
+                $rows = Broadcast::whereRaw("created_at >= DATE_SUB(?, INTERVAL 1 DAY)",[now()])->get();
                 $broadcastCount = $rows->count();
                 $smsFails = 0;
                 $emailFails = 0;
@@ -343,7 +343,7 @@ class SmsController extends ApiController
                     $reply = "Broadcasts $broadcastCount Recipients $totalRecipients SMS fails $smsFails Email fails $emailFails Last broadcast @ $lastDate";
                 }
 
-                $inboundCount = BroadcastMessage::where('direction', 'inbound')->whereRaw('created_at >= DATE_SUB(NOW(), INTERVAL 1 DAY)')->count();
+                $inboundCount = BroadcastMessage::where('direction', 'inbound')->whereRaw('created_at >= DATE_SUB(?, INTERVAL 1 DAY)', [ now() ])->count();
 
                 $reply .= " Inbound msgs $inboundCount";
             } else {

--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -662,7 +662,7 @@ class TimesheetController extends ApiController
                 case 'in':
                     // Sign in - create timesheet
                     if (empty($signin)) {
-                        $signin = SqlHelper::now();
+                        $signin = now();
                     }
 
                     $timesheet = new Timesheet([
@@ -687,7 +687,7 @@ class TimesheetController extends ApiController
                     }
 
                     if (empty($signout)) {
-                        $signout = SqlHelper::now();
+                        $signout = now();
                     }
                     $timesheet->off_duty = $signout;
                     $event = 'signoff';

--- a/app/Lib/RBS.php
+++ b/app/Lib/RBS.php
@@ -366,7 +366,7 @@ class RBS
         // Update the fail counters
         $broadcast->sms_failed = BroadcastMessage::countFail($broadcast->id, 'sms');
         $broadcast->email_failed = BroadcastMessage::countFail($broadcast->id, 'email');
-        $broadcast->retry_at = SqlHelper::now();
+        $broadcast->retry_at = now();
         $broadcast->retry_person_id = $retryPersonId;
         $broadcast->save();
     }

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -88,7 +88,7 @@ class ActionLog extends Model
         }
 
         if ($lastDay) {
-            $sql->where('created_at', '>=', DB::raw('DATE_SUB(NOW(), INTERVAL 25 HOUR)'));
+            $sql->whereRaw('created_at >= DATE_SUB(?, INTERVAL 24 HOUR)', [ now() ]);
         }
 
         // How many total for the query

--- a/app/Models/AssetPerson.php
+++ b/app/Models/AssetPerson.php
@@ -8,7 +8,7 @@ use App\Models\Person;
 use App\Models\AssetAttachment;
 use App\Models\Asset;
 
-use DB;
+use Illuminate\Support\Facades\DB;
 
 class AssetPerson extends ApiModel
 {
@@ -24,29 +24,33 @@ class AssetPerson extends ApiModel
 
     protected $casts = [
         'checked_out' => 'datetime',
-        'checked_in'  => 'datetime',
+        'checked_in' => 'datetime',
     ];
 
     protected $rules = [
         'person_id' => 'required|integer',
-        'asset_id'  => 'required|integer',
+        'asset_id' => 'required|integer',
     ];
 
-    const RELATIONSHIPS = [ 'asset', 'attachment', 'person:id,callsign' ];
+    const RELATIONSHIPS = ['asset', 'attachment', 'person:id,callsign'];
 
-    public function person() {
+    public function person()
+    {
         return $this->belongsTo('App\Models\Person');
     }
 
-    public function attachment() {
+    public function attachment()
+    {
         return $this->belongsTo('App\Models\AssetAttachment');
     }
 
-    public function asset() {
+    public function asset()
+    {
         return $this->belongsTo('App\Models\Asset');
     }
 
-    public function loadRelationships() {
+    public function loadRelationships()
+    {
         $this->load(self::RELATIONSHIPS);
     }
 
@@ -59,13 +63,14 @@ class AssetPerson extends ApiModel
      * @param array $query conditions to look up
      *
      */
-    public static function findForQuery($query) {
-        $sql = self::with([ 'asset', 'attachment' ]);
+    public static function findForQuery($query)
+    {
+        $sql = self::with(['asset', 'attachment']);
 
         if (@$query['person_id']) {
             $sql = $sql->where('person_id', $query['person_id']);
         } else {
-            $sql = $ql->with([ 'person:id,callsign' ]);
+            $sql = $ql->with(['person:id,callsign']);
         }
 
         if (@$query['year']) {
@@ -78,78 +83,81 @@ class AssetPerson extends ApiModel
     public static function retrieveHistory($assetId)
     {
         return self::where('asset_id', $assetId)
-                ->with([ 'person:id,callsign', 'attachment'])
-                ->get();
+            ->with(['person:id,callsign', 'attachment'])
+            ->get();
     }
 
     /**
      * Find if a person has checked out an asset.
      */
 
-     public static function findCheckedOutPerson($assetId)
-     {
-         return self::where('asset_id', $assetId)
-                ->whereNull('checked_in')
-                ->with('person:id,callsign')
-                ->first();
-     }
+    public static function findCheckedOutPerson($assetId)
+    {
+        return self::where('asset_id', $assetId)
+            ->whereNull('checked_in')
+            ->with('person:id,callsign')
+            ->first();
+    }
 
-     /**
-      * Find all raidios that were checked out with duration.
-      *
-      * query types are:
-      * year: the year to find radios, defaults to current year if not present
-      * include_qualified: include people who qualified for event radios, otherwise find only shift qualified individuals
-      * event_summary: report on all radios still checked out or was checked out over the hour limit.
-      * hour_limit: rpeort on radios checked out for more than X hours. defaults to 14
-      */
+    /**
+     * Find all raidios that were checked out with duration.
+     *
+     * query types are:
+     * year: the year to find radios, defaults to current year if not present
+     * include_qualified: include people who qualified for event radios, otherwise find only shift qualified individuals
+     * event_summary: report on all radios still checked out or was checked out over the hour limit.
+     * hour_limit: rpeort on radios checked out for more than X hours. defaults to 14
+     */
 
-     public static function findRadiosCheckedOutForQuery($query) {
-         $year = $query['year'] ?? current_year();
-         $sql = self::select(
-                     'asset_person.person_id',
-                     'person.callsign',
-                     'asset_person.checked_out',
-                     'asset_person.checked_in',
-                     'asset.barcode',
-                     'asset.perm_assign',
-                     DB::raw('(UNIX_TIMESTAMP(IFNULL(asset_person.checked_in, NOW())) - UNIX_TIMESTAMP(asset_person.checked_out)) AS duration'),
-                     DB::raw('IF(radio_eligible.max_radios > 0, true,false) AS eligible')
-                 )
-                 ->join('person', 'person.id', 'asset_person.person_id')
-                 ->join('asset', 'asset.id', 'asset_person.asset_id')
-                 ->whereYear('checked_out', $year)
-                 ->where('description', 'radio');
+    public static function findRadiosCheckedOutForQuery($query)
+    {
+        $year = $query['year'] ?? current_year();
+        $now = (string) now();
+        $sql = self::select(
+            'asset_person.person_id',
+            'person.callsign',
+            'asset_person.checked_out',
+            'asset_person.checked_in',
+            'asset.barcode',
+            'asset.perm_assign',
+            DB::raw("(UNIX_TIMESTAMP(IFNULL(asset_person.checked_in, '$now')) - UNIX_TIMESTAMP(asset_person.checked_out)) AS duration"),
+            DB::raw('IF(radio_eligible.max_radios > 0, true,false) AS eligible')
+        )
+            ->join('person', 'person.id', 'asset_person.person_id')
+            ->join('asset', 'asset.id', 'asset_person.asset_id')
+            ->whereYear('checked_out', $year)
+            ->where('description', 'radio');
 
-         $sql->leftJoin('radio_eligible', function ($query) use ($year) {
-                 $query->whereRaw('radio_eligible.person_id=asset_person.person_id');
-                 $query->where('year', $year);
-         });
+        $sql->leftJoin('radio_eligible', function ($query) use ($year) {
+            $query->whereRaw('radio_eligible.person_id=asset_person.person_id');
+            $query->where('year', $year);
+        });
 
-         $seconds = ($query['hour_limit'] ?? 14) * 3600;
+        $seconds = ($query['hour_limit'] ?? 14) * 3600;
 
-         if (isset($query['event_summary'])) {
-             $sql->where(function($q) use ($seconds) {
-                 $q->whereNull('checked_in');
-                 $q->orWhereRaw("(UNIX_TIMESTAMP(asset_person.checked_in) - UNIX_TIMESTAMP(asset_person.checked_out)) > $seconds");
-             });
-         } else {
-             $sql->whereRaw("(UNIX_TIMESTAMP() - UNIX_TIMESTAMP(asset_person.checked_out)) > $seconds")->whereNull('checked_in');
-         }
+        if (isset($query['event_summary'])) {
+            $sql->where(function ($q) use ($seconds) {
+                $q->whereNull('checked_in');
+                $q->orWhereRaw("(UNIX_TIMESTAMP(asset_person.checked_in) - UNIX_TIMESTAMP(asset_person.checked_out)) > $seconds");
+            });
+        } else {
+            $sql->whereRaw("(UNIX_TIMESTAMP() - UNIX_TIMESTAMP(asset_person.checked_out)) > $seconds")->whereNull('checked_in');
+        }
 
-         if (empty($query['include_qualified'])) {
-             $sql->whereNull('radio_eligible.max_radios');
-         }
+        if (empty($query['include_qualified'])) {
+            $sql->whereNull('radio_eligible.max_radios');
+        }
 
-         return $sql->orderBy('person.callsign')->orderBy('asset_person.checked_out')->get();
-     }
+        return $sql->orderBy('person.callsign')->orderBy('asset_person.checked_out')->get();
+    }
 
-     public function setAttachmentIdAttribute($value) {
-         if (empty($value)) {
-             $value = null;
-         }
+    public function setAttachmentIdAttribute($value)
+    {
+        if (empty($value)) {
+            $value = null;
+        }
 
-         $this->attributes['attachment_id'] = $value;
-     }
+        $this->attributes['attachment_id'] = $value;
+    }
 
 }

--- a/app/Models/Broadcast.php
+++ b/app/Models/Broadcast.php
@@ -108,7 +108,7 @@ class Broadcast extends ApiModel {
         if ($year) {
             $sql->whereYear('created_at', $year);
         } else if ($lastDay) {
-            $sql->where('created_at', '>=', DB::raw('DATE_SUB(NOW(), INTERVAL 25 HOUR)'));
+            $sql->whereRaw('created_at >= DATE_SUB(?, INTERVAL 1 DAY)', [ now() ]);
         }
 
         if ($failedOnly) {

--- a/app/Models/Clubhouse1Log.php
+++ b/app/Models/Clubhouse1Log.php
@@ -72,7 +72,7 @@ class Clubhouse1Log extends Model
         }
 
         if ($lastDay) {
-            $sql->where('occurred', '>=', DB::raw('DATE_SUB(NOW(), INTERVAL 25 HOUR)'));
+            $sql->whereRaw('occurred >= DATE_SUB(?, INTERVAL 1 DAY)', [now()]);
         }
 
         // How many total for the query

--- a/app/Models/ErrorLog.php
+++ b/app/Models/ErrorLog.php
@@ -140,7 +140,7 @@ class ErrorLog extends ApiModel
         }
 
         if (isset($query['last_day'])) {
-            $sql->where('created_at', '>=', DB::raw('DATE_SUB(NOW(), INTERVAL 25 HOUR)'));
+            $sql->whereRaw('created_at >= DATE_SUB(?, INTERVAL 1 DAY)', [now()]);
         }
 
         // How many total for the query

--- a/app/Models/EventDate.php
+++ b/app/Models/EventDate.php
@@ -94,26 +94,18 @@ class EventDate extends ApiModel
     }
 
     /**
-     * Retrieve the burn weekend date range if set.
+     * Retrieve the burn weekend date range.
      *
      * @return array start and ending time
      */
 
     public static function retrieveBurnWeekendPeriod()
     {
-/*        $burnWeekendPeriod = setting('BurnWeekendSignUpMotivationPeriod');
-        if (empty($burnWeekendPeriod)) {
-            return false; // Not set, don't bother
-        }
-
-        list($start, $end) = explode('/', $burnWeekendPeriod);
-        $start = Carbon::parse(trim($start));
-        $end = Carbon::parse(trim($end));
-*/
         $year = current_year();
         $laborDay = (new Carbon("September $year first monday"));
+        // Burn weekend is Friday @ 18:00 til Monday @ 00:00 (late Sunday night)
         $start = $laborDay->clone()->subDays(3)->setTime(18,0,0);
-        $end = $laborDay->clone()->subDays(1)->setTime(18,0,0);
+        $end = $laborDay->clone()->setTime(0,0,0);
 
         return [ $start, $end ];
     }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -344,12 +344,12 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         parent::boot();
 
         self::creating(function ($model) {
-            $model->create_date = SqlHelper::now();
+            $model->create_date = now();
         });
 
         self::saving(function ($model) {
             if ($model->isDirty('message')) {
-                $model->message_updated_at = SqlHelper::now();
+                $model->message_updated_at = now();
             }
 
             // Ensure shirts are always set correctly
@@ -975,7 +975,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         }
 
         $personId = $this->id;
-        $this->status_date = SqlHelper::now();
+        $this->status_date = now();
         $this->status = $newStatus;
 
         PersonStatus::record($this->id, $oldStatus, $newStatus, $reason, Auth::id());

--- a/app/Models/Survey.php
+++ b/app/Models/Survey.php
@@ -142,7 +142,8 @@ class Survey extends ApiModel
             'description',
             'signed_up',
             DB::raw('EXISTS (SELECT 1 FROM survey_answer WHERE slot_id=slot.id LIMIT 1) AS has_responses'),
-            DB::raw('IF(slot.ends < NOW(), TRUE, FALSE) as has_ended'))
+            DB::raw('IF(slot.ends < ? , TRUE, FALSE) as has_ended'),
+            )->setBindings([now()])
             ->whereYear('begins', $this->year)
             ->where('position_id', $this->position_id)
             ->orderBy('begins')

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -890,6 +890,7 @@ class Training extends Position
      */
     public static function retrieveDirtTrainingsForPersonYear(int $personId, int $year): Collection
     {
+        $now = (string)now();
         return DB::table('person_slot')
             ->select(
                 'slot.id as slot_id',
@@ -898,7 +899,7 @@ class Training extends Position
                 DB::raw('IFNULL(trainee_status.passed, FALSE) as passed'),
                 'trainee_status.notes',
                 'trainee_status.rank',
-                DB::raw('(NOW() >= slot.begins) as has_started')
+                DB::raw("('$now' >= slot.begins) as has_started")
             )->join('slot', function ($j) use ($year) {
                 $j->on('slot.id', 'person_slot.slot_id');
                 $j->whereYear('slot.begins', $year);
@@ -924,6 +925,7 @@ class Training extends Position
 
     public static function retrieveTrainingHistoryForIds($peopleIds, int $positionId, int $year): Collection
     {
+        $now = (string) now();
         // Find the sign ups
         $rows = DB::table('slot')
             ->select(
@@ -932,7 +934,7 @@ class Training extends Position
                 'slot.description as slot_description',
                 'slot.begins as slot_begins',
                 DB::raw('YEAR(slot.begins) as slot_year'),
-                DB::raw('IF(slot.ends < NOW(), true, false) as slot_has_ended'),
+                DB::raw("IF(slot.ends < '$now', true, false) as slot_has_ended"),
                 DB::raw('IFNULL(trainee_status.passed, FALSE) as training_passed'),
                 'trainee_status.rank as training_rank',
                 'trainee_status.feedback_delivered as feedback_delivered'

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -365,7 +365,7 @@ class TimesheetControllerTest extends TestCase
     {
         $timesheet = Timesheet::factory()->create([
             'person_id'   => $this->targetPerson->id,
-            'on_duty'     => SqlHelper::now(),
+            'on_duty'     => now(),
             'position_id' => Position::DIRT,
         ]);
 


### PR DESCRIPTION
- Removed SqlHelper::now() and the "now()" SQL function. Using now() (Carbon) exclusively, now. (All part of the plan to find a better training server solution with Ground Hog Day support.)
- Adjusted Burn Weekend to end on Monday @ 00:00 (late Sunday night)
- PersonController::userInfo - return the shift the person is signed into and figure out if the person is signed in as a mentor, mentee or other.