### PR TITLE
O.N.E. support changes. Start to use the Tech Ninja role for things.

### DIFF
--- a/app/Http/Controllers/AlertController.php
+++ b/app/Http/Controllers/AlertController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Alert;
 use App\Models\AlertPerson;
-use App\Http\Controllers\ApiController;
 
 class AlertController extends ApiController
 {
@@ -23,7 +22,7 @@ class AlertController extends ApiController
 
     public function store()
     {
-        $this->authorize('store', [ Alert::class ]);
+        $this->authorize('store', [Alert::class]);
 
         $alert = new Alert;
         $this->fromRest($alert);

--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use Carbon\Carbon;
-use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 
 class ConfigController extends Controller
 {
@@ -16,6 +16,7 @@ class ConfigController extends Controller
         'AdminEmail',
         'AuditorRegistrationDisabled',
         'EditorUrl',
+        'HQWindowInterfaceEnabled',
         'GeneralSupportEmail',
         'JoiningRangerSpecialTeamsUrl',
         'LoginManageOnPlayaEnabled',
@@ -37,10 +38,11 @@ class ConfigController extends Controller
     /**
      * Return the minimal set of settings used to boot the frontend application.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
 
-    public function show() {
+    public function show()
+    {
         $ghdTime = config('clubhouse.GroundhogDayTime');
         if (!empty($ghdTime)) {
             Carbon::setTestNow($ghdTime);
@@ -49,7 +51,7 @@ class ConfigController extends Controller
         $configs = setting(self::CLIENT_CONFIGS);
 
         if (config('clubhouse.GroundhogDayTime')) {
-            $configs['GroundhogDayTime'] = (string) now();
+            $configs['GroundhogDayTime'] = (string)now();
         }
 
         $configs['DeploymentEnvironment'] = config('clubhouse.DeploymentEnvironment');

--- a/app/Http/Controllers/PositionController.php
+++ b/app/Http/Controllers/PositionController.php
@@ -69,7 +69,7 @@ class PositionController extends ApiController
 
     public function update(Position $position): JsonResponse
     {
-        $this->authorize('update', Position::class);
+        $this->authorize('update', $position);
         $this->fromRest($position);
 
         if ($position->save()) {
@@ -87,7 +87,7 @@ class PositionController extends ApiController
      */
     public function destroy(Position $position)
     {
-        $this->authorize('delete', Position::class);
+        $this->authorize('delete', $position);
         $position->delete();
         PersonPosition::where('position_id', $position->id)->delete();
         return $this->restDeleteSuccess();

--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -833,6 +833,10 @@ class TimesheetController extends ApiController
             return false;
         }
 
+        // TODO: Remove post ONE
+        if (current_year() == 2021 && in_array($positionId, Position::ONE_POSITIONS)) {
+            return true;
+        }
 
         // Are they trained for this position?
         if (!Training::isPersonTrained($person, $positionId, current_year(), $requiredPositionId)) {

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -138,6 +138,20 @@ class Position extends ApiModel
     const ONE_OOD = 131;
     const ONE_HQ_WINDOW = 137;
     const ONE_HQ_ON_CALL = 138;
+    const ONE_HQ_LEADERS = 139;
+
+    // TODO: Remove post ONE.
+    const ONE_POSITIONS = [
+        self::ONE_SHIFT_LEAD,
+        self::ONE_TROUBLESHOOTER,
+        self::ONE_GREEN_DOT,
+        self::ONE_GERLACH_PATROL_DIRT,
+        self::ONE_RSCI,
+        self::ONE_OOD,
+        self::ONE_HQ_WINDOW,
+        self::ONE_HQ_ON_CALL,
+        self::ONE_HQ_LEADERS
+    ];
 
     /*
      * Position types

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -2,15 +2,7 @@
 
 namespace App\Models;
 
-use App\Helpers\SqlHelper;
-
 use App\Lib\WorkSummary;
-
-use App\Models\ApiModel;
-use App\Models\Slot;
-
-use Carbon\Carbon;
-
 use Exception;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
@@ -125,10 +117,13 @@ class Schedule extends ApiModel
 
             // .. and find out which slots a person has signed up for
             if ($shiftsAvailable) {
-                $sql->join('person_position', function ($join) use ($personId) {
-                    $join->where('person_position.person_id', $personId)
-                        ->on('person_position.position_id', 'slot.position_id');
-                });
+                $sql = DB::table('person_position')
+                    ->join('slot', function ($join) use ($personId) {
+                        $join->where('person_position.person_id', $personId)
+                            ->on('person_position.position_id', 'slot.position_id');
+                    });
+            } else {
+                $sql = DB::table('slot');
             }
         }
 
@@ -600,7 +595,7 @@ class Schedule extends ApiModel
                 $logInfo['added'] = [];
                 $logInfo['removed'] = [];
 
-                if (!PersonSlot::where([ 'person_id' => $personId, 'slot_id' => $slotId])->exists()) {
+                if (!PersonSlot::where(['person_id' => $personId, 'slot_id' => $slotId])->exists()) {
                     // Indicate the person is no longer signed up
                     $logInfo['no_signup'] = true;
                 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Models\ApiModel;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use InvalidArgumentException;
 use RuntimeException;
@@ -135,6 +134,12 @@ class Setting extends ApiModel
             'type' => self::TYPE_URL
         ],
 
+        'HQWindowInterfaceEnabled' => [
+            'description' => 'Enable the HQ Window Interface (normally enabled during the event)',
+            'type' => self::TYPE_BOOL,
+            'default' => true,
+        ],
+
         'GeneralSupportEmail' => [
             'description' => 'General Ranger Email Address',
             'type' => self::TYPE_EMAIL,
@@ -181,8 +186,9 @@ class Setting extends ApiModel
         ],
 
         'OnlineTrainingDisabledAllowSignups' => [
-            'description' => 'Enable shift signups even if Online Training is disabled',
+            'description' => 'Enable shift signups even if Online Training is disabled (VERY DANGEROUS)',
             'type' => self::TYPE_BOOL,
+            'default' => false,
         ],
 
         'OnlineTrainingOnlyForAuditors' => [

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -91,6 +91,12 @@ class Timesheet extends ApiModel
             if ($model->person && $model->person->status == Person::NON_RANGER) {
                 $model->is_non_ranger = true;
             }
+
+            if (in_array($model->position_id, Position::ONE_POSITIONS)) {
+                // Force all ONE positions to be non-ranger volunteer entries.
+                // TODO: Remove post ONE.
+                $model->is_non_ranger = true;
+            }
         });
     }
 

--- a/app/Policies/AlertPolicy.php
+++ b/app/Policies/AlertPolicy.php
@@ -13,7 +13,7 @@ class AlertPolicy
 
     public function before($user)
     {
-        if ($user->hasRole(Role::ADMIN)) {
+        if ($user->hasRole(Role::TECH_NINJA)) {
             return true;
         }
     }

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -13,7 +13,7 @@ class PositionPolicy
 
     public function before($user)
     {
-        if ($user->hasRole(Role::ADMIN)) {
+        if ($user->hasRole(Role::TECH_NINJA)) {
             return true;
         }
     }
@@ -74,7 +74,7 @@ class PositionPolicy
 
     public function sandmanQualified(Person $user): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return $user->hasRole([ Role::ADMIN, Role::MANAGE]);
     }
 
     /**
@@ -86,7 +86,7 @@ class PositionPolicy
 
     public function sanityChecker(Person $user): bool
     {
-        return $user->hasRole([Role::MANAGE, Role::GRANT_POSITION]);
+        return $user->hasRole([ Role::ADMIN, Role::MANAGE, Role::GRANT_POSITION]);
     }
 
     /**
@@ -98,7 +98,7 @@ class PositionPolicy
     public function repair(Person $user): bool
     {
         // Only admins & Gran Positions are allowed to run it.
-        return $user->hasRole(Role::GRANT_POSITION);
+        return $user->hasRole([ Role::ADMIN, Role::GRANT_POSITION]);
     }
 
     /**
@@ -109,7 +109,7 @@ class PositionPolicy
 
     public function bulkGrantRevoke(Person $user): bool
     {
-        // Only admins & are allowed to run it.
-        return false;
+        // Only admins are allowed to run it.
+        return $user->hasRole(Role::ADMIN);
     }
 }

--- a/tests/Feature/PositionControllerTest.php
+++ b/tests/Feature/PositionControllerTest.php
@@ -65,7 +65,7 @@ class PositionControllerTest extends TestCase
 
     public function testCreatePosition()
     {
-        $this->addRole(Role::ADMIN);
+        $this->addRole(Role::TECH_NINJA);
         $data = [
             'title' => 'Gerlach Pizza Patrol',
             'short_title' => 'PIZZA',
@@ -87,7 +87,7 @@ class PositionControllerTest extends TestCase
 
     public function testUpdatePosition()
     {
-        $this->addRole(Role::ADMIN);
+        $this->addRole(Role::TECH_NINJA);
         $position = Position::factory()->create();
 
         $response = $this->json('PATCH', "position/{$position->id}", [
@@ -105,7 +105,7 @@ class PositionControllerTest extends TestCase
 
     public function testDeletePosition()
     {
-        $this->addRole(Role::ADMIN);
+        $this->addRole(Role::TECH_NINJA);
         $position = Position::factory()->create();
         $positionId = $position->id;
 
@@ -120,7 +120,7 @@ class PositionControllerTest extends TestCase
 
     public function testSandmanQualificationReport()
     {
-        $this->addRole(Role::ADMIN);
+        $this->addRole(Role::MANAGE);
 
         $sandmanTraining = Slot::factory()->create([
             'description' => 'Stop that runner',


### PR DESCRIPTION
- Position, RBS Alerts, and Role modifications require the Tech Ninja role.
- Bypass training checks for O.N.E positions
- New HQWindowInterfaceEnabled setting (for web client, no effect on backend operations.)
- Force all timesheet ONE position entries to be marked as  non-ranger volunteer to avoid inclusion in service years and other related things.