### PR TITLE
Reworked sign up blockers.

### DIFF
--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -17,19 +17,19 @@ class ConfigController extends Controller
         'EditorUrl',
         'GeneralSupportEmail',
         'JoiningRangerSpecialTeamsUrl',
-        'MentorEmail',
         'MealDates',
         'MealInfoAvailable',
+        'MentorEmail',
         'MotorpoolPolicyEnable',
         'PersonnelEmail',
-        'RadioCheckoutFormUrl',
+        'RadioCheckoutAgreementEnabled',
         'RangerFeedbackFormUrl',
         'RangerManualUrl',
         'RangerPoliciesUrl',
         'RpTicketThreshold',
         'ScTicketThreshold',
         'TrainingAcademyEmail',
-        'VCEmail'
+        'VCEmail',
     ];
 
     public function show() {

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -577,12 +577,12 @@ class PersonController extends ApiController
         $person = new Person;
         $person->fill($params['person']);
 
-        if ($person->status != 'auditor') {
+        if ($person->status != Person::AUDITOR) {
             throw new InvalidArgumentException('Only the auditor status is allowed currently for registration.');
         }
 
         // make the callsign for an auditor.
-        if ($person->status == 'auditor') {
+        if ($person->status == Person::AUDITOR) {
             $person->resetCallsign();
         }
 
@@ -608,7 +608,7 @@ class PersonController extends ApiController
         PersonStatus::record($person->id, '', Person::AUDITOR, 'registration', $person->id);
 
         // Send a welcome email to the person if not an auditor
-        if ($person->status != 'auditor' && setting('SendWelcomeEmail')) {
+        if ($person->status != Person::AUDITOR && setting('SendWelcomeEmail')) {
             mail_to($person->email, new WelcomeMail($person), true);
         }
 

--- a/app/Http/Filters/PersonEventFilter.php
+++ b/app/Http/Filters/PersonEventFilter.php
@@ -21,14 +21,11 @@ class PersonEventFilter
         'may_request_stickers',
         'org_vehicle_insurance',
         'sandman_affidavit',
-    ];
-
-    const AGREEMENT_FIELDS = [
         'signed_motorpool_agreement',
         'signed_personal_vehicle_agreement',
     ];
 
-    const TIMESHEET_FIELDS = [
+     const TIMESHEET_FIELDS = [
         'timesheet_confirmed',
     ];
 
@@ -48,14 +45,12 @@ class PersonEventFilter
     const FIELDS_SERIALIZE = [
         [self::KEY_FIELDS],
         [self::ADMIN_FIELDS],
-        [self::AGREEMENT_FIELDS],
         [self::READONLY_FIELDS],
         [self::HQ_FIELDS],
         [self::TIMESHEET_FIELDS],
     ];
     const FIELDS_DESERIALIZE = [
         [self::ADMIN_FIELDS, false, [Role::ADMIN]],
-        [self::AGREEMENT_FIELDS, true, [Role::ADMIN, Role::MANAGE, Role::VC, Role::TRAINER, Role::MENTOR]],
         [self::READONLY_FIELDS, false, [Role::ADMIN]],
         [self::HQ_FIELDS, false, [Role::ADMIN, Role::MANAGE, Role::VC, Role::TRAINER, Role::MENTOR]],
         [self::TIMESHEET_FIELDS, true, [ Role::ADMIN, Role::TIMESHEET_MANAGEMENT]]

--- a/app/Lib/Milestones.php
+++ b/app/Lib/Milestones.php
@@ -36,6 +36,7 @@ class Milestones
             'online_training_url' => setting('OnlineTrainingUrl'),
             'behavioral_agreement' => $person->behavioral_agreement,
             'has_reviewed_pi' => $person->hasReviewedPi(),
+            'asset_authorized' => $event->asset_authorized,
             'trainings_available' => Slot::haveActiveForPosition(Position::TRAINING),
             'surveys' => Survey::retrieveUnansweredForPersonYear($person->id, $year),
             'period' => $period,

--- a/app/Lib/Scheduling.php
+++ b/app/Lib/Scheduling.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Lib;
+
+use App\Models\EventDate;
+use App\Models\Person;
+use App\Models\PersonOnlineTraining;
+use App\Models\PersonPhoto;
+use App\Models\Schedule;
+
+class Scheduling
+{
+    // Personal Information has not been reviewed
+    const PI_UNREVIEWED = 'pi-unreviewed';
+    // BPGUID has not been linked.
+    const BPGUID_MISSING = 'bpguid-missing';
+    // Online Training has not been completed
+    const OT_MISSING = 'ot-missing';
+    // Callsign is unapproved
+    const CALLSIGN_UNAPPROVED = 'callsign-unapproved';
+    // Photo is missing or been rejected
+    const PHOTO_UNAPPROVED = 'photo-unapproved';
+    // Person is a past prospective.
+    const PAST_PROSPECTIVE = 'past-prospective';
+
+    public static function retrieveSignUpPermission(Person $person, int $year)
+    {
+        $personId = $person->id;
+        $status = $person->status;
+        $callsignApproved = $person->callsign_approved;
+
+        if ($status == Person::PAST_PROSPECTIVE) {
+            return [
+                'signup_for_all_shifts' => false,
+                'signup_for_training' => false,
+                'requirements' => [ self::PAST_PROSPECTIVE ]
+            ];
+        }
+
+        $isAuditor = ($status == Person::AUDITOR);
+        $isPNV = ($status == Person::PROSPECTIVE || $status == Person::ALPHA);
+        $isNonRanger = ($status == Person::NON_RANGER);
+
+        if ($isAuditor || setting('AllowSignupsWithoutPhoto')) {
+            // Auditors do not have BMIDs.. or sign ups are allowed explicitly without a photo (DANGEROUS).
+            $photoStatus = PersonPhoto::NOT_REQUIRED;
+        } else {
+            $photoStatus = PersonPhoto::retrieveStatus($person);
+        }
+
+        if (setting('OnlineTrainingDisabledAllowSignups')) {
+            // OT not required
+            $otCompleted = true;
+        } else {
+            $otCompleted = PersonOnlineTraining::didCompleteForYear($personId, current_year());
+        }
+
+        $canSignUpForTraining = $otCompleted;
+        $canSignUpForAllShifts = true;
+
+        $requirements = [];
+        $trainingRequirements = [];
+
+        if ($isAuditor || $isPNV) {
+            if (!$person->hasReviewedPi()) {
+                // Auditors & PNVS have to have reviewed their Personal information first.
+                $requirements[] = self::PI_UNREVIEWED;
+            }
+
+            if (!$otCompleted) {
+                // .. and must pass Online Training before doing anything else
+                $requirements[] = self::OT_MISSING;
+            }
+        } else {
+            if (!$isNonRanger && !$otCompleted) {
+                $trainingRequirements[] = self::OT_MISSING;
+            }
+        }
+
+        if (!$isAuditor) {
+            if (!$callsignApproved) {
+                $requirements[] = self::CALLSIGN_UNAPPROVED;
+            }
+
+            if ($photoStatus != PersonPhoto::APPROVED && $photoStatus != PersonPhoto::NOT_REQUIRED) {
+                $requirements[] = self::PHOTO_UNAPPROVED;
+            }
+
+            // Everyone except Auditors and Non Rangers need to have BPGUID on file.
+            if (!$isNonRanger && empty($person->bpguid)) {
+                $requirements[] = self::BPGUID_MISSING;
+            }
+        }
+
+        /*
+          New for 2019, everyone has to agree to the org's behavioral standards agreement.
+          $missingBehaviorAgreement = !$person->behavioral_agreement;
+
+          July 5th, 2019 - agreement language is slightly broken. Agreement is optional.
+
+          if ($missingBehaviorAgreement) {
+             $canSignUpForAllShifts = false;
+           }
+        */
+
+        if (!empty($requirements)) {
+            // hard requirements are not met
+            $canSignUpForTraining = false;
+            $canSignUpForAllShifts = false;
+        } else if (!empty($trainingRequirements)) {
+            $canSignUpForTraining = false; // only training effected
+        }
+
+        $requirements = array_merge($requirements, $trainingRequirements);
+
+        return [
+            // Can the person sign up for all (except training) shifts?
+            'all_signups_allowed' => $canSignUpForAllShifts,
+            // Can the person sign up for training?
+            'training_signups_allowed' => $canSignUpForTraining,
+            'requirements' => $requirements,
+            'recommend_burn_weekend_shift' => self::recommendBurnWeekendShift($person),
+        ];
+    }
+
+    /**
+     * Should a burn weekend shift be recommended to the person?
+     * @param Person $person
+     * @return bool true if the person does not have any weekend shift signups.
+     */
+    public static function recommendBurnWeekendShift(Person $person)
+    {
+        $status = $person->status;
+        if ($status == Person::ALPHA
+            || $status == Person::AUDITOR
+            || $status == Person::PROSPECTIVE
+            || $status == Person::NON_RANGER) {
+            // Do not recommend to PNVs, Auditors, and Non Rangers
+            return false;
+        }
+
+        list ($start, $end) = EventDate::retrieveBurnWeekendPeriod();
+
+        if (now()->gt($end)) {
+            // The current time is past the burn weekend.
+            return false;
+        }
+
+        return !Schedule::hasSignupInPeriod($person->id, $start, $end);
+    }
+
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -222,9 +222,9 @@ class Setting extends ApiModel
             'type' => 'bool',
         ],
 
-        'RadioCheckoutFormUrl' => [
-            'description' => 'Radio Checkout Form URL',
-            'type' => 'string',
+        'RadioCheckoutAgreementEnabled' => [
+            'description' => 'Allows the Radio Checkout Agreement to be signed',
+            'type' => 'bool',
         ],
 
         'RadioInfoAvailable' => [
@@ -243,7 +243,7 @@ class Setting extends ApiModel
         ],
 
         'RangerPoliciesUrl' => [
-            'description' => 'Rnager Policy Document URL',
+            'description' => 'Ranger Policy Document URL',
             'type' => 'string',
         ],
 
@@ -253,7 +253,7 @@ class Setting extends ApiModel
         ],
 
         'SFEnableWritebacks' => [
-            'description' => 'Enable Saleforce Object Update',
+            'description' => 'Enable Salesforce Object Update',
             'type' => 'bool',
         ],
 


### PR DESCRIPTION
- Permission to sign up is broken into two pieces - all sign ups (excluding dirt training), and dirt training sign ups.
- Removed RadioCheckoutFormUrl setting
- Added RadioCheckoutAgreementEnabled setting
- person_event.asset_authorized is write restricted to self and admin. Login management no longer has write permission.