### PR TITLE
Changed reset password request flow.

### DIFF
--- a/app/Mail/ResetPassword.php
+++ b/app/Mail/ResetPassword.php
@@ -5,24 +5,47 @@ namespace App\Mail;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Models\Person;
 
 class ResetPassword extends Mailable
 {
     use Queueable, SerializesModels;
 
-    public $password;
     public $adminEmail;
+    public $greeting;
+    public $resetURL;
 
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct($password, $adminEmail)
+    public function __construct($person, $token, $adminEmail)
     {
-        $this->password = $password;
         $this->adminEmail = $adminEmail;
+
+        switch ($person->status) {
+            case Person::AUDITOR:
+                $this->greeting = "Auditor {$person->first_name}";
+                break;
+            case Person::PROSPECTIVE:
+            case Person::ALPHA:
+                $this->greeting = "Prospective Ranger {$person->callsign}";
+                break;
+            case Person::NON_RANGER:
+                $this->greeting = "Ranger Volunteer {$person->callsign}";
+                break;
+            default:
+                $this->greeting = "Ranger {$person->callsign}";
+                break;
+        }
+
+        if (config('clubhouse.DeploymentEnvironment') == 'Staging') {
+            $server = 'ranger-clubhouse-staging';
+        } else {
+            $server = 'ranger-clubhouse';
+        }
+        $this->resetURL = "https://{$server}.burningman.org/client/reset-password?token=$token";
     }
 
     /**
@@ -32,6 +55,6 @@ class ResetPassword extends Mailable
      */
     public function build()
     {
-        return $this->subject('Clubhouse Temporary Password')->view('emails.reset-password');
+        return $this->subject('Ranger Clubhouse password reset')->view('emails.reset-password');
     }
 }

--- a/resources/views/emails/reset-password.blade.php
+++ b/resources/views/emails/reset-password.blade.php
@@ -1,29 +1,38 @@
 @component('html-email')
-<p>
-    Dear Ranger,
-</p>
+    <p>
+        Hello {{$greeting}},
+    </p>
 
-<p>
-    You have been issued a temporary password to the Ranger Secret Clubhouse:
-</p>
+    <p>
+        You recently requested to reset your password for your Black Rock Ranger Secret Clubhouse account.
+        Click the button below to reset your password.
+    </p>
 
-<p>
-<b>{{ $password }}</b>
-</p>
+    <p class="text-align: center">
+        <div class="btn btn-primary"><a href="{{$resetURL}}">Reset Your Password</a></div>
+    </p>
 
-<p>
-    Please use it log in and change it to a password of your choice.
-</p>
+    <p>
+        If you did not request a password reset, please ignore this email or contact us at
+        <a href="mailto:{{$adminEmail}}">{{$adminEmail}}</a> to let us know someone is up to no good.
+    </p>
+    <p>
+        This password reset is only valid for the next 2 hours.
+    </p>
 
-<p>
-    If you are still unable to log in, or if you were not expecting this
-    message, please contact us at <a href="mailto:{{$adminEmail}}">{{$adminEmail}}</a>.
-</p>
+    <p>
+        Sincerely,
+    </p>
+    <p>
+        The Black Rock Ranger Tech Team<br>
+        <a href="mailto:{{$adminEmail}}">{{$adminEmail}}</a>
+    </p>
+    <p>
+        If you're having trouble clicking the password reset button, copy and paste the URL below
+        into your web browser.
+        <br>
+        <br>
+        <a href="{{$resetURL}}">{{$resetURL}}</a>
+    </p>
 
-<p>
-    Sincerely,
-</p>
-<p>
-    The Black Rock Ranger Tech Team
-</p>
 @endcomponent

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -18,7 +18,7 @@ class AuthControllerTest extends TestCase
      */
     public function testMissingParameters()
     {
-        $response = $this->json('POST', 'auth/login', [ ]);
+        $response = $this->json('POST', 'auth/login', []);
         $response->assertStatus(422);
     }
 
@@ -30,13 +30,13 @@ class AuthControllerTest extends TestCase
     {
         $response = $this->json(
             'POST', 'auth/login', [
-            'identification' => 'no-such-user@example.com',
-            'password'   => 'noshowers',
-             ]
+                'identification' => 'no-such-user@example.com',
+                'password' => 'noshowers',
+            ]
         );
 
         $response->assertStatus(401);
-        $response->assertJson([ 'status' => 'invalid-credentials']);
+        $response->assertJson(['status' => 'invalid-credentials']);
     }
 
     /**
@@ -45,15 +45,15 @@ class AuthControllerTest extends TestCase
 
     public function testSuspendedPerson()
     {
-        $user =Person::factory()->create([ 'status' => 'suspended']);
+        $user = Person::factory()->create(['status' => 'suspended']);
 
         $response = $this->json(
             'POST', 'auth/login',
-            [ 'identification' => $user->email, 'password'   => 'ineedashower!' ]
+            ['identification' => $user->email, 'password' => 'ineedashower!']
         );
 
         $response->assertStatus(401);
-        $response->assertJson([ 'status' => 'account-suspended' ]);
+        $response->assertJson(['status' => 'account-suspended']);
     }
 
 
@@ -63,60 +63,54 @@ class AuthControllerTest extends TestCase
 
     public function testWrongPassword()
     {
-        $user =Person::factory()->create();
+        $user = Person::factory()->create();
 
         $response = $this->json(
             'POST', 'auth/login',
-            [ 'identification' => $user->email, 'password'   => 'ineedashower! maybe' ]
+            ['identification' => $user->email, 'password' => 'ineedashower! maybe']
         );
 
         $response->assertStatus(401);
-        $response->assertJson([ 'status' => 'invalid-credentials' ]);
-    }
-
-   /**
-    * test for succesfull reset password
-    */
-
-    public function testResetPassword()
-    {
-        $user =Person::factory()->create();
-
-        Mail::fake();
-
-        $response = $this->json(
-            'POST', 'auth/reset-password', [
-            'identification' => $user->email,
-                ]
-        );
-
-        $response->assertStatus(200);
-        $response->assertJson([ 'status' => 'success' ]);
-
-        Mail::assertSent(
-            ResetPassword::class, function ($mail) use ($user) {
-                    return $mail->hasTo($user->email);
-            }
-        );
+        $response->assertJson(['status' => 'invalid-credentials']);
     }
 
     /**
-     * Test for failed reset password using non existant user
+     * test for successful reset password
+     */
+
+    public function testResetPassword()
+    {
+        $user = Person::factory()->create();
+
+        Mail::fake();
+
+        $response = $this->json('POST', 'auth/reset-password', ['identification' => $user->email]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 'success']);
+
+        Mail::assertSent(ResetPassword::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email);
+        });
+    }
+
+    /**
+     * Test for failed reset password using non existent user
      */
 
     public function testResetPasswordForUnknownUser()
     {
-        $user =Person::factory()->create();
+        $user = Person::factory()->create();
 
         Mail::fake();
 
         $response = $this->json(
             'POST', 'auth/reset-password',
-            [ 'identification' => 'whothehellami@nowhere.dev' ]
+            ['identification' => 'whothehellami@nowhere.dev']
         );
 
         $response->assertStatus(400);
-        $response->assertJson([ 'status' => 'not-found' ]);
+        $response->assertJson(['status' => 'not-found']);
         Mail::assertNothingSent();
     }
 
@@ -126,17 +120,17 @@ class AuthControllerTest extends TestCase
 
     public function testResetPasswordForDisabledUser()
     {
-        $user =Person::factory()->create([ 'status' => Person::SUSPENDED ]);
+        $user = Person::factory()->create(['status' => Person::SUSPENDED]);
 
         Mail::fake();
 
         $response = $this->json(
             'POST', 'auth/reset-password',
-            [ 'identification' => $user->email ]
+            ['identification' => $user->email]
         );
 
         $response->assertStatus(403);
-        $response->assertJson([ 'status' => 'account-disabled' ]);
+        $response->assertJson(['status' => 'account-disabled']);
         Mail::assertNothingSent();
     }
 

--- a/tests/Feature/PersonControllerTest.php
+++ b/tests/Feature/PersonControllerTest.php
@@ -456,6 +456,44 @@ class PersonControllerTest extends TestCase
         $response->assertStatus(200);
     }
 
+    /**
+     * Test changing password with password reset token.
+     */
+
+    public function testChangePasswordWithResetTokenSuccess()
+    {
+        $token = $this->user->createResetPasswordToken();
+        $response = $this->json(
+            'PATCH',
+            "person/{$this->user->id}/password",
+            [
+                'reset_token' => $token,
+                'password' => 'abcdef',
+                'password_confirmation' => 'abcdef',
+            ]
+        );
+        $response->assertStatus(200);
+    }
+
+    /**
+     * Test changing password with password reset token.
+     */
+
+    public function testChangePasswordWithInvalidResetToken()
+    {
+        $token = $this->user->createResetPasswordToken();
+        $response = $this->json(
+            'PATCH',
+            "person/{$this->user->id}/password",
+            [
+                'reset_token' => $token . 'blah',
+                'password' => 'abcdef',
+                'password_confirmation' => 'abcdef',
+            ]
+        );
+        $response->assertStatus(422);
+    }
+
 
     /**
      * Test change password failure with password confirmation mismatch.


### PR DESCRIPTION
- Temporary password (person.tpassword) has been redefined as a reset password token.
- /auth/login accepts a reset password token in addition to a email & password.
- Do not generate a new reset password token if the current token has not expired. Prevents multiple emails being sent out with different codes and confusing the user on which email is the right one.
- Reset password email revamped to send a reset password link, styled as a button, instead of the temporary password. No more copy-n-pasting.
- /person/X/password updated to accept a reset password token in place of the old password.