### PR TITLE
Online Training Only requirement work. Auditor registration disabled.

### DIFF
--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -14,6 +14,7 @@ class ConfigController extends Controller
 
     const CLIENT_CONFIGS = [
         'AdminEmail',
+        'AuditorRegistrationDisabled',
         'EditorUrl',
         'GeneralSupportEmail',
         'JoiningRangerSpecialTeamsUrl',

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -231,7 +231,7 @@ class PersonController extends ApiController
     public function eventInfo(Person $person)
     {
         $year = $this->getYear();
-        $eventInfo = PersonEventInfo::findForPersonYear($person->id, $year);
+        $eventInfo = PersonEventInfo::findForPersonYear($person, $year);
         if ($eventInfo) {
             return response()->json(['event_info' => $eventInfo]);
         }
@@ -576,6 +576,10 @@ class PersonController extends ApiController
 
     public function register()
     {
+        if (setting('AuditorRegistrationDisabled')) {
+            throw new \InvalidArgumentException("Auditor registration is disabled at this time.");
+        }
+
         $params = request()->validate([
             'intent' => 'required|string',
             'person.email' => 'required|email',

--- a/app/Models/Bmid.php
+++ b/app/Models/Bmid.php
@@ -473,4 +473,8 @@ class Bmid extends ApiModel
         return $matrix;
     }
 
+    public function effectiveMeals() : string {
+        $meals = $this->buildMealsMatrix();
+        return count($meals) == 3 ? Bmid::MEALS_ALL : implode('+', $meals);
+    }
 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -76,6 +76,12 @@ class Setting extends ApiModel
             'type' => self::TYPE_INTEGER
         ],
 
+        'AuditorRegistrationDisabled' => [
+            'description' => 'Prevent Auditors from registering for an account in the Clubhouse',
+            'type' => self::TYPE_BOOL,
+            'default' => false,
+        ],
+
         'BroadcastClubhouseNotify' => [
             'description' => 'Enable RBS notification of new Clubhouse messages',
             'type' => self::TYPE_BOOL,
@@ -175,6 +181,18 @@ class Setting extends ApiModel
         'OnlineTrainingDisabledAllowSignups' => [
             'description' => 'Enable shift signups even if Online Training is disabled',
             'type' => self::TYPE_BOOL,
+        ],
+
+        'OnlineTrainingOnlyForBinaries' => [
+            'description' => 'Only require Online Training and not Face-to-Face training for vets (2+ years)',
+            'type' => self::TYPE_BOOL,
+            'default' => false
+        ],
+
+        'OnlineTrainingOnlyForVets' => [
+            'description' => 'Only require Online Training and not Face-to-Face training for binaries (0-1 years)',
+            'type' => self::TYPE_BOOL,
+            'default' => false
         ],
 
         'MoodleDomain' => [

--- a/database/factories/PersonOnlineTrainingFactory.php
+++ b/database/factories/PersonOnlineTrainingFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PersonOnlineTraining;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PersonOnlineTrainingFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = PersonOnlineTraining::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'type' => PersonOnlineTraining::MOODLE,
+            'completed_at' => now()
+        ];
+    }
+}


### PR DESCRIPTION
- New settings OnlineTrainingOnlyForBinaries & OnlineTrainingOnlyForVets to control if either group only needs to complete Online Training to be consider "trained" for the event. (2021 event)
- person/X/event-info includes is_binary and online_training_only info
- Don't allow auditor registration if AuditorRegistrationDisabled is true