### PR TITLE
Report fixes.

### DIFF
--- a/app/Lib/RedactDatabase.php
+++ b/app/Lib/RedactDatabase.php
@@ -17,8 +17,8 @@ use Illuminate\Support\Facades\DB;
 class RedactDatabase {
     public static function execute($year) {
 
-        $salt = '123456';
-        $sha = sha1($salt . 'donothing');
+       // $salt = '123456';
+       // $sha = sha1($salt . 'donothing');
 
         // No fruit-cup.. err.. Personal Information for you tonight!
         DB::table('person')->update([
@@ -37,7 +37,7 @@ class RedactDatabase {
             'camp_location' => 'D-Lot',
             'emergency_contact' => 'On-playa: John Smith (father), camped at 3:45 and G. Off-playa: Jane Smith (mother), phone 123-456-7890, email jane@noemail.none',
             'tpassword' => '',
-            'password' => "$salt:$sha",
+          //  'password' => "$salt:$sha",
         ]);
 
         // Zap training notes

--- a/app/Lib/Reports/ShiftCoverageReport.php
+++ b/app/Lib/Reports/ShiftCoverageReport.php
@@ -115,7 +115,7 @@ class ShiftCoverageReport
     ];
 
     const ONE_POSITIONS = [
-        [ Position::ONE_OOD, 'ONE OOD', self::CALLSIGNS ],
+      //  [ Position::ONE_OOD, 'ONE OOD', self::CALLSIGNS ],
         [ Position::ONE_SHIFT_LEAD, 'ONE Lead', self::CALLSIGNS ],
         [ Position::ONE_RSCI, 'ONESCI', self::CALLSIGNS ],
         [ Position::ONE_TROUBLESHOOTER, 'ONE Troubleshooter', self::CALLSIGNS ],

--- a/app/Lib/Reports/ShiftLeadReport.php
+++ b/app/Lib/Reports/ShiftLeadReport.php
@@ -120,6 +120,13 @@ class ShiftLeadReport
             ->orderBy('slot.begins')
             ->orderByRaw('CASE WHEN position.id=' . Position::DIRT_SHINY_PENNY . ' THEN "1111" ELSE position.title END DESC');
 
+        // Only report on active positions for the current year. Previous years may reference
+        // positions that have been deactivated since.
+
+        if ($shiftStart->year == current_year()) {
+            $sql->where('position.active', true);
+        }
+
         self::buildShiftRange($sql, $shiftStart, $shiftEnd, 45);
 
         switch ($type) {


### PR DESCRIPTION
- Removed O.N.E. OOD position from Shift Coverage report.
- Only report on active positions if the current year is selected on the Shift Lead report.
- Don't reset the passwords when creating a redacted database.