### PR TITLE
Various bug fixes.

### DIFF
--- a/app/Console/Commands/ClubhouseGroundHogDayCommand.php
+++ b/app/Console/Commands/ClubhouseGroundHogDayCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
 
 class ClubhouseGroundHogDayCommand extends Command
 {
-    const GROUNDHOG_DATETIME = "2019-08-30 19:00:00";
+    const GROUNDHOG_DATETIME = "2019-08-30 17:50:00";
     const GROUNDHOG_DATABASE = "rangers_ghd";
 
     /**

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -101,7 +101,9 @@ class PersonController extends ApiController
 
                 if ($searchingForFKA) {
                     foreach ($person->formerlyKnownAsArray(true) as $fka) {
-                        if (stripos($fka, $query) !== false) {
+                        // Don't bother matching on the FKA if it already matches the beginning of the current callsign.
+                        // Helps with callsigns which were truncated (fka: doctor hubcap -> hubcap)
+                        if (stripos($fka, $query) !== false && stripos($person->callsign_normalized, $query) !== 0) {
                             $row['fka_match'] = $fka;
                             break;
                         }

--- a/app/Http/Controllers/PersonScheduleController.php
+++ b/app/Http/Controllers/PersonScheduleController.php
@@ -361,7 +361,7 @@ class PersonScheduleController extends ApiController
         $now = now();
         $year = $now->year;
 
-        list($rows, $positions) = Schedule::findForQuery($person->id, $year, ['remaining' => true]);
+        list($rows, $positions) = Schedule::findForQuery($person->id, $year, ['remaining' => true, 'only_signups' => true]);
 
         if (!$rows->isEmpty()) {
             // Warm the position credit cache.

--- a/app/Http/Controllers/SmsController.php
+++ b/app/Http/Controllers/SmsController.php
@@ -269,7 +269,7 @@ class SmsController extends ApiController
         $person = Person::where('sms_on_playa', $number)->orWhere('sms_off_playa', $number)->first();
         if (!$person) {
             // Who are you?
-            $reply = "Hello from the Ranger Clubhouse Bot. Sorry, your phone number cannot be found in our database. Contact rangers@burningman.org for help.";
+            $reply = "Hello from the Black Rock Ranger Clubhouse Bot. Sorry, your phone number cannot be found in the database. Contact rangers@burningman.org for help.";
             BroadcastMessage::record(null, Broadcast::STATUS_UNKNOWN_PHONE, null, 'sms', $number, 'inbound', $message);
             return SMSService::replyResponse($reply);
         }
@@ -280,7 +280,7 @@ class SmsController extends ApiController
 
 
         switch (strtolower(trim($message))) {
-        // The industry recongized stop-talking-to-me-damn-you commands.
+        // The industry recognized stop-talking-to-me-damn-you commands.
         case 'stop':
         case 'quit':
         case 'cancel':

--- a/app/Lib/RedactDatabase.php
+++ b/app/Lib/RedactDatabase.php
@@ -48,7 +48,6 @@ class RedactDatabase {
             'access_document_changes',
             'access_document_delivery',
             'access_document',
-            'action_logs',
             'broadcast_message',
             'broadcast',
             'contact_log',
@@ -66,6 +65,7 @@ class RedactDatabase {
             DB::statement("TRUNCATE $table");
         }
 
+        DB::delete("DELETE FROM action_logs WHERE event not in ('person-slot-add', 'person-slot-remove')");
         // Zap all the Clubhouse message archives including the current table
         $rows = DB::select('SHOW TABLES LIKE "person_message%"');
         foreach($rows as $row)

--- a/app/Models/Bmid.php
+++ b/app/Models/Bmid.php
@@ -487,6 +487,6 @@ class Bmid extends ApiModel
     public function effectiveMeals(): string
     {
         $meals = $this->buildMealsMatrix();
-        return count($meals) == 3 ? Bmid::MEALS_ALL : implode('+', $meals);
+        return count($meals) == 3 ? Bmid::MEALS_ALL : implode('+', array_keys($meals));
     }
 }

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -88,9 +88,10 @@ class Schedule extends ApiModel
     {
         $now = (string)now();
         $onlySignups = $query['only_signups'] ?? false;
+        $remaining = $query['remaining'] ?? false;
 
         $selectColumns = [
-            'slot.id as id',
+            DB::raw('DISTINCT slot.id as id'),
             'slot.position_id as position_id',
             'slot.begins AS slot_begins',
             'slot.ends AS slot_ends',
@@ -127,6 +128,11 @@ class Schedule extends ApiModel
                 $join->where('person_position.person_id', $personId)
                     ->on('person_position.position_id', 'slot.position_id');
             })->whereRaw('(person_slot.person_id IS NOT NULL OR person_position.person_id IS NOT NULL)');
+        }
+
+        if ($remaining) {
+            // Include slots already started but have not ended.
+            $sql->where('slot.ends', '>=', now());
         }
 
         $rows = $sql->get();


### PR DESCRIPTION
- Save person-slot-{add,remove} events in the action log when creating a redacted database so the schedule log works.
- Don't mark a callsign search result as matching the fka if the query matches the beginnning of the callsign. Helps to reduce noise on the search bar with truncated callsigns (e.g. doctor hubcap -> hubcap).
- Fixed schedule credit estimates. All possible shifts were being scanned and not just the signed up shifts.
- Fixed BMID meals reporting