### PR TITLE
Ticketing fixes, Marcato Exports tweaks, and other stuff.

### DIFF
--- a/app/Console/Commands/ClubhouseGroundHogDayCommand.php
+++ b/app/Console/Commands/ClubhouseGroundHogDayCommand.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\DB;
 
 class ClubhouseGroundHogDayCommand extends Command
 {
-    const GROUNDHOG_DATETIME = "2019-08-30 17:50:00";
     const GROUNDHOG_DATABASE = "rangers_ghd";
 
     /**
@@ -52,12 +51,12 @@ class ClubhouseGroundHogDayCommand extends Command
 
     public function handle(): bool
     {
-        $groundHogDay = Carbon::parse($this->option('day') ?? self::GROUNDHOG_DATETIME);
+        $groundHogDay = Carbon::parse($this->option('day') ?? ((date('Y') - 1) . '-08-30 18:00:00'));
         $ghdname = $this->option('tempdb') ?? self::GROUNDHOG_DATABASE;
         $noRedact = $this->option('no-redact') ?? false;
 
         $year = $groundHogDay->year;
-        $dumpDate = $groundHogDay->format('YYYY-MM-DD');
+        $dumpDate = $groundHogDay->format('Y-m-d');
 
         // The current database is the Ground Hog Day database.
         // Create the groundhog day database

--- a/app/Lib/TicketingStatistics.php
+++ b/app/Lib/TicketingStatistics.php
@@ -26,7 +26,6 @@ class TicketingStatistics
 
             'people_tickets_submitted' => AccessDocument::where('status', AccessDocument::SUBMITTED)
                 ->whereIn('type', AccessDocument::TICKET_TYPES)
-                ->whereRaw("NOT EXISTS (select 1 from access_document as claimed WHERE claimed.person_id=access_document.person_id and (claimed.status='claimed' or claimed.status = 'banked') LIMIT 1)")
                 ->distinct()
                 ->count('access_document.person_id'),
 

--- a/app/Models/Bmid.php
+++ b/app/Models/Bmid.php
@@ -559,7 +559,19 @@ class Bmid extends ApiModel
         return self::sortMeals($this->buildMealsMatrix());
     }
 
-    public static function sortMeals($meals)
+    public function effectiveShowers(): bool
+    {
+        return $this->showers || $this->allocated_showers || $this->earned_showers;
+    }
+
+    /**
+     * Sort the meals into the expected order: pre-event, event, and post-event weeks.
+     *
+     * @param $meals
+     * @return string
+     */
+
+    public static function sortMeals($meals): string
     {
         if (count($meals) == 3) {
             return self::MEALS_ALL;

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -444,7 +444,7 @@ class Setting extends ApiModel
 
         'TAS_PayByDateTime' => [
             'description' => 'The date and time items have to be paid for. Shown on the Ticketing is closed page',
-            'type' => self::TYPE_STRING,
+            'type' => self::TYPE_DATETIME,
         ],
 
         'TAS_Pickup_Locations' => [


### PR DESCRIPTION
- Fixed submitted count on ticketing stats api.
- Consume all meal allocations if meals are explicitly set or have any meal allocations (not grants)
- Shower export comment was include all possible sources (qualified, allocated, set), only the first one.
- WAP source was only using the first submitted or claimed doc, and not finding the most appropriate one. (i.e. SC + separate WAP with a date earlier than the SC).