### PR TITLE
MailSentListener: enhance the email regex a bit

### DIFF
--- a/app/Listeners/MailSentListener.php
+++ b/app/Listeners/MailSentListener.php
@@ -31,7 +31,7 @@ class MailSentListener
         foreach ($email->getTo() as $to) {
             $toEmail = $to->getAddress();
             // Don't bother looking up team/cadre mailing lists emails.
-            if (!preg_match('/^ranger-(.*)-(list|cadre|team)@.*burningman\.(com|org)$/i', $toEmail)) {
+            if (!preg_match('/^rangers?-[^@]*-(list|cadre|team)@([^@]*\.)?burningman\.(com|org)$/i', $toEmail)) {
                 $personId = Person::findByEmail($toEmail)?->id;
             } else {
                 $personId = null;


### PR DESCRIPTION
My eyes are always triggered when I see potential catastrophic backtracking situations (e.g. having multiple ".*" in one regex which can overlap), hence I add the "not @" requirement to limit that.

Also this stops "thisisntburningman.com" from erroneously matching, and it allows for plural "rangers" as a prefix, as we have for the tech team (and maybe any other groups?)

Example and a few unit tests here: https://regex101.com/r/SPJtyu/2