### PR TITLE
Fixed provisions clean up.

### DIFF
--- a/app/Http/Controllers/ProvisionController.php
+++ b/app/Http/Controllers/ProvisionController.php
@@ -149,6 +149,7 @@ class ProvisionController extends ApiController
 
         $user = $this->user->callsign;
         $rows = Provision::where('is_allocated', false)
+            ->whereIn('status', [ Provision::AVAILABLE, Provision::CLAIMED, Provision::SUBMITTED])
             ->with('person:id,callsign,status')
             ->get();
 
@@ -181,7 +182,7 @@ class ProvisionController extends ApiController
 
         foreach ($rows as $prov) {
             if ($prov->status == Provision::AVAILABLE) {
-                if (!$prov->type == Provision::EVENT_RADIO) {
+                if ($prov->type != Provision::EVENT_RADIO) {
                     // Other available provisions can be rolled over to the next event.
                     continue;
                 }

--- a/app/Policies/ProvisionPolicy.php
+++ b/app/Policies/ProvisionPolicy.php
@@ -86,7 +86,7 @@ class ProvisionPolicy
      * @return false
      */
 
-    public function bulkComment(Person $user)
+    public function bulkComment(Person $user): bool
     {
         return false;
     }

--- a/tests/Feature/ProvisionControllerTest.php
+++ b/tests/Feature/ProvisionControllerTest.php
@@ -162,23 +162,25 @@ class ProvisionControllerTest extends TestCase
     public function testCleanProvisionsFromPriorEvent()
     {
         $this->addAdminRole();
-
         $year = date('Y');
 
-        $person = Person::factory()->create();
+        $personA = Person::factory()->create();
+        $personB = Person::factory()->create();
 
         $submitted = Provision::factory()->create([
-            'person_id' => $person->id,
+            'person_id' => $personA->id,
             'source_year' => $year,
             'type' => Provision::ALL_EAT_PASS,
             'status' => Provision::SUBMITTED,
+            'is_allocated' => false,
         ]);
 
         $banked = Provision::factory()->create([
-            'person_id' => $person->id,
+            'person_id' => $personB->id,
             'source_year' => $year,
             'type' => Provision::WET_SPOT,
             'status' => Provision::BANKED,
+            'is_allocated' => false,
         ]);
 
         $response = $this->json('POST', 'provision/clean-provisions');
@@ -195,6 +197,7 @@ class ProvisionControllerTest extends TestCase
         $this->assertDatabaseHas('provision', ['id' => $submitted->id, 'status' => Provision::USED]);
         $this->assertDatabaseHas('provision', ['id' => $banked->id, 'status' => Provision::BANKED]);
 
+        $person = Person::factory()->create();
         $qualified = Provision::factory()->create([
             'person_id' => $person->id,
             'source_year' => $year,
@@ -202,6 +205,7 @@ class ProvisionControllerTest extends TestCase
             'status' => Provision::AVAILABLE,
             'is_allocated' => true,
         ]);
+
         $response = $this->json('POST', 'provision/clean-provisions');
         $response->assertStatus(200);
 
@@ -212,6 +216,7 @@ class ProvisionControllerTest extends TestCase
                 'status' => Provision::EXPIRED
             ]
         ]]);
+
         $this->assertDatabaseHas('provision', ['id' => $qualified->id, 'status' => Provision::EXPIRED]);
     }
 


### PR DESCRIPTION
- Look at Event Radios with status available and see if the person worked or checked out a radio. Mark as used if so.
- The type column was being used instead of status. (major d'oh!)
- Mark an allocated provision as used if the person had a submitted BMID.