### PR TITLE
Add positoin active status to report endpoints

### DIFF
--- a/app/Http/Controllers/PositionController.php
+++ b/app/Http/Controllers/PositionController.php
@@ -119,6 +119,7 @@ class PositionController extends ApiController
         $positionQuery = Position::select(
             'id',
             'title',
+            'active',
             'type',
             'new_user_eligible',
             'all_rangers',

--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -793,7 +793,7 @@ class TimesheetController extends ApiController
         $this->authorize('timesheetTotals', [Timesheet::class]);
         $year = $this->getYear();
 
-        return response()->json(['people' => TImesheet::retrieveTimesheetTotals($year)]);
+        return response()->json(['people' => Timesheet::retrieveTimesheetTotals($year)]);
     }
 
     /*
@@ -805,7 +805,7 @@ class TimesheetController extends ApiController
         $this->authorize('timesheetByPosition', [Timesheet::class]);
         $year = $this->getYear();
 
-        return response()->json(['positions' => TImesheet::retrieveByPosition($year, $this->userCanViewEmail())]);
+        return response()->json(['positions' => Timesheet::retrieveByPosition($year, $this->userCanViewEmail())]);
 
     }
 }

--- a/app/Lib/ShiftReporting.php
+++ b/app/Lib/ShiftReporting.php
@@ -422,7 +422,7 @@ class ShiftReporting
                 ->join('slot', 'slot.id', 'person_slot.slot_id')
                 ->join('person', 'person.id', 'person_slot.person_id')
                 ->whereIn('person_slot.slot_id', $slotIds)
-                ->with([ 'slot', 'slot.position:id,title', 'person:id,callsign,status' ])
+                ->with([ 'slot', 'slot.position:id,title,active', 'person:id,callsign,status' ])
                 ->orderBy('person.callsign')
                 ->orderBy('slot.begins')
                 ->get()
@@ -438,8 +438,9 @@ class ShiftReporting
                     $slot = $row->slot;
                     return [
                         'position'  => [
-                            'id'    => $slot->position_id,
-                            'title' => $slot->position ? $slot->position->title : "Position #{$slot->position_id}"
+                            'id'     => $slot->position_id,
+                            'title'  => $slot->position ? $slot->position->title : "Position #{$slot->position_id}",
+                            'active' => $slot->position ? $slot->position->active : false
                         ],
                         'begins'      => (string) $slot->begins,
                         'ends'        => (string) $slot->ends,

--- a/app/Lib/ShiftReporting.php
+++ b/app/Lib/ShiftReporting.php
@@ -369,7 +369,7 @@ class ShiftReporting
                 ->join('position', 'position.id', 'slot.position_id')
                 ->whereYear('begins', $year)
                 ->where('slot.active', true)
-                ->with([ 'position:id,title', 'person_slot.person:id,callsign,status' ])
+                ->with([ 'position:id,title,active', 'person_slot.person:id,callsign,status' ])
                 ->orderBy('position.title')
                 ->orderBy('slot.begins')
                 ->get()
@@ -383,6 +383,7 @@ class ShiftReporting
             return [
                 'id'    => $position->id,
                 'title' => $position->title,
+                'active' => $position->active,
                 'slots' => $p->map(function ($slot) {
                     $signups = $slot->person_slot->sort(function ($a, $b) {
                         $aCallsign = $a->person ? $a->person->callsign : "Person #{$a->person_id}";

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -818,7 +818,7 @@ class Timesheet extends ApiModel
     public static function retrieveByPosition($year, $includeEmail=false)
     {
         $rows = Timesheet::whereYear('on_duty', $year)
-                ->with([ 'person:id,callsign,status,email', 'position:id,title' ])
+                ->with([ 'person:id,callsign,status,email', 'position:id,title,active' ])
                 ->orderBy('on_duty')
                 ->get()
                 ->groupBy('position_id');
@@ -828,8 +828,9 @@ class Timesheet extends ApiModel
         foreach ($rows as $positionId => $entries) {
             $position = $entries[0]->position;
             $results[] = [
-                'id'    => $position->id,
-                'title' => $position->title,
+                'id'     => $position->id,
+                'title'  => $position->title,
+                'active' => $position->active,
                 'timesheets' => $entries->map(function($r) use ($includeEmail) {
                     $person = $r->person;
                     $personInfo = [

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -770,7 +770,8 @@ class Timesheet extends ApiModel
     public static function retrieveAllForYearByCallsign($year)
     {
         $rows = self::whereYear('on_duty', $year)
-                ->with([ 'person:id,callsign,status', 'position:id,title,type,count_hours' ])
+                ->with([ 'person:id,callsign,status',
+                          'position:id,title,active,type,count_hours' ])
                 ->orderBy('on_duty')
                 ->get();
 
@@ -801,8 +802,9 @@ class Timesheet extends ApiModel
                         'duration'  => $t->duration,
                         'credits'   => $t->credits,
                         'position'   => [
-                            'id'    => $t->position_id,
-                            'title' => $t->position ? $t->position->title : "Position #".$t->position_id,
+                            'id'     => $t->position_id,
+                            'title'  => $t->position ? $t->position->title : "Position #".$t->position_id,
+                            'active' => $t->position->active,
                             'count_hours' => $t->position ? $t->position->count_hours : 0,
                         ]
                     ];

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -45,6 +45,7 @@ class TimesheetControllerTest extends TestCase
                 'id'    => Position::DIRT,
                 'title' => 'Dirt',
                 'type'  => 'Frontline',
+                'active' => false
             ]
         );
 
@@ -1227,7 +1228,9 @@ class TimesheetControllerTest extends TestCase
         $response->assertJson([
             'positions' => [
                 [
-                    'id'    => Position::DIRT,
+                    'id'     => Position::DIRT,
+                    'title'  => 'Dirt',
+                    'active' => false,
                     'timesheets' => [[
                             'person' => [
                                 'id'        => $personA->id,
@@ -1240,7 +1243,9 @@ class TimesheetControllerTest extends TestCase
                     ]],
                 ],
                 [
-                    'id'    => Position::HQ_WINDOW,
+                    'id'     => Position::HQ_WINDOW,
+                    'title'  => 'HQ Window',
+                    'active' => true,
                     'timesheets' => [[
                             'person' => [
                                 'id'        => $personB->id,

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -1119,7 +1119,8 @@ class TimesheetControllerTest extends TestCase
                         [
                             'position' => [
                                 'id' => Position::DIRT,
-                                'title' => 'Dirt'
+                                'title' => 'Dirt',
+                                'active'=> false,
                             ],
                             'on_duty' => (string)$entry->on_duty,
                             'off_duty' => (string)$entry->off_duty,


### PR DESCRIPTION
> ⚠️ This PR is required by burningmantech/ranger-clubhouse-web/pull/752

Add the position active status to report endpoints so that the reports can display the status of positions.