### PR TITLE
Shift Lead report performance work.

### DIFF
--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -1049,7 +1049,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         $check = trim(strtolower($gender));
 
         // Female gender
-        if (preg_match('/\b(female|girl|femme|lady|she|her|woman|famale|femal|fem)\b/', $check) || $check == 'f') {
+        if (preg_match('/\b(female|girl|femme|lady|she|her|woman|famale|femal|fem|cis[\s\-]?female)\b/', $check) || $check == 'f') {
             return 'F';
         }
 


### PR DESCRIPTION
- API response payload has been reduced by 40%. Positions & slots columns are no longer inlined with each callsign row. Instead both are returned in their own response and each callsign row only references a slot and/or position id.
- Bulk look up passing Green Dot ARTs instead of individually looking up each person.
- Switch to using Person::summarizeGender() to count how many female GDs are scheduled, reduced down to one select statement, and eliminated use of the SQL REGEXP operator.