### PR TITLE
New roles - Login Management On Playa & Tech Ninja.

### DIFF
--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -394,16 +394,20 @@ class PersonController extends ApiController
         $newIds = [];
         $deleteIds = [];
 
+        // Only tech ninjas may grant/revoke the tech ninja role. Ignore attempts to alter the role by
+        // mere mortals.
+        $isTechNinja = $this->userHasRole(Role::TECH_NINJA);
+
         // Find the new ids
         foreach ($roleIds as $id) {
-            if (!in_array($id, $existingRoles)) {
+            if (!in_array($id, $existingRoles) && ($id != Role::TECH_NINJA || $isTechNinja)) {
                 $newIds[] = $id;
             }
         }
 
         // Find the ids to be deleted
         foreach ($existingRoles as $id) {
-            if (!in_array($id, $roleIds)) {
+            if (!in_array($id, $roleIds) && ($id != Role::TECH_NINJA || $isTechNinja)) {
                 $deleteIds[] = $id;
             }
         }

--- a/app/Http/Filters/PersonFilter.php
+++ b/app/Http/Filters/PersonFilter.php
@@ -33,11 +33,7 @@ class PersonFilter
         'last_seen_at'
     ];
 
-    const ROLES_FIELDS = [
-        'roles',
-    ];
-
-    const CERTIFICATIONS_FIELDS = [
+     const CERTIFICATIONS_FIELDS = [
         'osha10',
         'osha30',
     ];
@@ -150,7 +146,6 @@ class PersonFilter
     const FIELDS_SERIALIZE = [
         [ self::NAME_GENDER_FIELDS ],
         [ self::STATUS_FIELDS ],
-        [ self::ROLES_FIELDS ],
         [ self::ACCOUNT_FIELDS ],
         [ self::CALLSIGNS_FIELDS ],
         [ self::CERTIFICATIONS_FIELDS ],
@@ -176,7 +171,6 @@ class PersonFilter
         [ self::MESSAGE_FIELDS, false, [ Role::ADMIN, Role::MANAGE, Role::VC, Role::TRAINER ]],
         [ self::CERTIFICATIONS_FIELDS, false, [ Role::VC ]],
         [ self::STATUS_FIELDS, false, [  Role::MENTOR, Role::VC ] ],
-        [ self::ROLES_FIELDS, false, [ Role::MENTOR, Role::VC ] ],
         [ self::CALLSIGNS_FIELDS, false, [ Role::MENTOR, Role::VC] ],
         [ self::EMAIL_FIELDS, true, [ Role::VC ] ],
         [ self::PERSONAL_INFO_FIELDS, true, [ Role::VC ] ],

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -27,6 +27,9 @@ class Role extends ApiModel
     const MEGAPHONE        = 105; // RBS access
     const TIMESHEET_MANAGEMENT = 106; // Create, edit, correct, verify timesheets
     const SURVEY_MANAGEMENT = 107; // Allow to create/edit/delete surveys, and view responders identity.
+    const MANAGE_ON_PLAYA = 108; // Treated as MANAGE if setting LoginManageOnPlayaEnabled is true
+
+    const TECH_NINJA = 1000;    // godlike powers granted - access to dangerous maintenance functions, raw database access.
 
     protected $casts = [
         'new_user_eligible' => 'bool'

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -40,7 +40,6 @@ class Setting extends ApiModel
      * options: array of possible options format is [ 'option', 'description' ]
      */
 
-
     const DESCRIPTIONS = [
         'AccountCreationEmail' => [
             'description' => 'Alert email address when accounts register',
@@ -511,6 +510,11 @@ class Setting extends ApiModel
             'description' => 'Email(s) to notify when vehicle requests are queued up for review. (nightly mail)',
             'type' => 'email'
         ],
+
+        'LoginManageOnPlayaEnabled' => [
+            'description' => 'Enables Login Manage On Playa role',
+            'type' => 'bool'
+        ]
     ];
 
     /*

--- a/database/migrations/2020_12_29_122848_add_lm_on_playa_to_roles.php
+++ b/database/migrations/2020_12_29_122848_add_lm_on_playa_to_roles.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use App\Models\Role;
+
+class AddLmOnPlayaToRoles extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Role::find(Role::MANAGE_ON_PLAYA)) {
+            Role::insert([ 'id' => Role::MANAGE_ON_PLAYA, 'title' => 'Login Manage On Playa']);
+        }
+        if (!Role::find(Role::TECH_NINJA)) {
+            Role::insert([ 'id' => Role::TECH_NINJA, 'title' => 'Tech Ninja']);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Role::whereIn('id', [Role::MANAGE_ON_PLAYA, Role::TECH_NINJA])->delete();
+    }
+}

--- a/tests/Feature/PersonControllerTest.php
+++ b/tests/Feature/PersonControllerTest.php
@@ -833,6 +833,49 @@ class PersonControllerTest extends TestCase
         );
     }
 
+    /**
+     * Ensure a non-Tech Ninja cannot add the Tech Ninja Role
+     */
+    public function test_user_cannot_add_tech_nina_role()
+    {
+        $person = Person::factory()->create();
+        $this->addAdminRole();
+
+        $response = $this->json('POST', "person/{$person->id}/roles", [ 'role_ids' => [Role::MENTOR, Role::TECH_NINJA ]]);
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('person_role', [
+            'person_id' => $person->id,
+            'role_id' => Role::TECH_NINJA
+        ]);
+
+        $this->assertDatabaseHas('person_role', [
+            'person_id' => $person->id,
+            'role_id' => Role::MENTOR
+        ]);
+    }
+
+    /**
+     * Test if a tech ninja can add the tech ninja role to another person.
+     *
+     */
+    public function test_user_can_add_tech_nina_role()
+    {
+        $person = Person::factory()->create();
+        $this->addAdminRole();
+        $this->addRole(Role::TECH_NINJA);
+
+        $response = $this->json('POST', "person/{$person->id}/roles", [ 'role_ids' => [Role::MENTOR, Role::TECH_NINJA ]]);
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('person_role', [
+            'person_id' => $person->id,
+            'role_id' => Role::TECH_NINJA
+        ]);
+
+        $this->assertDatabaseHas('person_role', [
+            'person_id' => $person->id,
+            'role_id' => Role::MENTOR
+        ]);
+    }
 
     /*
      * Test how many years a person has rangered

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Carbon\Carbon;
 use Tests\TestCase;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -746,6 +747,9 @@ class TimesheetControllerTest extends TestCase
 
     public function testradioEligibilityReport()
     {
+        // 2020 is funky
+        Carbon::setTestNow('2019-01-01 12:34:56');
+        $this->year = 2019;
         $lastYear = $this->year - 1;
         $prevYear = $this->year - 2;
         $person = $this->targetPerson;


### PR DESCRIPTION
- New role Login Management On Playa. Works exactly like Login Management except is controlled through the LoginManagementOnPlayaEnabled setting.
- New role Tech Ninja. Can only be granted/revoked by other Tech Nina roles. Groundwork for future features.
- Removed obsoleted de/serialization of Person->roles. The frontend uses a separate interface to query & update roles.