### PR TITLE
Radio Eligibility Report API adjustments

### DIFF
--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -695,7 +695,7 @@ class TimesheetController extends ApiController
         $this->authorize('radioEligibilityReport', [Timesheet::class]);
         $year = $this->getYear();
 
-        return response()->json(['people' => RadioEligibilityReport::execute($year)]);
+        return response()->json(RadioEligibilityReport::execute($year));
     }
 
     /**

--- a/app/Lib/RedactDatabase.php
+++ b/app/Lib/RedactDatabase.php
@@ -56,7 +56,6 @@ class RedactDatabase
         $tables = [
 //            'access_document',
             'access_document_changes',
-            'access_document_delivery',
             'broadcast_message',
             'broadcast',
             'contact_log',

--- a/php-inis/xdebug.ini
+++ b/php-inis/xdebug.ini
@@ -10,7 +10,7 @@
 # Change the path to whats appropriate for your development environment.
 
 [xdebug]
-zend_extension=/opt/homebrew/Cellar/php/8.1.11/pecl/20210902/xdebug.so
+zend_extension=/opt/homebrew/Cellar/php/8.1.13/pecl/20210902/xdebug.so
 #xdebug.mode = profile
 xdebug.mode=debug
 xdebug.client_host=127.0.0.1


### PR DESCRIPTION
- Report on the last 3 events as per policy, not just the last 2.
- Return the years being reported on.
- Indicate what Shift Lead positions are being considered.