### PR TITLE
Timesheet restructuring.

### DIFF
--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -5,11 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\Asset;
 use App\Http\Controllers\ApiController;
 use App\Models\AssetPerson;
-use App\Helpers\SqlHelper;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use InvalidArgumentException;
 
 class AssetController extends ApiController

--- a/app/Http/Controllers/AssetPersonController.php
+++ b/app/Http/Controllers/AssetPersonController.php
@@ -4,10 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 
-use App\Helpers\SqlHelper;
 use App\Http\Controllers\ApiController;
 
-use App\Models\Asset;
 use App\Models\AssetPerson;
 
 class AssetPersonController extends ApiController
@@ -31,13 +29,14 @@ class AssetPersonController extends ApiController
     /**
      * Create an asset person
      */
-    public function store(Request $request)
+
+    public function store()
     {
         $this->authorize('store', [ AssetPerson::class ]);
         $asset_person = new AssetPerson;
-        $this->fromReset($asset_person);
+        $this->fromRest($asset_person);
 
-        if (!$this->save()) {
+        if (!$asset_person->save()) {
             return $this->restError($asset_person);
         }
 

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -11,6 +10,7 @@ use Illuminate\Support\Facades\DB;
 use App\Http\Controllers\ApiController;
 
 use App\Lib\Milestones;
+use App\Lib\Reports\TimesheetWorkSummaryReport;
 
 use App\Models\Person;
 use App\Models\PersonEvent;
@@ -18,27 +18,19 @@ use App\Models\PersonEventInfo;
 use App\Models\PersonLanguage;
 use App\Models\PersonMentor;
 use App\Models\PersonMessage;
-use App\Models\PersonOnlineTraining;
 use App\Models\PersonPhoto;
 use App\Models\PersonPosition;
 use App\Models\PersonRole;
-use App\Models\PersonSlot;
 use App\Models\PersonStatus;
 use App\Models\Position;
 use App\Models\Role;
-use App\Models\Slot;
 use App\Models\SurveyAnswer;
 use App\Models\Timesheet;
-use App\Models\TraineeStatus;
 use App\Models\Training;
 
 use App\Mail\AccountCreationMail;
 use App\Mail\NotifyVCEmailChangeMail;
 use App\Mail\WelcomeMail;
-
-use Carbon\Carbon;
-use InvalidArgumentException;
-use RuntimeException;
 
 class PersonController extends ApiController
 {
@@ -130,7 +122,7 @@ class PersonController extends ApiController
     public function store(Request $request)
     {
         $this->authorize('store');
-        throw new RuntimeException('unimplemented');
+        throw new \RuntimeException('unimplemented');
     }
 
     /*
@@ -511,14 +503,10 @@ class PersonController extends ApiController
 
     public function timesheetSummary(Person $person)
     {
-        $params = request()->validate([
-            'year' => 'integer|required'
-        ]);
-
         $this->authorize('view', $person);
-
+        $year = $this->getYear();
         return response()->json([
-            'summary' => Timesheet::workSummaryForPersonYear($person->id, $params['year'])
+            'summary' => TimesheetWorkSummaryReport::execute($person->id, $year)
         ]);
     }
 
@@ -578,7 +566,7 @@ class PersonController extends ApiController
         $person->fill($params['person']);
 
         if ($person->status != Person::AUDITOR) {
-            throw new InvalidArgumentException('Only the auditor status is allowed currently for registration.');
+            throw new \InvalidArgumentException('Only the auditor status is allowed currently for registration.');
         }
 
         // make the callsign for an auditor.

--- a/app/Http/Filters/TimesheetFilter.php
+++ b/app/Http/Filters/TimesheetFilter.php
@@ -16,9 +16,8 @@ class TimesheetFilter
     }
 
     const USER_FIELDS = [
-        'notes',
-        'verified',
-        'is_incorrect'
+        'additional_notes',
+        'review_status',
     ];
 
     const MANAGE_FIELDS = [
@@ -26,13 +25,12 @@ class TimesheetFilter
         'on_duty',
         'person_id',
         'position_id',
-        'review_status',
-        'reviewer_notes',
+        'additional_reviewer_notes',
     ];
 
     public function deserialize(Person $user = null): array
     {
-        if ($user->hasRole([ Role::ADMIN, Role::TIMESHEET_MANAGEMENT ]))
+        if ($user->hasRole([Role::ADMIN, Role::TIMESHEET_MANAGEMENT]))
             return array_merge(self::USER_FIELDS, self::MANAGE_FIELDS);
 
         if ($this->record->person_id == $user->id || $user->hasRole(Role::MANAGE)) {

--- a/app/Http/Filters/TimesheetMissingFilter.php
+++ b/app/Http/Filters/TimesheetMissingFilter.php
@@ -16,18 +16,17 @@ class TimesheetMissingFilter
     }
 
     const USER_FIELDS = [
-        'notes',
+        'additional_notes',
         'off_duty',
         'on_duty',
         'partner',
         'person_id',
         'position_id',
-        'verified',
     ];
 
     const MANAGE_FIELDS = [
         'review_status',
-        'reviewer_notes',
+        'additional_reviewer_notes',
         'create_entry',
         'new_off_duty',
         'new_on_duty',

--- a/app/Lib/Reports/CombinedTimesheetCorrectionRequestsReport.php
+++ b/app/Lib/Reports/CombinedTimesheetCorrectionRequestsReport.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\PositionCredit;
+use App\Models\Timesheet;
+
+use App\Models\TimesheetMissing;
+
+class CombinedTimesheetCorrectionRequestsReport
+{
+    public static function execute($year)
+    {
+        // Find all the unverified timesheets
+        $rows = Timesheet::with(['person:id,callsign', 'position:id,title'])
+            ->whereYear('on_duty', $year)
+            ->where('review_status', Timesheet::STATUS_PENDING)
+            ->whereNotNull('off_duty')
+            ->orderBy('on_duty')
+            ->get();
+
+        // Warm up the position credit cache so the database is not being slammed.
+        PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
+
+        $corrections = $rows->sortBy(function ($p) {
+            return $p->person->callsign;
+        }, SORT_NATURAL | SORT_FLAG_CASE)->values();
+
+        $requests = [];
+        foreach ($corrections as $req) {
+            $requests[] = [
+                'person' => $req->person,
+                'position' => $req->position,
+                'on_duty' => (string)$req->on_duty,
+                'off_duty' => (string)$req->off_duty,
+                'duration' => $req->duration,
+                'credits' => $req->credits,
+                'is_missing' => false,
+                'notes' => $req->notes
+            ];
+        }
+
+        $missing = TimesheetMissing::retrieveForPersonOrAllForYear(null, $year);
+
+        foreach ($missing as $req) {
+            $requests[] = [
+                'person' => $req->person,
+                'position' => $req->position,
+                'on_duty' => (string)$req->on_duty,
+                'off_duty' => (string)$req->off_duty,
+                'duration' => $req->duration,
+                'credits' => $req->credits,
+                'is_missing' => true,
+                'notes' => $req->notes
+            ];
+        }
+
+        usort($requests, function ($a, $b) {
+            return strcasecmp($a['person']->callsign, $b['person']->callsign);
+        });
+
+        return $requests;
+    }
+}

--- a/app/Lib/Reports/FreakingYearsReport.php
+++ b/app/Lib/Reports/FreakingYearsReport.php
@@ -1,0 +1,75 @@
+<?php
+
+
+namespace App\Lib\Reports;
+
+
+use App\Models\Person;
+use App\Models\Position;
+use Illuminate\Support\Facades\DB;
+
+class FreakingYearsReport
+{
+    /**
+     * Build a Freaking Years report - how long a person has rangered, the first year rangered, the last year to ranger,
+     * and if the person intends to ranger in the intended year (usually the current year)
+     *
+     * @param bool $showAll false if only report on active status rangers, otherwise everyone.
+     * @param int $intendToWorkYear year the person might work in (usually the current year)
+     * @return array|\Illuminate\Support\Collection
+     */
+
+    public static function execute(bool $showAll, int $intendToWorkYear)
+    {
+        $excludePositionIds = implode(',', [Position::ALPHA, Position::HQ_RUNNER]);
+        $statusCond = $showAll ? '' : 'person.status="active" AND ';
+
+        $rows = DB::select(
+            'SELECT E.person_id, sum(year) AS years, ' .
+            "(SELECT YEAR(on_duty) FROM timesheet ts WHERE ts.person_id=E.person_id AND YEAR(ts.on_duty) > 0 GROUP BY YEAR(ts.on_duty) ORDER BY YEAR(ts.on_duty) ASC LIMIT 1) AS first_year, " .
+            "(SELECT YEAR(on_duty) FROM timesheet ts WHERE ts.person_id=E.person_id AND YEAR(ts.on_duty) > 0 GROUP BY YEAR(ts.on_duty) ORDER BY YEAR(ts.on_duty) DESC LIMIT 1) AS last_year, " .
+            "EXISTS (SELECT 1 FROM person_slot JOIN slot ON slot.id=person_slot.slot_id AND YEAR(slot.begins)=$intendToWorkYear WHERE person_slot.person_id=E.person_id LIMIT 1) AS signed_up " .
+            'FROM (SELECT person.id as person_id, COUNT(DISTINCT(YEAR(on_duty))) AS year FROM ' .
+            "person, timesheet WHERE $statusCond person.id = person_id " .
+            "AND position_id  NOT IN ($excludePositionIds)" .
+            'GROUP BY person.id, YEAR(on_duty)) AS E ' .
+            'GROUP BY E.person_id'
+        );
+        if (empty($rows)) {
+            return [];
+        }
+
+        $personIds = array_column($rows, 'person_id');
+        $people = Person::select('id', 'callsign', 'first_name', 'last_name', 'status')
+            ->whereIn('id', $personIds)
+            ->get()
+            ->keyBy('id');
+
+        $freaks = array_map(function ($row) use ($people) {
+            $person = $people[$row->person_id];
+            return [
+                'id' => $row->person_id,
+                'callsign' => $person->callsign,
+                'status' => $person->status,
+                'first_name' => $person->first_name,
+                'last_name' => $person->last_name,
+                'years' => (int)$row->years,
+                'first_year' => (int)$row->first_year,
+                'last_year' => (int)$row->last_year,
+                'signed_up' => (int)$row->signed_up,
+            ];
+        }, $rows);
+
+        usort($freaks, function ($a, $b) {
+            if ($a['years'] == $b['years']) {
+                return strcasecmp($a['callsign'], $b['callsign']);
+            } else {
+                return $b['years'] - $a['years'];
+            }
+        });
+
+        return collect($freaks)->groupBy('years')->map(function ($people, $year) {
+            return ['years' => $year, 'people' => $people];
+        })->values();
+    }
+}

--- a/app/Lib/Reports/HoursCreditsReport.php
+++ b/app/Lib/Reports/HoursCreditsReport.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Lib\WorkSummary;
+
+use App\Models\EventDate;
+use App\Models\Person;
+use App\Models\PositionCredit;
+use App\Models\Timesheet;
+
+class HoursCreditsReport
+{
+    /**
+     * Report on hours and credits for the given year
+     *
+     * @param int $year
+     * @return array
+     */
+    public static function execute(int $year)
+    {
+        $eventDates = EventDate::findForYear($year);
+
+        if (!$eventDates) {
+            return [
+                'event_start' => '',
+                'event_end' => '',
+                'people' => []
+            ];
+        }
+
+        $people = Person::whereNotIn('status', [Person::ALPHA, Person::AUDITOR, Person::BONKED, Person::PAST_PROSPECTIVE, Person::PROSPECTIVE, Person::UBERBONKED])
+            ->whereRaw('EXISTS (SELECT 1 FROM timesheet WHERE timesheet.person_id=person.id AND YEAR(on_duty)=? LIMIT 1)', [$year])
+            ->orderBy('callsign')
+            ->get();
+
+        if ($people->isEmpty()) {
+            return [
+                'event_start' => (string)$eventDates->event_start,
+                'event_end' => (string)$eventDates->event_end,
+                'people' => []
+            ];
+        }
+
+
+        $personIds = $people->pluck('id');
+        $yearsByIds = Timesheet::yearsRangeredCountForIds($personIds);
+
+        PositionCredit::warmYearCache($year, []);
+
+        $entriesByPerson = Timesheet::whereIn('person_id', $personIds)
+            ->whereYear('on_duty', $year)
+            ->with(['position:id,count_hours'])
+            ->get()
+            ->groupBy('person_id');
+
+        $results = [];
+        $now = now()->timestamp;
+
+        foreach ($people as $person) {
+            $entries = $entriesByPerson[$person->id] ?? null;
+            if (!$entries) {
+                continue;
+            }
+
+            $summary = new WorkSummary($eventDates->event_start->timestamp, $eventDates->event_end->timestamp, $year);
+            foreach ($entries as $entry) {
+                $summary->computeTotals(
+                    $entry->position_id,
+                    $entry->on_duty->timestamp,
+                    $entry->off_duty ? $entry->off_duty->timestamp : $now,
+                    $entry->position->count_hours
+                );
+            }
+
+            $results[] = [
+                'id' => $person->id,
+                'callsign' => $person->callsign,
+                'status' => $person->status,
+                'first_name' => $person->first_name,
+                'last_name' => $person->last_name,
+                'email' => $person->email,
+                'years' => $yearsByIds[$person->id] ?? 0,
+                'pre_event_duration' => $summary->pre_event_duration,
+                'pre_event_credits' => $summary->pre_event_credits,
+                'event_duration' => $summary->event_duration,
+                'event_credits' => $summary->event_credits,
+                'post_event_duration' => $summary->post_event_duration,
+                'post_event_credits' => $summary->post_event_credits,
+                'total_duration' => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration + $summary->other_duration),
+                'total_credits' => ($summary->pre_event_credits + $summary->event_credits + $summary->post_event_credits),
+                'other_duration' => $summary->other_duration,
+                'counted_duration' => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration),
+            ];
+        }
+
+        return [
+            'event_start' => (string)$eventDates->event_start,
+            'event_end' => (string)$eventDates->event_end,
+            'people' => $results
+        ];
+    }
+}

--- a/app/Lib/Reports/PeopleWithUnconfirmedTimesheetsReport.php
+++ b/app/Lib/Reports/PeopleWithUnconfirmedTimesheetsReport.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use Illuminate\Support\Facades\DB;
+
+class PeopleWithUnconfirmedTimesheetsReport
+{
+    /*
+     * Retrieve all people who has not indicated their timesheet entries are correct.
+     */
+
+    public static function execute(int $year)
+    {
+        return DB::select(
+            "SELECT person.id, callsign, first_name, last_name, email, home_phone,
+                    (SELECT count(*) FROM timesheet
+                        WHERE person.id=timesheet.person_id
+                          AND YEAR(timesheet.on_duty)=?
+                          AND  timesheet.review_status not in ('verified', 'rejected')  ) as unverified_count
+               FROM person
+               LEFT JOIN person_event ON person_event.person_id=person.id AND person_event.year=?
+               WHERE status in ('active', 'inactive', 'inactive extension', 'retired')
+                 AND IFNULL(person_event.timesheet_confirmed, FALSE) != TRUE
+                 AND EXISTS (SELECT 1 FROM timesheet WHERE timesheet.person_id=person.id AND YEAR(timesheet.on_duty)=?)
+               ORDER BY callsign",
+            [$year, $year, $year]
+        );
+    }
+}

--- a/app/Lib/Reports/PotentialEarnedShirtsReport.php
+++ b/app/Lib/Reports/PotentialEarnedShirtsReport.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Person;
+use App\Models\Position;
+use Illuminate\Support\Facades\DB;
+
+class PotentialEarnedShirtsReport
+{
+    /*
+      * Retrieve folks who potentially earned a t-shirt
+      */
+
+    public static function execute($year, $thresholdSS, $thresholdLS)
+    {
+        $active_statuses = implode("','", Person::ACTIVE_STATUSES);
+        $report = DB::select(
+            "SELECT
+          person.id, person.callsign, person.status, person.first_name, person.mi, person.last_name,
+          eh.estimated_hours,
+          ah.actual_hours,
+          person.teeshirt_size_style, person.longsleeveshirt_size_style
+        FROM
+          person
+        LEFT JOIN (
+          SELECT
+            person_slot.person_id,
+            round(sum(((TIMESTAMPDIFF(MINUTE, slot.begins, slot.ends))/60)),2) AS estimated_hours
+          FROM
+            slot
+          JOIN
+            person_slot ON person_slot.slot_id = slot.id
+          JOIN
+            position ON position.id = slot.position_id
+          WHERE
+            YEAR(slot.begins) = ?
+            AND position.count_hours IS TRUE
+          GROUP BY person_id
+        ) eh ON eh.person_id = person.id
+
+        LEFT JOIN (
+          SELECT
+            timesheet.person_id,
+            round(sum(((TIMESTAMPDIFF(MINUTE, timesheet.on_duty, timesheet.off_duty))/60)),2) AS actual_hours
+          FROM
+            timesheet
+          JOIN
+            position ON position.id = timesheet.position_id
+          WHERE
+            YEAR(timesheet.on_duty) = ?
+            AND position.count_hours IS TRUE
+          GROUP BY person_id
+        ) ah ON ah.person_id = person.id
+
+        WHERE
+          ( actual_hours > 0 OR estimated_hours > 0 )
+          AND person.id NOT IN (
+            SELECT
+              timesheet.person_id
+            FROM
+              timesheet
+            JOIN
+              position ON position.id = timesheet.position_id
+            WHERE
+              YEAR(timesheet.on_duty) = ?
+              AND position_id = ?
+          )
+          AND person.status IN ('" . $active_statuses . "')
+        ORDER BY
+          person.callsign
+        "
+            , [$year, $year, $year, Position::ALPHA]
+        );
+
+        if (empty($report)) {
+            return [];
+        }
+
+        $report = collect($report);
+        return $report->map(function ($row) use ($thresholdSS, $thresholdLS) {
+            return [
+                'id' => $row->id,
+                'callsign' => $row->callsign,
+                'first_name' => $row->first_name,
+                'middle_initial' => $row->mi,
+                'last_name' => $row->last_name,
+                'estimated_hours' => $row->estimated_hours,
+                'actual_hours' => $row->actual_hours,
+                'longsleeveshirt_size_style' => $row->longsleeveshirt_size_style,
+                'earned_ls' => ($row->actual_hours >= $thresholdLS),
+                'teeshirt_size_style' => $row->teeshirt_size_style,
+                'earned_ss' => ($row->actual_hours >= $thresholdSS), // gonna be true always, but just in case the selection above changes.
+            ];
+        });
+    }
+}

--- a/app/Lib/Reports/RadioEligibilityReport.php
+++ b/app/Lib/Reports/RadioEligibilityReport.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Person;
+use App\Models\Position;
+use Illuminate\Support\Facades\DB;
+
+class RadioEligibilityReport
+{
+    /*
+     */
+
+    /**
+     * Radio Eligibility
+     *
+     * Takes the current year, and figures out:
+     * - How many hours worked (excluding Alpha & Training shifts) in the previous two years
+     * - If the person is signed up to work in the current year.
+     *
+     * @param int $currentYear
+     * @return array
+     */
+
+    public static function execute(int $currentYear)
+    {
+        // 2020 didn't happen, so adjust for that.
+        if ($currentYear == 2021) {
+            $lastYear = 2019;
+            $prevYear = 2018;
+        } else if ($currentYear == 2022) {
+            $lastYear = 2021;
+            $prevYear = 2019;
+        } else {
+            $lastYear = $currentYear - 1;
+            $prevYear = $currentYear - 2;
+        }
+
+        $statuses = implode("','", [ Person::ACTIVE, Person::INACTIVE, Person::INACTIVE_EXTENSION, Person::RETIRED ]);
+        $shiftLeadPosititons = implode(',', [Position::OOD, Position::DEPUTY_OOD, Position::RSC_SHIFT_LEAD, Position::RSC_SHIFT_LEAD_PRE_EVENT]);
+        $excludePositions = implode(',', [ Position::ALPHA, Position::TRAINING]);
+
+        $people = DB::select("SELECT person.id, person.callsign,
+                (SELECT SUM(TIMESTAMPDIFF(second, on_duty, off_duty))/3600.0 FROM timesheet WHERE person.id=timesheet.person_id AND year(on_duty)=$lastYear AND position_id NOT IN (1,13)) as hours_last_year,
+                (SELECT SUM(TIMESTAMPDIFF(second, on_duty, off_duty))/3600.0 FROM timesheet WHERE person.id=timesheet.person_id AND year(on_duty)=$prevYear AND position_id NOT IN (1,13)) as hours_prev_year,
+                EXISTS (SELECT 1 FROM person_position WHERE person_position.person_id=person.id AND person_position.position_id IN ($shiftLeadPosititons) LIMIT 1) AS shift_lead,
+                EXISTS (SELECT 1 FROM person_slot JOIN slot ON person_slot.slot_id=slot.id AND YEAR(slot.begins)=$currentYear AND slot.begins >= '$currentYear-08-15 00:00:00' AND position_id NOT IN ($excludePositions) WHERE person_slot.person_id=person.id LIMIT 1) as signed_up
+                FROM person WHERE person.status IN ('$statuses')
+                ORDER by callsign");
+
+        // Person must have worked in one of the previous two years, or is a shift lead
+        $people = array_values(array_filter($people, function ($p) {
+            return $p->hours_prev_year || $p->hours_last_year || $p->shift_lead;
+        }));
+
+        foreach ($people as $person) {
+            // Normalized the hours - no timesheets found in a given years will result in null
+            if (!$person->hours_last_year) {
+                $person->hours_last_year = 0.0;
+            }
+
+            $person->hours_last_year = round($person->hours_last_year, 2);
+
+            if (!$person->hours_prev_year) {
+                $person->hours_prev_year = 0.0;
+            }
+            $person->hours_prev_year = round($person->hours_prev_year, 2);
+
+            // Qualified radio hours is last year, OR the previous year if last year
+            // was less than 10 hours and the previous year was greater than last year.
+            $person->radio_hours = $person->hours_last_year;
+            if ($person->hours_last_year < 10.0 && ($person->hours_prev_year > $person->hours_last_year)) {
+                $person->radio_hours = $person->hours_prev_year;
+            }
+        }
+
+        return $people;
+    }
+}

--- a/app/Lib/Reports/SpecialTeamsWorkReport.php
+++ b/app/Lib/Reports/SpecialTeamsWorkReport.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Person;
+use Illuminate\Support\Facades\DB;
+
+class SpecialTeamsWorkReport
+{
+    /**
+     * Retrieve time worked on special teams
+     *
+     * @param array $positionIds positions to report on
+     * @param int $startYear beginning year
+     * @param int $endYear ending year
+     * @param bool $includeInactive include inactive Rangers
+     * @param bool $viewEmail include email addresses
+     * @return array
+     */
+    public static function execute(array $positionIds, int $startYear, int $endYear, bool $includeInactive, bool $viewEmail = false)
+    {
+        $sql = DB::table('person')
+            ->select(
+                'person.id as person_id',
+                DB::raw('IFNULL(person_position.position_id, timesheet.position_id) as position_id'),
+                DB::raw('YEAR(timesheet.on_duty) as year'),
+                DB::raw('SUM( TIMESTAMPDIFF( SECOND, timesheet.on_duty, timesheet.off_duty ) ) AS duration')
+            )
+            ->leftJoin('person_position', function ($q) use ($positionIds) {
+                $q->on('person_position.person_id', 'person.id');
+                $q->whereIn('person_position.position_id', $positionIds);
+            })
+            ->leftJoin('timesheet', function ($q) use ($startYear, $endYear, $positionIds) {
+                $q->on('timesheet.person_id', 'person.id');
+                $q->whereYear('on_duty', '>=', $startYear);
+                $q->whereYear('on_duty', '<=', $endYear);
+                $q->whereIn('timesheet.position_id', $positionIds);
+            })
+            ->where(function ($q) {
+                $q->whereNotNull('timesheet.id');
+                $q->orWhereNotNull('person_position.position_id');
+            })
+            ->groupBy('person.id')
+            ->groupBy(DB::raw('IFNULL(person_position.position_id, timesheet.position_id)'))
+            ->groupBy('year')
+            ->orderBy('person.id')
+            ->orderBy('year');
+
+        if (!$includeInactive) {
+            $sql->whereNotNull('timesheet.id');
+        }
+
+        $rows = $sql->get();
+        $peopleByIds = Person::whereIn('id', $rows->pluck('person_id')->unique())->get()->keyBy('id');
+        $rows = $rows->groupBy('person_id');
+
+        $results = [];
+
+        foreach ($rows as $personId => $worked) {
+            $timeByYear = $worked->keyBy('year');
+
+            $person = $peopleByIds[$personId];
+
+            $years = [];
+            $totalDuration = 0;
+            for ($year = $startYear; $year <= $endYear; $year++) {
+                $duration = (int)($timeByYear->has($year) ? $timeByYear[$year]->duration : 0);
+                $years[] = $duration;
+                $totalDuration += $duration;
+            }
+
+            $result = [
+                'id' => $person->id,
+                'callsign' => $person->callsign,
+                'first_name' => $person->first_name,
+                'last_name' => $person->last_name,
+                'status' => $person->status,
+                'years' => $years,
+                'total_duration' => $totalDuration
+            ];
+
+            if ($viewEmail) {
+                $result['email'] = $person->email;
+            }
+
+            $results[] = $result;
+        }
+
+        usort($results, function ($a, $b) {
+            return strcasecmp($a['callsign'], $b['callsign']);
+        });
+
+        return $results;
+    }
+}

--- a/app/Lib/Reports/ThankYouCardsReport.php
+++ b/app/Lib/Reports/ThankYouCardsReport.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Person;
+
+class ThankYouCardsReport
+{
+    /**
+     * Figure out who to send Thank You cards to.
+     *
+     * @param int $year
+     * @return array
+     */
+    public static function execute(int $year)
+    {
+        $people = Person::whereNotIn('status',
+                    [
+                        Person::ALPHA, Person::AUDITOR, Person::BONKED,
+                        Person::PAST_PROSPECTIVE, Person::PROSPECTIVE,
+                        Person::SUSPENDED, Person::UBERBONKED
+                    ])
+            ->whereRaw('EXISTS (SELECT 1 FROM timesheet WHERE timesheet.person_id=person.id AND YEAR(on_duty)=? LIMIT 1)', [$year])
+            ->orderBy('callsign')
+            ->get();
+
+        return $people->map(function ($row) {
+            return [
+                'id' => $row->id,
+                'first_name' => $row->first_name,
+                'last_name' => $row->last_name,
+                'callsign' => $row->callsign,
+                'status' => $row->status,
+                'email' => $row->email,
+                'bpguid' => $row->bpguid,
+                'street1' => $row->street1,
+                'street2' => $row->street2,
+                'city' => $row->city,
+                'state' => $row->state,
+                'zip' => $row->zip,
+                'country' => $row->country,
+            ];
+        })->values()->toArray();
+    }
+}

--- a/app/Lib/Reports/TimesheetByCallsignReport.php
+++ b/app/Lib/Reports/TimesheetByCallsignReport.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\PositionCredit;
+use App\Models\Timesheet;
+
+class TimesheetByCallsignReport
+{
+    /**
+     * Retrieve all timesheets for a given year, grouped by callsign
+     *
+     * @param int $year
+     * @return array
+     */
+    public static function execute(int $year)
+    {
+        $rows = Timesheet::whereYear('on_duty', $year)
+            ->with(['person:id,callsign,status', 'position:id,title,type,count_hours,active'])
+            ->orderBy('on_duty')
+            ->get();
+
+        if (!$rows->isEmpty()) {
+            PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
+        }
+
+        $personGroups = $rows->groupBy('person_id');
+
+        return $personGroups->map(function ($group) {
+            $person = $group[0]->person;
+
+            return [
+                'id' => $group[0]->person_id,
+                'callsign' => $person ? $person->callsign : "Person #" . $group[0]->person_id,
+                'status' => $person ? $person->status : 'deleted',
+
+                'total_credits' => $group->pluck('credits')->sum(),
+                'total_duration' => $group->pluck('duration')->sum(),
+                'total_appreciation_duration' => $group->filter(function ($t) {
+                    return $t->position ? $t->position->count_hours : false;
+                })->pluck('duration')->sum(),
+
+                'timesheet' => $group->map(function ($t) {
+                    return [
+                        'on_duty' => (string)$t->on_duty,
+                        'off_duty' => (string)$t->off_duty,
+                        'duration' => $t->duration,
+                        'credits' => $t->credits,
+                        'position' => [
+                            'id' => $t->position_id,
+                            'title' => $t->position ? $t->position->title : "Position #" . $t->position_id,
+                            'count_hours' => $t->position ? $t->position->count_hours : 0,
+                            'active' => $t->position ? $t->position->active : false,
+                        ]
+                    ];
+                })->values()
+            ];
+        })->sortBy('callsign', SORT_NATURAL | SORT_FLAG_CASE)->values()->toArray();
+    }
+}

--- a/app/Lib/Reports/TimesheetByPositionReport.php
+++ b/app/Lib/Reports/TimesheetByPositionReport.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Timesheet;
+
+class TimesheetByPositionReport
+{
+    /**
+     * Breakdown the positions within a given year
+     *
+     * @param int $year
+     * @param bool $includeEmail
+     * @return array
+     */
+
+    public static function execute(int $year, bool $includeEmail = false)
+    {
+        $rows = Timesheet::whereYear('on_duty', $year)
+            ->with(['person:id,callsign,status,email', 'position:id,title,active'])
+            ->orderBy('on_duty')
+            ->get()
+            ->groupBy('position_id');
+
+        $results = [];
+
+        foreach ($rows as $positionId => $entries) {
+            $position = $entries[0]->position;
+            $results[] = [
+                'id' => $position->id,
+                'title' => $position->title,
+                'active' => $position->active,
+                'timesheets' => $entries->map(function ($r) use ($includeEmail) {
+                    $person = $r->person;
+                    $personInfo = [
+                        'id' => $r->person_id,
+                        'callsign' => $person ? $person->callsign : 'Person #' . $r->person_id,
+                        'status' => $person ? $person->status : 'deleted'
+                    ];
+
+                    if ($includeEmail) {
+                        $personInfo['email'] = $person ? $person->email : '';
+                    }
+
+                    return [
+                        'id' => $r->id,
+                        'on_duty' => (string)$r->on_duty,
+                        'off_duty' => (string)$r->off_duty,
+                        'duration' => $r->duration,
+                        'person' => $personInfo
+                    ];
+                })
+            ];
+        }
+
+        usort($results, function ($a, $b) {
+            return strcasecmp($a['title'], $b['title']);
+        });
+
+        return $results;
+    }
+}

--- a/app/Lib/Reports/TimesheetSanityCheckReport.php
+++ b/app/Lib/Reports/TimesheetSanityCheckReport.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Position;
+use App\Models\Timesheet;
+
+use Illuminate\Support\Facades\DB;
+
+class TimesheetSanityCheckReport
+{
+    /*
+    * Run through the timesheets in a given year, and sniff for problematic entries.
+    */
+
+    public static function execute(int $year)
+    {
+        $withBase = ['position:id,title', 'person:id,callsign'];
+
+        $rows = Timesheet::whereYear('on_duty', $year)
+            ->whereNull('off_duty')
+            ->with($withBase)
+            ->get()
+            ->sortBy('person.callsign')
+            ->values();
+
+        $onDutyEntries = $rows->map(function ($row) {
+            return self::buildEntry($row);
+        })->values();
+
+        $rows = Timesheet::whereYear('on_duty', $year)
+            ->whereRaw('on_duty > off_duty')
+            ->whereNotNull('off_duty')
+            ->with($withBase)
+            ->get()
+            ->sortBy('person.callsign')
+            ->values();
+
+        /*
+         * Do any entries have the end time before the start time?
+         * (should never happen..famous last words)
+         */
+
+        $endBeforeStartEntries = $rows->map(function ($row) {
+            return self::buildEntry($row);
+        });
+
+        /*
+         * Look for overlapping entries
+         */
+
+        $people = Timesheet::whereYear('on_duty', $year)
+            ->whereNotNull('off_duty')
+            ->with($withBase)
+            ->orderBy('person_id')
+            ->orderBy('on_duty')
+            ->get()
+            ->groupBy('person_id');
+
+        $overlappingPeople = [];
+        foreach ($people as $personId => $entries) {
+            $overlapping = [];
+
+            $prevEntry = null;
+            foreach ($entries as $entry) {
+                if ($prevEntry) {
+                    if ($entry->on_duty->timestamp < ($prevEntry->on_duty->timestamp + $prevEntry->duration)) {
+                        $overlapping[] = [
+                            [
+                                'timesheet_id' => $prevEntry->id,
+                                'position' => [
+                                    'id' => $prevEntry->position_id,
+                                    'title' => $prevEntry->position ? $prevEntry->position->title : 'Position #' . $prevEntry->position_id,
+                                ],
+                                'on_duty' => (string)$prevEntry->on_duty,
+                                'off_duty' => (string)$prevEntry->off_duty,
+                                'duration' => $prevEntry->duration,
+                            ],
+                            [
+                                'timesheet_id' => $entry->id,
+                                'position' => [
+                                    'id' => $entry->position_id,
+                                    'title' => $entry->position ? $entry->position->title : 'Position #' . $entry->position_id,
+                                ],
+                                'on_duty' => (string)$entry->on_duty,
+                                'off_duty' => (string)$entry->off_duty,
+                                'duration' => $entry->duration,
+                            ]
+                        ];
+                    }
+                }
+                $prevEntry = $entry;
+            }
+
+            if (!empty($overlapping)) {
+                $first = $entries[0];
+                $overlappingPeople[] = [
+                    'person' => [
+                        'id' => $first->person_id,
+                        'callsign' => $first->person ? $first->person->callsign : 'Person #' . $first->person_id
+                    ],
+                    'entries' => $overlapping
+                ];
+            }
+        }
+
+        usort($overlappingPeople, function ($a, $b) {
+            return strcasecmp($a['person']['callsign'], $b['person']['callsign']);
+        });
+
+        $minHour = 24;
+        foreach (Position::PROBLEM_HOURS as $positionId => $hours) {
+            if ($hours < $minHour) {
+                $minHour = $hours;
+            }
+        }
+
+        $now = now();
+        $rows = Timesheet:: select('timesheet.*', DB::raw("TIMESTAMPDIFF(SECOND, on_duty, IFNULL(off_duty,'$now')) as duration"))
+            ->whereYear('on_duty', $year)
+            ->whereRaw("TIMESTAMPDIFF(HOUR, on_duty, IFNULL(off_duty,'$now')) >= $minHour")
+            ->with($withBase)
+            ->orderBy('duration', 'desc')
+            ->get();
+
+        /*
+         * Look for entries that may be too long. (i.e. a person forgot to signout in a timely manner.)
+         */
+
+        $tooLongEntries = $rows->filter(function ($row) {
+            if (!isset(Position::PROBLEM_HOURS[$row->position_id])) {
+                return true;
+            }
+
+            return Position::PROBLEM_HOURS[$row->position_id] < ($row->duration / 3600.0);
+        })->values()->map(function ($row) {
+            return self::buildEntry($row);
+        })->toArray();
+
+        return [
+            'on_duty' => $onDutyEntries,
+            'end_before_start' => $endBeforeStartEntries,
+            'overlapping' => $overlappingPeople,
+            'too_long' => $tooLongEntries
+        ];
+    }
+
+    public static function buildEntry($row)
+    {
+        return [
+            'person' => [
+                'id' => $row->person_id,
+                'callsign' => $row->person ? $row->person->callsign : 'Person #' . $row->person_id,
+            ],
+            'callsign' => $row->person ? $row->person->callsign : 'Person #' . $row->person_id,
+            'on_duty' => (string)$row->on_duty,
+            'off_duty' => (string)$row->off_duty,
+            'duration' => $row->duration,
+            'credits' => $row->credits,
+            'position' => [
+                'id' => $row->position_id,
+                'title' => $row->position ? $row->position->title : 'Position #' . $row->position_id,
+            ]
+        ];
+    }
+}

--- a/app/Lib/Reports/TimesheetTotalsReport.php
+++ b/app/Lib/Reports/TimesheetTotalsReport.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\PositionCredit;
+use App\Models\Timesheet;
+
+class TimesheetTotalsReport
+{
+    /*
+      */
+
+    /**
+     * Find everyone who worked in a given year, and summarize the positions (total time & credits)
+     *
+     * @param int $year
+     * @return array
+     */
+
+    public static function execute(int $year)
+    {
+        $rows = Timesheet::whereYear('on_duty', $year)
+            ->join('position', 'position.id', 'timesheet.position_id')
+            ->where('position.count_hours', true)
+            ->with(['person:id,callsign,status', 'position:id,title,active'])
+            ->orderBy('timesheet.person_id')
+            ->get();
+
+        if (!$rows->isEmpty()) {
+            PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
+        }
+
+        $timesheetByPerson = $rows->groupBy('person_id');
+
+        $results = [];
+
+        foreach ($timesheetByPerson as $personId => $entries) {
+            $person = $entries[0]->person;
+
+            $group = $entries->groupBy('position_id');
+            $positions = [];
+            $totalDuration = 0;
+            $totalCredits = 0.0;
+
+            // Summarize the positions worked
+            foreach ($group as $positionId => $posEntries) {
+                $position = $posEntries[0];
+                $duration = $posEntries->pluck('duration')->sum();
+                $totalDuration += $duration;
+                $credits = $posEntries->pluck('credits')->sum();
+                $totalCredits += $credits;
+                $positions[] = [
+                    'id' => $positionId,
+                    'title' => $position->title,
+                    'active' => $position->active,
+                    'duration' => $duration,
+                    'credits' => $credits,
+                ];
+            }
+
+            // Sort by position title
+            usort($positions, function ($a, $b) {
+                return strcasecmp($a['title'], $b['title']);
+            });
+
+            $results[] = [
+                'id' => $personId,
+                'callsign' => $person ? $person->callsign : 'Person #' . $personId,
+                'status' => $person->status,
+                'positions' => $positions,
+                'total_duration' => $totalDuration,
+                'total_credits' => $totalCredits,
+            ];
+        }
+
+        usort($results, function ($a, $b) {
+            return strcasecmp($a['callsign'], $b['callsign']);
+        });
+
+        return $results;
+    }
+}

--- a/app/Lib/Reports/TimesheetWorkSummaryReport.php
+++ b/app/Lib/Reports/TimesheetWorkSummaryReport.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Lib\WorkSummary;
+
+use App\Models\EventDate;
+use App\Models\PositionCredit;
+use App\Models\Timesheet;
+
+class TimesheetWorkSummaryReport
+{
+    /**
+     * Summarize a person's timesheet into pre-event, event week, and post event hours and credits.
+     *
+     * @param int $personId
+     * @param int $year
+     * @return array
+     */
+
+    public static function execute(int $personId, int $year) : array
+    {
+        $rows = Timesheet::findForQuery(['person_id' => $personId, 'year' => $year]);
+
+        $eventDates = EventDate::findForYear($year);
+
+        if (!$rows->isEmpty()) {
+            PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
+        }
+
+        if (!$eventDates) {
+            // No event dates - return everything as happening during the event
+            $time = $rows->pluck('duration')->sum();
+            $credits = $rows->pluck('credits')->sum();
+
+            return [
+                'pre_event_duration' => 0,
+                'pre_event_credits' => 0,
+                'event_duration' => $time,
+                'event_credits' => $credits,
+                'post_event_duration' => 0,
+                'post_event_credits' => 0,
+                'other_duration' => 0,
+                'counted_duration' => 0,
+                'total_duration' => $time,
+                'total_credits' => $credits,
+                'no_event_dates' => true,
+            ];
+        }
+
+        $summary = new WorkSummary($eventDates->event_start->timestamp, $eventDates->event_end->timestamp, $year);
+
+        foreach ($rows as $row) {
+            $summary->computeTotals(
+                $row->position_id,
+                $row->on_duty->timestamp,
+                ($row->off_duty ?? now())->timestamp,
+                $row->position->count_hours
+            );
+        }
+
+        return [
+            'pre_event_duration' => $summary->pre_event_duration,
+            'pre_event_credits' => $summary->pre_event_credits,
+            'event_duration' => $summary->event_duration,
+            'event_credits' => $summary->event_credits,
+            'post_event_duration' => $summary->post_event_duration,
+            'post_event_credits' => $summary->post_event_credits,
+            'total_duration' => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration + $summary->other_duration),
+            'total_credits' => ($summary->pre_event_credits + $summary->event_credits + $summary->post_event_credits),
+            'other_duration' => $summary->other_duration,
+            'counted_duration' => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration),
+            'event_start' => (string)$eventDates->event_start,
+            'event_end' => (string)$eventDates->event_end,
+        ];
+    }
+}

--- a/app/Lib/Reports/TopHourEarnersReport.php
+++ b/app/Lib/Reports/TopHourEarnersReport.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Person;
+use App\Models\Timesheet;
+use Illuminate\Support\Collection;
+
+class TopHourEarnersReport
+{
+    /**
+     * Retrieve the top N people worked within a given year range.
+     *
+     * @param int $startYear
+     * @param int $endYear
+     * @param int $topLimit the top N people
+     * @return Collection
+     */
+
+    public static function execute(int $startYear, int $endYear, int $topLimit)
+    {
+        // Find all eligible candidates
+        $people = Person::select('id', 'callsign', 'status', 'email')
+            ->whereIn('status', [Person::ACTIVE, Person::INACTIVE])
+            ->get();
+
+        $candidates = collect([]);
+
+        foreach ($people as $person) {
+            for ($year = $endYear; $year >= $startYear; $year = $year - 1) {
+                // Walk backward thru time and find the most recent year worked.
+                $seconds = Timesheet::join('position', 'timesheet.position_id', 'position.id')
+                    ->where('person_id', $person->id)
+                    ->whereYear('on_duty', $year)
+                    ->where('position.count_hours', true)
+                    ->get()
+                    ->sum('duration');
+                if ($seconds > 0) {
+                    // Hey found a candidate
+                    $candidates[] = (object)[
+                        'person' => $person,
+                        'seconds' => $seconds,
+                        'year' => $year
+                    ];
+                    break;
+                }
+            }
+        }
+
+        $candidates = $candidates->sortByDesc('seconds')->splice(0, $topLimit);
+
+        return $candidates->map(function ($c) {
+            $person = $c->person;
+            return [
+                'id' => $person->id,
+                'callsign' => $person->callsign,
+                'status' => $person->status,
+                'email' => $person->email,
+                'hours' => round($c->seconds / 3600.0, 2),
+                'year' => $c->year,
+            ];
+        });
+    }
+}

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -2,17 +2,18 @@
 
 namespace App\Models;
 
+use App\Models\Position;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 use Carbon\Carbon;
-use App\Helpers\SqlHelper;
 
 use App\Lib\WorkSummary;
 
 use App\Models\ApiModel;
 use App\Models\Person;
-use App\Models\Position;
 use App\Models\PositionCredit;
 use App\Models\Slot;
 
@@ -25,32 +26,36 @@ class Timesheet extends ApiModel
     const STATUS_PENDING = 'pending';
     const STATUS_APPROVED = 'approved';
     const STATUS_REJECTED = 'rejected';
+    const STATUS_VERIFIED = 'verified';
+    const STATUS_UNVERIFIED = 'unverified';
 
     const EXCLUDE_POSITIONS_FOR_YEARS = [
-      Position::ALPHA,
-      Position::TRAINING,
+        Position::ALPHA,
+        Position::TRAINING,
     ];
 
     protected $fillable = [
-        'notes',
         'off_duty',
         'on_duty',
         'person_id',
         'position_id',
         'review_status',
         'reviewed_at',
-        'reviewer_notes',
         'reviewer_person_id',
         'timesheet_confirmed_at',
         'timesheet_confirmed',
-        'verified',
-        'slot_id'
+        'slot_id',
+
+        'additional_notes',  // pseudo field -- appends to notes
+        'additional_reviewer_notes'  // pseudo field -- appends to reviewer_notes
+
+        // no longer directly settable: notes, reviewer_notes
     ];
 
     protected $rules = [
         'person_id' => 'required|integer',
         'position_id' => 'required|integer',
-        'off_duty'    => 'nullable|sometimes|after_or_equal:on_duty'
+        'off_duty' => 'nullable|sometimes|after_or_equal:on_duty'
     ];
 
     protected $appends = [
@@ -66,12 +71,10 @@ class Timesheet extends ApiModel
         'verified_at',
     ];
 
-    protected $casts = [
-        'verified' => 'boolean',
-        'is_incorrect' => 'boolean'
-    ];
+    const RELATIONSHIPS = ['reviewer_person:id,callsign', 'verified_person:id,callsign', 'position:id,title,count_hours'];
 
-    const RELATIONSHIPS = [ 'reviewer_person:id,callsign', 'verified_person:id,callsign', 'position:id,title,count_hours' ];
+    public $_additional_notes;
+    public $_additional_reviewer_notes;
 
     public function person()
     {
@@ -103,27 +106,10 @@ class Timesheet extends ApiModel
         return $this->load(self::RELATIONSHIPS);
     }
 
-    public static function find($id)
-    {
-        return self::selectBase()->where('id', $id)->first();
-    }
-
-    public static function findOrFail($id)
-    {
-        return self::selectBase()->where('id', $id)->firstOrFail();
-    }
-
-    public static function selectBase()
-    {
-        $now = (string) now();
-        return self::select('timesheet.*', DB::raw("TIMESTAMPDIFF(SECOND, on_duty, IFNULL(off_duty,'$now')) as duration"))
-            ->with(self::RELATIONSHIPS);
-    }
-
     public static function findForQuery($query)
     {
         $year = 0;
-        $sql = self::selectBase();
+        $sql = self::query();
 
         $year = $query['year'] ?? null;
         $personId = $query['person_id'] ?? null;
@@ -144,19 +130,21 @@ class Timesheet extends ApiModel
         if ($onDuty) {
             $sql->whereNull('off_duty');
             if ($overHours) {
-                $sql->whereRaw("TIMESTAMPDIFF(HOUR, on_duty, ?) >= ?", [ now(), $overHours ]);
+                $sql->whereRaw("TIMESTAMPDIFF(HOUR, on_duty, ?) >= ?", [now(), $overHours]);
             }
         }
 
         if ($dutyDate) {
             $sql->where('on_duty', '<=', $dutyDate);
-            $sql->whereRaw('IFNULL(off_duty, ?) >= ?', [ now(), $dutyDate ]);
+            $sql->whereRaw('IFNULL(off_duty, ?) >= ?', [now(), $dutyDate]);
         }
+
+        $sql->with(self::RELATIONSHIPS);
 
         $rows = $sql->orderBy('on_duty', 'asc')->get();
 
         if (!$personId) {
-            $rows = $rows->sortBy('person.callsign', SORT_NATURAL|SORT_FLAG_CASE)->values();
+            $rows = $rows->sortBy('person.callsign', SORT_NATURAL | SORT_FLAG_CASE)->values();
         }
 
         return $rows;
@@ -165,10 +153,10 @@ class Timesheet extends ApiModel
     public static function findPersonOnDuty($personId)
     {
         return self::where('person_id', $personId)
-                ->whereYear('on_duty', current_year())
-                ->whereNull('off_duty')
-                ->with([ 'position:id,title,type' ])
-                ->first();
+            ->whereYear('on_duty', current_year())
+            ->whereNull('off_duty')
+            ->with(['position:id,title,type'])
+            ->first();
     }
 
     /*
@@ -204,36 +192,37 @@ class Timesheet extends ApiModel
     {
         return self::where('person_id', $personId)
             ->where(function ($sql) use ($onduty, $offduty) {
-                $sql->whereBetween('on_duty', [ $onduty, $offduty ]);
-                $sql->orWhereBetween('off_duty', [ $onduty, $offduty ]);
-                $sql->orWhereRaw('? BETWEEN on_duty AND off_duty', [ $onduty ]);
-                $sql->orWhereRaw('? BETWEEN on_duty AND off_duty', [ $offduty ]);
+                $sql->whereBetween('on_duty', [$onduty, $offduty]);
+                $sql->orWhereBetween('off_duty', [$onduty, $offduty]);
+                $sql->orWhereRaw('? BETWEEN on_duty AND off_duty', [$onduty]);
+                $sql->orWhereRaw('? BETWEEN on_duty AND off_duty', [$offduty]);
             })->first();
     }
 
     public static function findShiftWithinMinutes($personId, $startTime, $withinMinutes)
     {
-        return self::with([ 'position:id,title' ])
+        return self::with(['position:id,title'])
             ->where('person_id', $personId)
             ->whereRaw(
                 'on_duty BETWEEN DATE_SUB(?, INTERVAL ? MINUTE) AND DATE_ADD(?, INTERVAL ? MINUTE)',
-                [ $startTime, $withinMinutes, $startTime, $withinMinutes]
+                [$startTime, $withinMinutes, $startTime, $withinMinutes]
             )->first();
     }
 
-
-    /*
+    /**
      * Find the years a person was on working
      *
-     * @param integer $everything if true include all scheduled years as well
+     * @param int $personId
+     * @param bool $everything if true include all scheduled years as well
+     * @return array
      */
 
-    public static function years($personId, $everything=false)
+    public static function years(int $personId, bool $everything = false)
     {
         $query = self::selectRaw("YEAR(on_duty) as year")
-                ->where('person_id', $personId)
-                ->groupBy("year")
-                ->orderBy("year", "asc");
+            ->where('person_id', $personId)
+            ->groupBy("year")
+            ->orderBy("year", "asc");
 
         if (!$everything) {
             $query = $query->whereNotIn("position_id", self::EXCLUDE_POSITIONS_FOR_YEARS);
@@ -247,13 +236,13 @@ class Timesheet extends ApiModel
 
         // Look at the sign up schedule as well
         $signUpYears = DB::table('person_slot')
-                ->selectRaw("YEAR(begins) as year")
-                ->join('slot', 'slot.id', '=', 'person_slot.slot_id')
-                ->where('person_id', $personId)
-                ->groupBy('year')
-                ->orderBy('year')
-                ->pluck('year')
-                ->toArray();
+            ->selectRaw("YEAR(begins) as year")
+            ->join('slot', 'slot.id', '=', 'person_slot.slot_id')
+            ->where('person_id', $personId)
+            ->groupBy('year')
+            ->orderBy('year')
+            ->pluck('year')
+            ->toArray();
 
         $years = array_unique(array_merge($years, $signUpYears));
         sort($years, SORT_NUMERIC);
@@ -265,14 +254,14 @@ class Timesheet extends ApiModel
      * Find the latest timesheet entry for a person in a position and given year
      */
 
-     public static function findLatestForPersonPosition($personId, $positionId, $year)
-     {
-         return self::where('person_id', $personId)
+    public static function findLatestForPersonPosition($personId, $positionId, $year)
+    {
+        return self::where('person_id', $personId)
             ->where('position_id', $positionId)
             ->whereYear('on_duty', $year)
             ->orderBy('on_duty', 'desc')
             ->first();
-     }
+    }
 
     /*
      * Find out how many years list of people have rangered.
@@ -298,8 +287,8 @@ class Timesheet extends ApiModel
             return [];
         }
 
-        $rows = DB::select("SELECT person_id, COUNT(year) as years FROM (SELECT YEAR(on_duty) as year, person_id FROM timesheet WHERE person_id in (".implode(',', $ids).") AND  position_id not in (1, 13, 29, 30) GROUP BY person_id,year ORDER BY year) as rangers group by person_id");
-
+        $excludePositions = implode(',', [Position::ALPHA, Position::TRAINING]);
+        $rows = DB::select("SELECT person_id, COUNT(year) as years FROM (SELECT YEAR(on_duty) as year, person_id FROM timesheet WHERE person_id in (" . implode(',', $ids) . ") AND  position_id not in ($excludePositions) GROUP BY person_id,year ORDER BY year) as rangers group by person_id");
 
         $people = [];
         foreach ($rows as $row) {
@@ -316,9 +305,9 @@ class Timesheet extends ApiModel
     public static function hasAlphaEntry($personId)
     {
         return Timesheet::where('person_id', $personId)
-                ->whereYear('on_duty', current_year())
-                ->where('position_id', Position::ALPHA)
-                ->exists();
+            ->whereYear('on_duty', current_year())
+            ->where('position_id', Position::ALPHA)
+            ->exists();
     }
 
     /**
@@ -332,47 +321,23 @@ class Timesheet extends ApiModel
     public static function retrieveAllForPositionIds(array $personIds, int $positionId)
     {
         return self::whereIn('person_id', $personIds)
-                ->where('position_id', $positionId)
-                ->orderBy('on_duty')
-                ->get()
-                ->groupBy([
-                    'person_id',
-                    function ($row) {
-                        return $row->on_duty->year;
-                    }
-                ]);
-    }
-
-    /*
-     * Retrieve all corrections requests for a given year
-     */
-
-    public static function retrieveCorrectionRequestsForYear($year)
-    {
-        // Find all the unverified timesheets
-        $rows = self::with([ 'person:id,callsign', 'position:id,title'])
-            ->whereYear('on_duty', $year)
-            ->where('verified', false)
-            ->where('notes', '!=', '')
-            ->where('review_status', 'pending')
-            ->whereNotNull('off_duty')
+            ->where('position_id', $positionId)
             ->orderBy('on_duty')
-            ->get();
-
-        // Warm up the position credit cache so the database is not being slammed.
-        PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
-
-        return $rows->sortBy(function ($p) {
-            return $p->person->callsign;
-        }, SORT_NATURAL|SORT_FLAG_CASE)->values();
+            ->get()
+            ->groupBy([
+                'person_id',
+                function ($row) {
+                    return $row->on_duty->year;
+                }
+            ]);
     }
 
-    public static function countUnverifiedForPersonYear($personId, $year)
+    public static function countUnverifiedForPersonYear(int $personId, int $year)
     {
         // Find all the unverified timesheets
-        return self::where('person_id', $personId)
+        return Timesheet::where('person_id', $personId)
             ->whereYear('on_duty', $year)
-            ->where('verified', false)
+            ->whereIn('review_status', [Timesheet::STATUS_UNVERIFIED, Timesheet::STATUS_APPROVED])
             ->whereNotNull('off_duty')
             ->count();
     }
@@ -527,243 +492,6 @@ class Timesheet extends ApiModel
     }
 
     /*
-     * Build a Freanking Years report - how long a person has rangered, the first year rangered, the last year to ranger,
-     * and if the person intends to ranger in the intended year (usually the current year)
-     */
-
-    public static function retrieveFreakingYears($showAll=false, $intendToWorkYear)
-    {
-        $excludePositionIds = implode(',', [ Position::ALPHA, Position::HQ_RUNNER ]);
-        $statusCond = $showAll ? '' : 'person.status="active" AND ';
-
-        $rows = DB::select(
-                'SELECT E.person_id, sum(year) AS years, '.
-                "(SELECT YEAR(on_duty) FROM timesheet ts WHERE ts.person_id=E.person_id AND YEAR(ts.on_duty) > 0 GROUP BY YEAR(ts.on_duty) ORDER BY YEAR(ts.on_duty) ASC LIMIT 1) AS first_year, ".
-                "(SELECT YEAR(on_duty) FROM timesheet ts WHERE ts.person_id=E.person_id AND YEAR(ts.on_duty) > 0 GROUP BY YEAR(ts.on_duty) ORDER BY YEAR(ts.on_duty) DESC LIMIT 1) AS last_year, ".
-                "EXISTS (SELECT 1 FROM person_slot JOIN slot ON slot.id=person_slot.slot_id AND YEAR(slot.begins)=$intendToWorkYear WHERE person_slot.person_id=E.person_id LIMIT 1) AS signed_up ".
-               'FROM (SELECT person.id as person_id, COUNT(DISTINCT(YEAR(on_duty))) AS year FROM ' .
-               "person, timesheet WHERE $statusCond person.id = person_id ".
-               "AND position_id  NOT IN ($excludePositionIds)".
-               'GROUP BY person.id, YEAR(on_duty)) AS E ' .
-               'GROUP BY E.person_id'
-        );
-        if (empty($rows)) {
-            return [];
-        }
-
-        $personIds = array_column($rows, 'person_id');
-        $people = Person::select('id', 'callsign', 'first_name', 'last_name', 'status')
-                ->whereIn('id', $personIds)
-                ->get()
-                ->keyBy('id');
-
-        $freaks = array_map(function ($row) use ($people) {
-            $person = $people[$row->person_id];
-            return [
-                'id'         => $row->person_id,
-                'callsign'   => $person->callsign,
-                'status'     => $person->status,
-                'first_name' => $person->first_name,
-                'last_name'  => $person->last_name,
-                'years'      => (int) $row->years,
-                'first_year' => (int) $row->first_year,
-                'last_year'  => (int) $row->last_year,
-                'signed_up'  => (int) $row->signed_up,
-            ];
-        }, $rows);
-
-        usort($freaks, function ($a, $b) {
-            if ($a['years'] == $b['years']) {
-                return strcasecmp($a['callsign'], $b['callsign']);
-            } else {
-                return $b['years'] - $a['years'];
-            }
-        });
-
-        return collect($freaks)->groupBy('years')->map(function ($people, $year) {
-            return [ 'years' => $year, 'people' => $people ];
-        })->values();
-    }
-
-    /**
-     *
-     * Retrieve the top N hours worked within a given year range.
-     */
-
-    public static function retrieveTopHourEarners($startYear, $endYear, $topLimit)
-    {
-        // Find all eligible candidates
-        $people = Person::select('id', 'callsign', 'status', 'email')
-                    ->whereIn('status', [ Person::ACTIVE, Person::INACTIVE ])
-                    ->get();
-
-        $cadidates = collect([]);
-
-        foreach ($people as $person) {
-            for ($year = $endYear; $year >= $startYear; $year = $year - 1) {
-                // Walk backward thru time and find the most recent year worked.
-                $seconds = self::join('position', 'timesheet.position_id', 'position.id')
-                        ->where('person_id', $person->id)
-                        ->whereYear('on_duty', $year)
-                        ->where('position.count_hours', true)
-                        ->get()
-                        ->sum('duration');
-                if ($seconds > 0) {
-                    // Hey found a candidate
-                    $cadidates[] = (object) [
-                        'person'    => $person,
-                        'seconds'   => $seconds,
-                        'year'      => $year
-                    ];
-                    break;
-                }
-            }
-        }
-
-        $cadidates = $cadidates->sortByDesc('seconds')->splice(0, $topLimit);
-
-        return $cadidates->map(function ($c) {
-            $person = $c->person;
-            return [
-                'id'       => $person->id,
-                'callsign' => $person->callsign,
-                'status'   => $person->status,
-                'email'    => $person->email,
-                'hours'    => round($c->seconds / 3600.0, 2),
-                'year'     => $c->year,
-            ];
-        });
-    }
-
-    /*
-     * Radio Eligibility
-     *
-      * Takes the current year, and figures out:
-      * - How many hours worked (excluding Alpha & Training shifts) in the previous two years
-      * - If the person is signed up to work in the current year.
-     */
-    public static function retrieveRadioEligilibity($currentYear)
-    {
-        $lastYear = $currentYear-1;
-        $prevYear = $currentYear-2;
-
-        $people = DB::select("SELECT person.id, person.callsign,
-                (SELECT SUM(TIMESTAMPDIFF(second, on_duty, off_duty))/3600.0 FROM timesheet WHERE person.id=timesheet.person_id AND year(on_duty)=$lastYear AND position_id NOT IN (1,13)) as hours_last_year,
-                (SELECT SUM(TIMESTAMPDIFF(second, on_duty, off_duty))/3600.0 FROM timesheet WHERE person.id=timesheet.person_id AND year(on_duty)=$prevYear AND position_id NOT IN (1,13)) as hours_prev_year,
-                EXISTS (SELECT 1 FROM person_position WHERE person_position.person_id=person.id AND person_position.position_id IN (10,12) LIMIT 1) AS shift_lead,
-                EXISTS (SELECT 1 FROM person_slot JOIN slot ON person_slot.slot_id=slot.id AND YEAR(slot.begins)=$currentYear AND slot.begins >= '$currentYear-08-15 00:00:00' AND position_id NOT IN (1,13) WHERE person_slot.person_id=person.id LIMIT 1) as signed_up
-                FROM person WHERE person.status IN ('active', 'inactive', 'inactive extension', 'retired')
-                ORDER by callsign");
-
-        // Person must have worked in one of the previous two years, or is a shift lead
-        $people = array_values(array_filter($people, function ($p) {
-            return $p->hours_prev_year || $p->hours_last_year || $p->shift_lead;
-        }));
-
-        foreach ($people as $person) {
-            // Normalized the hours - no timesheets found in a given years will result in null
-            if (!$person->hours_last_year) {
-                $person->hours_last_year = 0.0;
-            }
-            $person->hours_last_year = round($person->hours_last_year, 2);
-
-            if (!$person->hours_prev_year) {
-                $person->hours_prev_year = 0.0;
-            }
-            $person->hours_prev_year = round($person->hours_prev_year, 2);
-
-            // Qualified radio hours is last year, OR the previous year if last year
-            // was less than 10 hours and the previous year was greater than last year.
-            $person->radio_hours = $person->hours_last_year;
-            if ($person->hours_last_year < 10.0 && ($person->hours_prev_year > $person->hours_last_year)) {
-                $person->radio_hours = $person->hours_prev_year;
-            }
-        }
-
-        return $people;
-    }
-
-    /*
-     * Retrieve time worked on special teams
-     */
-
-    public static function retrieveSpecialTeamsWork($positionIds, $startYear, $endYear, $includeInactive, $viewEmail = false)
-    {
-        $sql = DB::table('person')
-            ->select(
-                    'person.id as person_id',
-                    DB::raw('IFNULL(person_position.position_id, timesheet.position_id) as position_id'),
-                    DB::raw('YEAR(timesheet.on_duty) as year'),
-                    DB::raw('SUM( TIMESTAMPDIFF( SECOND, timesheet.on_duty, timesheet.off_duty ) ) AS duration')
-                )
-            ->leftJoin('person_position', function ($q) use ($positionIds) {
-                $q->on('person_position.person_id', 'person.id');
-                $q->whereIn('person_position.position_id', $positionIds);
-            })
-            ->leftJoin('timesheet', function ($q) use ($startYear, $endYear, $positionIds) {
-                $q->on('timesheet.person_id', 'person.id');
-                $q->whereYear('on_duty', '>=', $startYear);
-                $q->whereYear('on_duty', '<=', $endYear);
-                $q->whereIn('timesheet.position_id', $positionIds);
-            })
-            ->where(function ($q) {
-                $q->whereNotNull('timesheet.id');
-                $q->orWhereNotNull('person_position.position_id');
-            })
-            ->groupBy('person.id')
-            ->groupBy(DB::raw('IFNULL(person_position.position_id, timesheet.position_id)'))
-            ->groupBy('year')
-            ->orderBy('person.id')
-            ->orderBy('year');
-
-        if (!$includeInactive) {
-            $sql->whereNotNull('timesheet.id');
-        }
-
-        $rows = $sql->get();
-        $peopleByIds = Person::whereIn('id', $rows->pluck('person_id')->unique())->get()->keyBy('id');
-        $rows = $rows->groupBy('person_id');
-
-        $results = [];
-
-        foreach ($rows as $personId => $worked) {
-            $timeByYear = $worked->keyBy('year');
-
-            $person = $peopleByIds[$personId];
-
-            $years = [];
-            $totalDuration = 0;
-            for ($year = $startYear; $year <= $endYear; $year++) {
-                $duration = (int)($timeByYear->has($year) ? $timeByYear[$year]->duration : 0);
-                $years[] = $duration;
-                $totalDuration += $duration;
-            }
-
-            $result = [
-                'id'         => $person->id,
-                'callsign'   => $person->callsign,
-                'first_name' => $person->first_name,
-                'last_name'  => $person->last_name,
-                'status'     => $person->status,
-                'years'      => $years,
-                'total_duration' => $totalDuration
-            ];
-
-            if ($viewEmail) {
-                $result['email'] = $person->email;
-            }
-
-            $results[] = $result;
-        }
-
-        usort($results, function ($a, $b) {
-            return strcasecmp($a['callsign'], $b['callsign']);
-        });
-
-        return $results;
-    }
-
-    /*
      * Retrieve all timesheets for a given year, grouped by callsign
      */
 
@@ -864,13 +592,13 @@ class Timesheet extends ApiModel
     }
 
     /*
-     * Determine if the person has worked one or more positions in the last X years
-     */
+    * Determine if the person has worked one or more positions in the last X years
+    */
 
     public static function didPersonWorkPosition($personId, $years, $positionIds)
     {
         if (!is_array($positionIds)) {
-            $positionIds = [ $positionIds ];
+            $positionIds = [$positionIds];
         }
 
         $cutoff = current_year() - $years;
@@ -889,23 +617,23 @@ class Timesheet extends ApiModel
      * @param int $year
      * @return bool
      */
-    public static function didPersonWork(int $personId, int $year) : bool
+    public static function didPersonWork(int $personId, int $year): bool
     {
         return DB::table('timesheet')
             ->where('person_id', $personId)
             ->whereYear('on_duty', $year)
-            ->whereNotIn('position_id', [ Position::TRAINING, Position::ALPHA])
+            ->whereNotIn('position_id', [Position::TRAINING, Position::ALPHA])
             ->limit(1)
             ->exists();
     }
 
     /*
-     * Calcuate how many credits earned for a year
+     * Calculate how many credits earned for a year
      */
 
     public static function earnedCreditsForYear($personId, $year)
     {
-        $rows = Timesheet::findForQuery([ 'person_id' => $personId, 'year' => $year]);
+        $rows = Timesheet::findForQuery(['person_id' => $personId, 'year' => $year]);
         if (!$rows->isEmpty()) {
             PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
         }
@@ -913,430 +641,18 @@ class Timesheet extends ApiModel
         return $rows->pluck('credits')->sum();
     }
 
-    public static function workSummaryForPersonYear($personId, $year)
-    {
-        $rows = Timesheet::findForQuery([ 'person_id' => $personId, 'year' => $year]);
-
-        $eventDates = EventDate::findForYear($year);
-
-        if (!$rows->isEmpty()) {
-            PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
-        }
-
-        if (!$eventDates) {
-            // No event dates - return everything as happening during the event
-            $time = $rows->pluck('duration')->sum();
-            $credits = $rows->pluck('credits')->sum();
-
-            return [
-                'pre_event_duration'  => 0,
-                'pre_event_credits'   => 0,
-                'event_duration'      => $time,
-                'event_credits'       => $credits,
-                'post_event_duration' => 0,
-                'post_event_credits'  => 0,
-                'other_duration'      => 0,
-                'counted_duration'    => 0,
-                'total_duration'      => $time,
-                'total_credits'       => $credits,
-                'no_event_dates'      => true,
-            ];
-        }
-
-        $summary = new WorkSummary($eventDates->event_start->timestamp, $eventDates->event_end->timestamp, $year);
-
-        foreach ($rows as $row) {
-            $summary->computeTotals(
-                    $row->position_id,
-                    $row->on_duty->timestamp,
-                    ($row->off_duty ?? now())->timestamp,
-                    $row->position->count_hours
-                );
-        }
-
-        return [
-            'pre_event_duration'  => $summary->pre_event_duration,
-            'pre_event_credits'   => $summary->pre_event_credits,
-            'event_duration'      => $summary->event_duration,
-            'event_credits'       => $summary->event_credits,
-            'post_event_duration' => $summary->post_event_duration,
-            'post_event_credits'  => $summary->post_event_credits,
-            'total_duration'      => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration + $summary->other_duration),
-            'total_credits'       => ($summary->pre_event_credits + $summary->event_credits + $summary->post_event_credits),
-            'other_duration'      => $summary->other_duration,
-            'counted_duration'    => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration),
-            'event_start'         => (string) $eventDates->event_start,
-            'event_end'           => (string) $eventDates->event_end,
-        ];
-    }
-
-    public static function retrieveHoursCredits($year)
-    {
-        $eventDates = EventDate::findForYear($year);
-
-        if (!$eventDates) {
-            return [
-                'event_start' => '',
-                'event_end'   => '',
-                'people'      => []
-            ];
-        }
-
-        $people = Person::whereNotIn('status', [ 'alpha', 'auditor', 'bonked', 'past prospective', 'prospective' ])
-            ->whereRaw('EXISTS (SELECT 1 FROM timesheet WHERE timesheet.person_id=person.id AND YEAR(on_duty)=? LIMIT 1)', [ $year ])
-            ->orderBy('callsign')
-            ->get();
-
-        if ($people->isEmpty()) {
-            return [
-                'event_start' => (string) $eventDates->event_start,
-                'event_end'   => (string) $eventDates->event_end,
-                'people'      => []
-            ];
-        }
-
-
-        $personIds = $people->pluck('id');
-        $yearsByIds = self::yearsRangeredCountForIds($personIds);
-
-        PositionCredit::warmYearCache($year, []);
-
-        $entriesByPerson = self::whereIn('person_id', $personIds)
-            ->whereYear('on_duty', $year)
-            ->with([ 'position:id,count_hours' ])
-            ->get()
-            ->groupBy('person_id');
-
-        $results = [];
-        $now = now()->timestamp;
-
-        foreach ($people as $person) {
-            $entries = $entriesByPerson[$person->id] ?? null;
-            if (!$entries) {
-                continue;
-            }
-
-            $summary = new WorkSummary($eventDates->event_start->timestamp, $eventDates->event_end->timestamp, $year);
-            foreach ($entries as $entry) {
-                $summary->computeTotals(
-                        $entry->position_id,
-                         $entry->on_duty->timestamp,
-                         $entry->off_duty ? $entry->off_duty->timestamp :  $now,
-                         $entry->position->count_hours
-                );
-            }
-
-            $results[] = [
-                'id'                  => $person->id,
-                'callsign'            => $person->callsign,
-                'status'              => $person->status,
-                'first_name'          => $person->first_name,
-                'last_name'           => $person->last_name,
-                'email'               => $person->email,
-                'years'               => $yearsByIds[$person->id] ?? 0,
-                'pre_event_duration'  => $summary->pre_event_duration,
-                'pre_event_credits'   => $summary->pre_event_credits,
-                'event_duration'      => $summary->event_duration,
-                'event_credits'       => $summary->event_credits,
-                'post_event_duration' => $summary->post_event_duration,
-                'post_event_credits'  => $summary->post_event_credits,
-                'total_duration'      => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration + $summary->other_duration),
-                'total_credits'       => ($summary->pre_event_credits + $summary->event_credits + $summary->post_event_credits),
-                'other_duration'      => $summary->other_duration,
-                'counted_duration'    => ($summary->pre_event_duration + $summary->event_duration + $summary->post_event_duration),
-            ];
-        }
-
-        return [
-            'event_start' => (string) $eventDates->event_start,
-            'event_end'   => (string) $eventDates->event_end,
-            'people'      => $results
-        ];
+    public function log($action, $data=null) {
+        TimesheetLog::record($action, $this->person_id, Auth::id(), $this->id, $data, $this->on_duty->year);
     }
 
     /*
-     * Run through the timesheets in a given year, and sniff for problematic entries.
-     */
-
-    public static function sanityChecker($year)
-    {
-        $withBase = [ 'position:id,title', 'person:id,callsign' ];
-
-        $rows = self::whereYear('on_duty', $year)
-                ->whereNull('off_duty')
-                ->with($withBase)
-                ->get()
-                ->sortBy('person.callsign')
-                ->values();
-
-        $onDutyEntries = $rows->map(function ($row) {
-            return [
-                'person'    => [
-                    'id'    => $row->person_id,
-                    'callsign'  => $row->person ? $row->person->callsign : 'Person #'.$row->person_id,
-                ],
-                'callsign'  => $row->person ? $row->person->callsign : 'Person #'.$row->person_id,
-                'on_duty'   => (string) $row->on_duty,
-                'duration'  => $row->duration,
-                'credits'   => $row->credits,
-                'position'  => [
-                    'id'    => $row->position_id,
-                    'title' => $row->position ? $row->position->title : 'Position #'.$row->position_id,
-                ]
-            ];
-        })->values();
-
-        $rows = self::whereYear('on_duty', $year)
-                ->whereRaw('on_duty > off_duty')
-                ->whereNotNull('off_duty')
-                ->with($withBase)
-                ->get()
-                ->sortBy('person.callsign')
-                ->values();
-
-        /*
-         * Do any entries have the end time before the start time?
-         * (should never happen..famous last words)
-         */
-
-        $endBeforeStartEntries = $rows->map(function ($row) {
-            return [
-                'person'    => [
-                    'id'    => $row->person_id,
-                    'callsign'  => $row->person ? $row->person->callsign : 'Person #'.$row->person_id,
-                ],
-                'on_duty'   => (string) $row->on_duty,
-                'off_duty'  => (string) $row->off_duty,
-                'duration'  => $row->duration,
-                'position'  => [
-                    'id'    => $row->position_id,
-                    'title' => $row->position ? $row->position->title : 'Position #'.$row->position_id,
-                ]
-            ];
-        });
-
-        /*
-         * Look for overlapping entries
-         */
-
-        $people = self::whereYear('on_duty', $year)
-                ->whereNotNull('off_duty')
-                ->with($withBase)
-                ->orderBy('person_id')
-                ->orderBy('on_duty')
-                ->get()
-                ->groupBy('person_id');
-
-        $overlappingPeople = [];
-        foreach ($people as $personId => $entries) {
-            $overlapping = [];
-
-            $prevEntry = null;
-            foreach ($entries as $entry) {
-                if ($prevEntry) {
-                    if ($entry->on_duty->timestamp < ($prevEntry->on_duty->timestamp + $prevEntry->duration)) {
-                        $overlapping[] = [
-                            [
-                                'timesheet_id'  => $prevEntry->id,
-                                'position' => [
-                                    'id'    => $prevEntry->position_id,
-                                    'title' => $prevEntry->position ? $prevEntry->position->title : 'Position #'.$prevEntry->position_id,
-                                ],
-                                'on_duty'   => (string) $prevEntry->on_duty,
-                                'off_duty'  => (string) $prevEntry->off_duty,
-                                'duration'  => $prevEntry->duration,
-                            ],
-                            [
-                                'timesheet_id'  => $entry->id,
-                                'position' => [
-                                    'id'    => $entry->position_id,
-                                    'title' => $entry->position ? $entry->position->title : 'Position #'.$entry->position_id,
-                                ],
-                                'on_duty'   => (string) $entry->on_duty,
-                                'off_duty'  => (string) $entry->off_duty,
-                                'duration'  => $entry->duration,
-                            ]
-                        ];
-                    }
-                }
-                $prevEntry = $entry;
-            }
-
-            if (!empty($overlapping)) {
-                $first = $entries[0];
-                $overlappingPeople[] = [
-                    'person'    => [
-                        'id'    => $first->person_id,
-                        'callsign' => $first->person ? $first->person->callsign : 'Person #'.$first->person_id
-                    ],
-                    'entries' => $overlapping
-                ];
-            }
-        }
-
-        usort($overlappingPeople, function ($a, $b) {
-            return strcasecmp($a['person']['callsign'], $b['person']['callsign']);
-        });
-
-        $minHour = 24;
-        foreach (Position::PROBLEM_HOURS as $positionId => $hours) {
-            if ($hours < $minHour) {
-                $minHour = $hours;
-            }
-        }
-
-        $now = now();
-        $rows = self:: select('timesheet.*', DB::raw("TIMESTAMPDIFF(SECOND, on_duty, IFNULL(off_duty,'$now')) as duration"))
-                ->whereYear('on_duty', $year)
-                ->whereRaw("TIMESTAMPDIFF(HOUR, on_duty, IFNULL(off_duty,'$now')) >= $minHour")
-                ->with($withBase)
-                ->orderBy('duration', 'desc')
-                ->get();
-
-        /*
-         * Look for entries that may be too long. (i.e. a person forgot to signout in a timely manner.)
-         */
-
-        $tooLongEntries = $rows->filter(function ($row) {
-            if (!isset(Position::PROBLEM_HOURS[$row->position_id])) {
-                return true;
-            }
-
-            return Position::PROBLEM_HOURS[$row->position_id] < ($row->duration / 3600.0);
-        })->values()->map(function ($row) {
-            return [
-                'person'    => [
-                    'id'       => $row->person_id,
-                    'callsign' => $row->person ? $row->person->callsign : 'Person #'.$row->person_id,
-                ],
-                'on_duty'   => (string) $row->on_duty,
-                'off_duty'  => (string) $row->off_duty,
-                'duration'  => $row->duration,
-                'position'  => [
-                    'id'    => $row->position_id,
-                    'title' => $row->position ? $row->position->title : 'Position #'.$row->position_id,
-                ]
-            ];
-        });
-
-        return [
-            'on_duty'          => $onDutyEntries,
-            'end_before_start' => $endBeforeStartEntries,
-            'overlapping'      => $overlappingPeople,
-            'too_long'         => $tooLongEntries
-        ];
-    }
-
-    public static function retrievePeopleToThank($year)
-    {
-        $people = Person::whereNotIn('status', [ Person::ALPHA, Person::AUDITOR, Person::BONKED, Person::PAST_PROSPECTIVE, Person::PROSPECTIVE, Person::SUSPENDED, Person::UBERBONKED ])
-            ->whereRaw('EXISTS (SELECT 1 FROM timesheet WHERE timesheet.person_id=person.id AND YEAR(on_duty)=? LIMIT 1)', [ $year ])
-            ->orderBy('callsign')
-            ->get();
-
-        return $people->map(function ($row) {
-            return [
-                'id'         => $row->id,
-                'first_name' => $row->first_name,
-                'last_name'  => $row->last_name,
-                'callsign'   => $row->callsign,
-                'status'     => $row->status,
-                'email'      => $row->email,
-                'bpguid'     => $row->bpguid,
-                'street1'    => $row->street1,
-                'street2'    => $row->street2,
-                'city'       => $row->city,
-                'state'      => $row->state,
-                'zip'        => $row->zip,
-                'country'    => $row->country,
-            ];
-        })->values();
-    }
-
-    /*
-     * Find everyone who worked in a given year, and summarize the positions (total time & credits)
-     */
-
-    public static function retrieveTimesheetTotals($year)
-    {
-        $rows = Timesheet::whereYear('on_duty', $year)
-            ->join('position', 'position.id', 'timesheet.position_id')
-            ->where('position.count_hours', true)
-            ->with([ 'person:id,callsign,status', 'position:id,title'])
-            ->orderBy('timesheet.person_id')
-            ->get();
-
-        if (!$rows->isEmpty()) {
-            PositionCredit::warmYearCache($year, array_unique($rows->pluck('position_id')->toArray()));
-        }
-
-        $timesheetByPerson = $rows->groupBy('person_id');
-
-        $results = [];
-
-        foreach ($timesheetByPerson as $personId => $entries) {
-            $person = $entries[0]->person;
-
-            $group = $entries->groupBy('position_id');
-            $positions = [];
-            $totalDuration = 0;
-            $totalCredits = 0.0;
-
-            // Summarize the positions worked
-            foreach ($group as $positionId => $posEntries) {
-                $position = $posEntries[0];
-                $duration = $posEntries->pluck('duration')->sum();
-                $totalDuration += $duration;
-                $credits = $posEntries->pluck('credits')->sum();
-                $totalCredits += $credits;
-                $positions[] = [
-                    'id'       => $positionId,
-                    'title'    => $position->title,
-                    'duration' => $duration,
-                    'credits'  => $credits,
-                ];
-            }
-
-            // Sort by position title
-            usort($positions, function ($a,$b) {
-                return strcasecmp($a['title'], $b['title']);
-            });
-
-            $results[] = [
-                'id'        => $personId,
-                'callsign'  => $person ? $person->callsign : 'Person #'.$personId,
-                'status'    => $person->status,
-                'positions' => $positions,
-                'total_duration' => $totalDuration,
-                'total_credits'  => $totalCredits,
-            ];
-        }
-
-        usort($results, function ($a, $b) {
-            return strcasecmp($a['callsign'], $b['callsign']);
-        });
-
-        return $results;
-    }
-
-    /*
-     * Return the total seconds on duty.
-     */
+    * Return the total seconds on duty.
+    */
 
     public function getDurationAttribute()
     {
-        // Did a SQL SELECT already compute this?
-        if (isset($this->attributes['duration'])) {
-            return (int)$this->attributes['duration'];
-        }
-
-        $on_duty = $this->getOriginal('on_duty');
-        if ($this->off_duty) {
-            return $this->off_duty->diffInSeconds($this->on_duty);
-        }
-
-        // Still on duty - return how many seconds have elasped so far
-        return Carbon::parse(now())->diffInSeconds($this->on_duty);
+        $offDuty = $this->off_duty ?? now();
+        return $offDuty->diffInSeconds($this->on_duty);
     }
 
     public function getPositionTitleAttribute()
@@ -1383,7 +699,43 @@ class Timesheet extends ApiModel
         $this->verified_at = now();
     }
 
-    public function getPositionSubtypeAttribute() {
+    public function getPositionSubtypeAttribute()
+    {
         return $this->position->subtype;
+    }
+
+    public function setAdditionalReviewerNotesAttribute($notes)
+    {
+        if (empty($notes)) {
+            return;
+        }
+
+        $this->_additional_reviewer_notes = $notes;
+        $user = Auth::user();
+        $callsign = $user ? $user->callsign : '(unknown)';
+
+        $date = date('Y/m/d H:m:s');
+        $this->reviewer_notes = $this->reviewer_notes . "From $callsign on $date:\n$notes\n\n";
+    }
+
+    public function getAdditionalReviewerNotesAttribute()
+    {
+        return $this->_additional_reviewer_notes;
+    }
+
+    public function setAdditionalNotesAttribute($notes)
+    {
+        if (empty($notes)) {
+            return;
+        }
+
+        $this->_additional_notes = $notes;
+        $date = date('Y/m/d H:m:s');
+        $this->notes = $this->notes . "$date:\n$notes\n\n";
+    }
+
+    public function getAdditionalNotesAttribute()
+    {
+        return $this->_additional_notes;
     }
 }

--- a/app/Models/TimesheetMissing.php
+++ b/app/Models/TimesheetMissing.php
@@ -8,21 +8,26 @@ use App\Models\ApiModel;
 use App\Models\Position;
 use App\Models\Person;
 use App\Models\Timesheet;
+use Illuminate\Support\Facades\Auth;
 
 class TimesheetMissing extends ApiModel
 {
     protected $table = "timesheet_missing";
     protected $auditModel = true;
 
+    const APPROVED = 'approved';
+    const REJECTED = 'rejected';
+    const PENDING = 'pending';
+
     protected $fillable = [
-        'notes',
+        'additional_notes',
         'off_duty',
         'on_duty',
         'partner',
         'person_id',
         'position_id',
         'review_status',
-        'reviewer_notes',
+        'additional_reviewer_notes',
 
         // Used for creating new entries when review_status == 'approved'
         'create_entry',
@@ -255,6 +260,29 @@ class TimesheetMissing extends ApiModel
 
     public function setNewPositionIdAttribute($value) {
         $this->new_position_id = $value;
+    }
+
+    public function setAdditionalReviewerNotesAttribute($note)
+    {
+        if (empty($note)) {
+            return;
+        }
+
+        $user = Auth::user();
+        $callsign = $user ? $user->callsign : '(unknown)';
+
+        $date = date('Y/m/d H:m:s');
+        $this->reviewer_notes = $this->reviewer_notes . "From $callsign on $date:\n$note\n\n";
+    }
+
+    public function setAdditionalNotesAttribute($note)
+    {
+        if (empty($note)) {
+            return;
+        }
+
+        $date = date('Y/m/d H:m:s');
+        $this->notes = $this->notes . "$date:\n$note\n\n";
     }
 
 }

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -145,6 +145,7 @@ class Training extends Position
                 if (!$isQualified) {
                     $info->is_unqualified = true;
                     $info->unqualified_reason = $unqualifiedReason;
+                    $info->unqualified_message = Position::UNQUALIFIED_MESSAGES[$unqualifiedReason];
                 }
             }
 

--- a/database/factories/PositionFactory.php
+++ b/database/factories/PositionFactory.php
@@ -13,10 +13,11 @@ class PositionFactory extends Factory
 
     public function definition()
     {
-return [
-        'title' => $this->faker->text(10),
-        'max'   => 1,
-        'min'   => 0
-    ];
-}
+        return [
+            'title' => $this->faker->text(10),
+            'max' => 1,
+            'min' => 0,
+            'active' => true
+        ];
+    }
 }

--- a/database/migrations/2020_10_26_150235_convert_timesheets.php
+++ b/database/migrations/2020_10_26_150235_convert_timesheets.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class ConvertTimesheets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("ALTER TABLE timesheet CHANGE COLUMN review_status review_status enum('approved', 'rejected', 'pending', 'unverified', 'verified') default 'unverified'");
+        DB::statement("UPDATE timesheet SET review_status='verified' WHERE verified is true ");
+        DB::statement("UPDATE timesheet SET review_status='unverified' WHERE verified is false and review_status='pending'");
+        DB::statement("ALTER TABLE timesheet_log CHANGE COLUMN action action enum('unconfirmed', 'confirmed', 'signon', 'signoff', 'created', 'update', 'delete', 'review', 'verify', 'unverified') not null");
+        DB::statement("ALTER TABLE timesheet_log CHANGE COLUMN created_at created_at DATETIME NOT NULL");
+        DB::statement("ALTER TABLE timesheet_log ADD COLUMN year INTEGER NOT NULL DEFAULT 0");
+        DB::statement("ALTER TABLE timesheet_log ADD COLUMN data LONGTEXT");
+        DB::statement("ALTER TABLE timesheet DROP COLUMN verified");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,32 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./app</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" printerClass="NunoMaduro\Collision\Adapters\Phpunit\Printer" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./app</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+  </php>
 </phpunit>


### PR DESCRIPTION
- Eliminated timesheet.verified column. verification state added to review_status.
- Added timesheet_log.data column to supersede the message column.
- Added timesheet_log.year column to ensure audit trails are retrieved for actions performed in a different year than th
e timesheet entry.
- Notes and reviewer notes are read only. Use additional_{notes,reviewer_notes} to append with timestamps.
- Timesheet logging switched over to using json encoding for enhanced and more consistent auditing. Plain text has been
dropped.
- Fixed bug were the logs for a deleted timesheet entry were not being found.
- Logging includes notes written to help with timesheet auditing post-event.
- Pulled most reports out of Timesheet model and placed into app/Lib/Reports.
- Untrained and unqualified errors combined into a single error status.
- New Timesheet::log function to help DRY up a few things.