### PR TITLE
BMID Sanity Checker fixes.

### DIFF
--- a/app/Lib/GrantPasses.php
+++ b/app/Lib/GrantPasses.php
@@ -84,7 +84,7 @@ class GrantPasses
     public static function grantWAPsToRangers(): mixed
     {
         $people = self::findRangersWhoNeedWAPs();
-        self::grantAccessDocumentToPeople($people, AccessDocument::WAP, null, current_year());
+        self::grantAccessDocumentToPeople($people, AccessDocument::WAP, setting('TAS_DefaultWAPDate'), current_year());
 
         return $people;
     }

--- a/app/Models/AccessDocument.php
+++ b/app/Models/AccessDocument.php
@@ -556,10 +556,13 @@ class AccessDocument extends ApiModel
      * Add a comment to the comments column.
      */
 
-    public function addComment($comment, $callsign)
+    public function addComment($comment, $user)
     {
+        if ($user instanceof Person) {
+            $user = $user->callsign;
+        }
         $date = date('n/j/y G:i:s');
-        $this->comments = "$date $callsign: $comment\n{$this->comments}";
+        $this->comments = "$date $user: $comment\n{$this->comments}";
     }
 
     /**


### PR DESCRIPTION
- Scan ALL access documents when trying to determine if a person's shift starts before an access document. Claim or Submitted WAP / SC takes precedences
- Include a reason why the checker was triggered
- Exclude auditors and past prospectives.