### PR TITLE
Per TA & council manager request, allow Training role to sign up trainees.

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -98,7 +98,7 @@ class ApiController extends Controller
     }
 
     /**
-     * Does the user hold the role or roles?
+     * Does the user hold the effective role or roles?
      *
      * @param $roles
      * @return bool
@@ -112,6 +112,23 @@ class ApiController extends Controller
 
         return $this->user->hasRole($roles);
     }
+
+    /**
+     * Does the user hold the true role or roles?
+     *
+     * @param $roles
+     * @return bool
+     */
+
+    public function userHasTrueRole($roles): bool
+    {
+        if (!$this->user) {
+            return false;
+        }
+
+        return $this->user->hasTrueRole($roles);
+    }
+
 
     /**
      * Load a model record using a filter

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -539,6 +539,7 @@ class PersonController extends ApiController
             'status' => $person->status,
             'bpguid' => $person->bpguid,
             'roles' => $person->roles,
+            'true_roles' => $person->trueRoles,
             'teacher' => [
                 'is_trainer' => $person->hasRole([Role::ADMIN, Role::TRAINER]),
                 'is_art_trainer' => $isArtTrainer,

--- a/app/Http/Controllers/PersonScheduleController.php
+++ b/app/Http/Controllers/PersonScheduleController.php
@@ -451,11 +451,12 @@ class PersonScheduleController extends ApiController
      *
      * - Admins are allowed
      * - ART Trainers (role) are allowed for any ART training
-     * - Trainers (role) are only allowed to remove people, not sign up (per 2020 TA request)
+     * - Trainers (effective role) are only allowed to remove people, not sign up (per 2020 TA request)
+     * - Trainers (true role) are allowed to force sign up trainees to dirt trainings.
      *
      * @param Slot $slot
-     * @param bool $isSignup true if check for a sign up, false for a removal
-     * @return array
+     * @param bool $isSignup true if is a sign-up, otherwise a removal.
+     * @return array<bool,bool>
      */
 
     private function canForceScheduleChange(Slot $slot, bool $isSignup = true): array
@@ -467,10 +468,18 @@ class PersonScheduleController extends ApiController
             if ($slot->isArt()) {
                 $roleCanForce = Role::ART_TRAINER;
                 $isTrainer = true;
-            } else if (!$isSignup) {
+            } else if ($isSignup) {
                 /*
-                 * Per request from TA 2020 - Dirt Trainers may NOT manually add students BUT
-                 * are allowed to remove students.
+                 * Per TA 2023 - T.A. cadre members now only have the Trainer role, all other trainers have Training Seasonal.
+                 * Allow the real Training role to force add trainees.
+                 */
+                if ($this->userHasTrueRole(Role::TRAINER)) {
+                    return [true, true];
+                }
+            } else {
+                /*
+                 * Per request from TA 2020 - Dirt Trainers may NOT manually add trainees BUT
+                 * are allowed to remove trainees.
                  */
                 $roleCanForce = Role::TRAINER;
                 $isTrainer = true;


### PR DESCRIPTION
- Starting with the 2022 event, the T.A. has requested the Training role only be assigned to T.A. cadre members. All other eligible trainers will be given the Training Season role. This allows the Admin role to be deprecated in favor of the Training role for performing privileged Training interface actions (e.g., sign up trainees).
- The "true" (unadjusted/un-massaged) roles are being tracked. A new method, `$user->hasTrueRole()` checks for the unadjusted role grants. (e.g., we want to identify the explicitly granted Training role, and not the Training Seasonal role which masquerades as the Training role. hasRole(TRAINER) will be true, where as hasTrueRole(TRAINER) will be false.)