### PR TITLE
New Clubhouse settings purge command. Groundhog Day work.

### DIFF
--- a/app/Console/Commands/ClubhouseGroundHogDayCommand.php
+++ b/app/Console/Commands/ClubhouseGroundHogDayCommand.php
@@ -10,7 +10,7 @@ use App\Lib\RedactDatabase;
 
 class ClubhouseGroundHogDayCommand extends Command
 {
-    const GROUNDHOG_DATETIME = "2018-08-30 18:00:00";
+    const GROUNDHOG_DATETIME = "2019-08-30 19:00:00";
     const GROUNDHOG_DATABASE = "rangers_ghd";
 
     /**
@@ -121,11 +121,13 @@ class ClubhouseGroundHogDayCommand extends Command
         // Setup an announcement
 
         DB::table('motd')->insert([
-            'message'    => "Welcome to the Training Server where the date is always ".date('l, F jS Y', strtotime($groundHogDay)).".",
+            'subject' => 'Welcome to '.date('l, F jS Y', strtotime($groundHogDay)).'!',
+            'message'    => 'Remember the temporal prime directive, do not muck up the timeline by killing your own grandparent in the past.',
             'person_id' => 4594,
             'for_rangers' => true,
             'for_pnvs' => true,
-            'for_auditors' => true
+            'for_auditors' => true,
+            'expires_at' => '2099-09-01 12:00:00'
         ]);
 
         $this->info("Creating mysql dump of groundhog database");

--- a/app/Console/Commands/ClubhousePurgeSettings.php
+++ b/app/Console/Commands/ClubhousePurgeSettings.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Setting;
+
+class ClubhousePurgeSettings extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'clubhouse:purge-settings';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Purge any Clubhouse setting from the database that are no longer defined in app/Models/Settings.php';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $settings = Setting::all();
+
+        foreach ($settings as $setting) {
+            if (!isset(Setting::DESCRIPTIONS[$setting->name])) {
+                $this->info("Purging {$setting->name}");
+                $setting->delete();
+            }
+        }
+        return 0;
+    }
+}

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
@@ -25,7 +26,19 @@ class ApiController extends Controller
 
     public function __construct()
     {
-        if (Auth::check()) {
+        /*
+         * The JWT token has an expiry timestamp - do the authentication check
+         * before setting up the ground hog day time, otherwise the JWT token will be invalidated
+         */
+        $check = Auth::check();
+
+        $ghdTime = config('clubhouse.GroundhogDayServer');
+        if (!empty($ghdTime)) {
+            // Remember the temporal prime directive - don't kill your own grandfather when traveling to the past
+            Carbon::setTestNow($ghdTime);
+        }
+
+        if ($check) {
             $this->user = Auth::user();
             if (in_array($this->user->status, Person::LOCKED_STATUSES)) {
                 // A user should not be able to login when not authorized.

--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
-use App\Helpers\SqlHelper;
 
 class ConfigController extends Controller
 {
@@ -32,7 +32,18 @@ class ConfigController extends Controller
         'VCEmail',
     ];
 
+    /**
+     * Return the minimal set of settings used to boot the frontend application.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+
     public function show() {
+        $ghdTime = config('clubhouse.GroundhogDayServer');
+        if (!empty($ghdTime)) {
+            Carbon::setTestNow($ghdTime);
+        }
+
         $configs = setting(self::CLIENT_CONFIGS);
 
         if (config('clubhouse.GroundhogDayServer')) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,14 +2,12 @@
 
 namespace App\Providers;
 
-use Blade;
-use DB;
-use Event;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Validator;
+
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Facades\Log;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/docker/start-nginx
+++ b/docker/start-nginx
@@ -18,6 +18,9 @@ cd /var/www/application;
 echo "Waiting for database to come online...";
 php artisan db:wait;
 
+echo "Purging obsoleted Clubhouse settings ...";
+php artisan clubhouse:purge-settings
+
 echo "Caching Laravel configuration and routes...";
 php artisan config:cache;
 php artisan route:cache;


### PR DESCRIPTION
- New 'clubhouse:purge-settings' command to delete obsoleted settings from the database.
  Run as part of the Docker image startup sequence.
- RANGER_CLUBHOUSE_GROUNDHOG_DAY_SERVER is treated as a datetime string instead of a boolean.
- Using Carbon::setTestNow() to time travel - JWT token generation requires special casing since
  the embedded expiry timestamps have to be in the current timeline and not the simulated one.