### PR TITLE
Scheduling work.

### DIFF
--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -251,7 +251,7 @@ class TimesheetController extends ApiController
 
         if ($timesheet->isDirty('position_id')) {
             // Find new sign up to associate with
-            $timesheet->slot_id = Schedule::findSlotSignUpByPositionTime($timesheet->person_id, $timesheet->position_id, $timesheet->on_duty);
+            $timesheet->slot_id = Schedule::findSlotIdSignUpByPositionTime($timesheet->person_id, $timesheet->position_id, $timesheet->on_duty);
         }
 
         $auditColumns = [];
@@ -353,7 +353,7 @@ class TimesheetController extends ApiController
         $oldPositionId = $timesheet->position_id;
         $timesheet->position_id = $positionId;
         // Find new sign up to associate with
-        $timesheet->slot_id = Schedule::findSlotSignUpByPositionTime($personId, $positionId, $timesheet->on_duty);
+        $timesheet->slot_id = Schedule::findSlotIdSignUpByPositionTime($personId, $positionId, $timesheet->on_duty);
         $timesheet->auditReason = 'position update while on duty';
         $timesheet->saveOrThrow();
 
@@ -427,12 +427,13 @@ class TimesheetController extends ApiController
         }
 
         $timesheet = new Timesheet($params);
+        $timesheet->setOnDutyToNow();
+
         if (!$timesheet->slot_id) {
             // Try to associate a slot with the sign on
-            $timesheet->slot_id = Schedule::findSlotSignUpByPositionTime($timesheet->person_id, $timesheet->position_id, $timesheet->on_duty);
+            $timesheet->slot_id = Schedule::findSlotIdSignUpByPositionTime($timesheet->person_id, $timesheet->position_id, $timesheet->on_duty);
         }
 
-        $timesheet->setOnDutyToNow();
         $timesheet->auditReason = 'sign in';
         if (!$timesheet->save()) {
             return $this->restError($timesheet);

--- a/app/Http/Controllers/TimesheetMissingController.php
+++ b/app/Http/Controllers/TimesheetMissingController.php
@@ -115,7 +115,7 @@ class TimesheetMissingController extends ApiController
 
                 if (!$timesheet->slot_id) {
                     // Try to associate a slot with the sign on
-                    $timesheet->slot_id = Schedule::findSlotSignUpByPositionTime($person->id, $timesheet->position_id, $timesheet->on_duty);
+                    $timesheet->slot_id = Schedule::findSlotIdSignUpByPositionTime($person->id, $timesheet->position_id, $timesheet->on_duty);
                 }
 
                 if (!$timesheet->save()) {

--- a/app/Lib/BulkSignInOut.php
+++ b/app/Lib/BulkSignInOut.php
@@ -424,7 +424,7 @@ class BulkSignInOut
 
             if (!$timesheet->slot_id) {
                 // Try to associate a sign up with the entry
-                $timesheet->slot_id = Schedule::findSlotSignUpByPositionTime($timesheet->person_id, $timesheet->position_id, $timesheet->on_duty);
+                $timesheet->slot_id = Schedule::findSlotIdSignUpByPositionTime($timesheet->person_id, $timesheet->position_id, $timesheet->on_duty);
             }
 
             $timesheet->auditReason = 'bulk sign in/out';

--- a/app/Lib/Milestones.php
+++ b/app/Lib/Milestones.php
@@ -121,7 +121,7 @@ class Milestones
                 // Full day's training required, and walk a cheetah shift.
                 $milestones['needs_full_training'] = true;
                 $milestones['is_cheetah_cub'] = true;
-                $cheetah = Schedule::findEnrolledSlotIds($person->id, $year, Position::CHEETAH_CUB)->last();
+                $cheetah = Schedule::findEnrolledSlots($person->id, $year, Position::CHEETAH_CUB)->last();
                 if ($cheetah) {
                     $milestones['cheetah_cub_shift'] = [
                         'slot_id' => $cheetah->id,

--- a/composer.lock
+++ b/composer.lock
@@ -114,16 +114,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.193.4",
+            "version": "3.194.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "758c2225c484088b2118c4e3ff5b37ccfea3948f"
+                "reference": "3b4787381bd747753059a223b801ea5eb7d11780"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/758c2225c484088b2118c4e3ff5b37ccfea3948f",
-                "reference": "758c2225c484088b2118c4e3ff5b37ccfea3948f",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3b4787381bd747753059a223b801ea5eb7d11780",
+                "reference": "3b4787381bd747753059a223b801ea5eb7d11780",
                 "shasum": ""
             },
             "require": {
@@ -199,9 +199,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.193.4"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.194.0"
             },
-            "time": "2021-09-14T18:19:00+00:00"
+            "time": "2021-09-16T18:16:59+00:00"
         },
         {
             "name": "brick/math",
@@ -8674,7 +8674,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-09-28T06:45:17+00:00"
         },
         {

--- a/tests/Feature/PersonScheduleControllerTest.php
+++ b/tests/Feature/PersonScheduleControllerTest.php
@@ -249,7 +249,7 @@ class PersonScheduleControllerTest extends TestCase
         $response->assertStatus(200);
 
         // Should match 6 shifts - 3 trainings and 3 dirt shift
-        $this->assertCount(6, $response->json()['schedules']);
+        $this->assertCount(6, $response->json()['slots']);
     }
 
 
@@ -259,9 +259,9 @@ class PersonScheduleControllerTest extends TestCase
 
     public function testDoNotFindAnyShiftsForYear()
     {
-        $response = $this->json('GET', "person/{$this->user->id}/schedule", ['year' => $this->year, 'shifts_available' => 1]);
+        $response = $this->json('GET', "person/{$this->user->id}/schedule", ['year' => $this->year]);
         $response->assertStatus(200);
-        $response->assertJson(['schedules' => []]);
+        $response->assertJson(['slots' => []]);
     }
 
 


### PR DESCRIPTION
- Don't return person/X/schedule as a REST like resource since it's no longer treated as a pseudo-table on the front end.
- Renamed Schedule::findSlotSignUpByPositionTime to findSlotIdsSignUpByPositionTime
- Fixed a bug associating a shift sign in with a slot sign up.
- Warn if an about-to-start shift is not within 15 minutes of the current time. Used by the HQ Window Interface to assist workers in telling Rangers to go chill for a bit more before working.
- Added and/or updated existing phpdoc comments.
- Fixed a bug where a cheetah cub shift was not reported correctly to the dashboard.