### PR TITLE
Various bug fixes.

### DIFF
--- a/app/Lib/Reports/ShiftCoverageReport.php
+++ b/app/Lib/Reports/ShiftCoverageReport.php
@@ -74,7 +74,6 @@ class ShiftCoverageReport
         [ Position::RSCI_MENTEE, 'RSCIM', self::CALLSIGNS ],
         [ Position::RSC_WESL, 'WESL', self::CALLSIGNS ],
         [ Position::OPERATOR, 'Opr', self::CALLSIGNS ],
-        [ Position::RSC_WESL, 'WESL', self::CALLSIGNS ],
         [ [ Position::TROUBLESHOOTER, Position::TROUBLESHOOTER_MENTEE ], 'TS', self::CALLSIGNS, [ Position::TROUBLESHOOTER_MENTEE => 'Mentee' ] ],
         [ [ Position::LEAL, Position::LEAL_PARTNER ], 'LEAL', self::CALLSIGNS, [ Position::LEAL_PARTNER => 'Partner' ] ],
         [ [ Position::GREEN_DOT_LEAD, Position::GREEN_DOT_LEAD_INTERN ], 'GDL', self::CALLSIGNS, [ Position::GREEN_DOT_LEAD_INTERN => 'Intern' ] ],

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -215,8 +215,8 @@ class Position extends ApiModel
     const UNQUALIFIED_UNTRAINED = 'untrained';
 
     const UNQUALIFIED_MESSAGES = [
-        self::UNQUALIFIED_UNSIGNED_SANDMAN_AFFIDAVIT => 'no signed Sandman affidavit',
-        self::UNQUALIFIED_NO_BURN_PERIMETER_EXP => 'no Burn Perimeter experience',
+        self::UNQUALIFIED_UNSIGNED_SANDMAN_AFFIDAVIT => 'Sandman Affidavit not signed',
+        self::UNQUALIFIED_NO_BURN_PERIMETER_EXP => 'No Burn Perimeter experience',
         self::UNQUALIFIED_UNTRAINED => 'Not trained',
     ];
 

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -513,15 +513,14 @@ class Schedule extends ApiModel
     public static function summarizeShiftSignups(Person $person): array
     {
         $year = current_year();
-        list ($rows, $positions) = self::findForQuery($person->id, $year);
+        list ($rows, $positions) = self::findForQuery($person->id, $year, [ 'only_signups' => true]);
 
         $positionsById = [];
         foreach ($positions as $position) {
-            $positionById[$position->id] = $position;
+            $positionsById[(int)$position->id] = $position;
         }
-
         $rows = $rows->filter(function ($r) use ($positionsById) {
-            return $positionsById[$r->position_id]->type != Position::TYPE_TRAINING;
+            return $positionsById[(int)$r->position_id]->type != Position::TYPE_TRAINING;
         });
 
         if (!$rows->isEmpty()) {


### PR DESCRIPTION
- Removed duplicate WESL columns from the Shift Coverage report.
- Tweaked unqualified shift check-in texts.
- Schedule::summarizeShiftSignups was pulling in all potential shifts, not the signed-up-for shifts.