### PR TITLE
Fixed shift lead report.

### DIFF
--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -184,9 +184,9 @@ class Training extends Position
      * @return bool true if the person passed in the given year
      */
 
-    public static function didPersonPassForYear(Person $person, int $positionId, int $year): bool
+    public static function didPersonPassForYear(Person|int $person, int $positionId, int $year): bool
     {
-        $personId = $person->id;
+        $personId =  is_a($person, Person::class) ? $person->id : $person;
 
         if ($positionId == Position::TRAINING) {
             $isBinary = Timesheet::isPersonBinary($person);


### PR DESCRIPTION
- Incorrect argument type was passed to Training::didPersonPassForYear().
- Added coded to work around differences in regular expressions between Mysql 5.0 ("spencer" style) and 8.0 (modern regexp)