### PR TITLE
Spelling: s/Exodous/Exodus/

### DIFF
--- a/app/Lib/ReservedCallsigns.php
+++ b/app/Lib/ReservedCallsigns.php
@@ -142,7 +142,7 @@ class ReservedCallsigns
         'Double Oh Seven',
         'E S D',
         'Echelon', 'Eschelon',
-        'Exodous',
+        'Exodus',
         'Gate',
         'Green Dot',
         'Greeters',


### PR DESCRIPTION
As pointed out by Threepio