### PR TITLE
New API - person/N/schedule/log - retrieve the scheduling log for a person & year.

### DIFF
--- a/app/Http/Controllers/PersonScheduleController.php
+++ b/app/Http/Controllers/PersonScheduleController.php
@@ -378,6 +378,24 @@ class PersonScheduleController extends ApiController
     }
 
     /**
+     * Retrieve the scheduling log for a person & year.
+     * Allows a login management user to see the shift sign up and removals
+     * for another person without having to have full access to the action log.
+     *
+     * @param Person $person
+     * @return JsonResponse
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+
+    public function scheduleLog(Person $person)
+    {
+        $this->authorize('view', [Schedule::class, $person]);
+        $year = $this->getYear();
+
+        return response()->json(['logs' => Schedule::retrieveScheduleLog($person->id, $year)]);
+    }
+
+    /**
      * Is the user allowed to force a schedule change?
      *
      * - Admins are allowed

--- a/app/Models/ActionLog.php
+++ b/app/Models/ActionLog.php
@@ -168,6 +168,7 @@ class ActionLog extends Model
             $log->data = $data;
         }
 
+        $log->created_at = now();
         $log->save();
     }
 

--- a/app/Models/PersonSlot.php
+++ b/app/Models/PersonSlot.php
@@ -5,8 +5,11 @@ namespace App\Models;
 use Carbon\Carbon;
 
 use App\Models\ApiModel;
+use App\Models\ActionLog;
 use App\Models\Person;
 use App\Models\Slot;
+
+use Illuminate\Support\Facades\Auth;
 
 class PersonSlot extends ApiModel
 {
@@ -38,10 +41,17 @@ class PersonSlot extends ApiModel
     }
 
     /*
-     * Delete all records refering to a slot. Used by slot deletion.
+     * Delete all records referring to a slot. Used by slot deletion.
      */
 
     public static function deleteForSlot($slotId) {
-        return self::where('slot_id', $slotId)->delete();
+        $rows = self::where('slot_id', $slotId)->get();
+        $user = Auth::user();
+
+        foreach ($rows as $row) {
+            ActionLog::record($user, 'person-slot-remove', 'slot deletion', ['slot_id' => $slotId], $row->person_id);
+        }
+
+        self::where('slot_id', $slotId)->delete();
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -176,6 +176,7 @@ Route::group([
     Route::get('person/{person}/schedule/imminent', 'PersonScheduleController@imminent');
     Route::get('person/{person}/schedule/expected', 'PersonScheduleController@expected');
     Route::get('person/{person}/schedule/summary', 'PersonScheduleController@scheduleSummary');
+    Route::get('person/{person}/schedule/log', 'PersonScheduleController@scheduleLog');
     Route::resource('person/{person}/schedule', 'PersonScheduleController', ['only' => ['index', 'store', 'destroy']]);
 
     Route::get('person/{person}/positions', 'PersonController@positions');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,8 @@ use App\Models\PersonRole;
 use App\Models\PersonPosition;
 use App\Models\Setting;
 
+use Carbon\Carbon;
+
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
@@ -26,6 +28,9 @@ abstract class TestCase extends BaseTestCase
         gc_collect_cycles();
 
         Setting::$cache = [];
+
+        // Set the time to the beginning of the year
+        Carbon::setTestNow(date('Y-01-01 12:34:56'));
     }
 
     public function createUser()


### PR DESCRIPTION
- Tests are set to the time {current year}-01-01 12:45:56 to help with scheduling testing.
- PersonSlot::deleteForSlot logs all sign ups before deleting the slot.