### PR TITLE
New Email address (change) history tracking. New person fuzzy search API.

### DIFF
--- a/app/Http/Controllers/EmailHistoryController.php
+++ b/app/Http/Controllers/EmailHistoryController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\EmailHistory;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+
+class EmailHistoryController extends ApiController
+{
+    /**
+     * Show a list of email history records
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function index(): JsonResponse
+    {
+        $this->authorize('index', EmailHistory::class);
+
+        $params = request()->validate([
+            'person_id' => 'required_without:email|integer|exists:person,id',
+            'email' => 'required_without:person_id|string',
+            'include_source_person' => 'sometimes|boolean',
+        ]);
+
+        return $this->success(EmailHistory::findForQuery($params), null, 'email_history');
+    }
+}

--- a/app/Lib/PersonSearch.php
+++ b/app/Lib/PersonSearch.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace App\Lib;
+
+use App\Helpers\SqlHelper;
+use App\Models\Person;
+use Closure;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+class PersonSearch
+{
+    const FIELD_CALLSIGN = 'callsign';
+    const FIELD_EMAIL = 'email';
+    const FIELD_OLD_EMAIL = 'old-email';
+    const FIELD_FKA = 'fka';
+    const FIELD_ID = 'id';
+    const FIELD_NAME = 'name';
+    const FIELD_LAST_NAME = 'last';
+
+    const BASE_COLUMNS = ['person.id', 'person.callsign', 'person.status', 'person.first_name', 'person.last_name'];
+
+    public array $results = [];
+    public int $limit;
+    public int $offset;
+    public string $query;
+    public ?string $statuses;
+    public ?string $excludeStatuses;
+
+    /**
+     * Perform a fuzzy search for a person based on the given query.
+     *
+     * @param array $query
+     * @param bool $canViewEmail
+     * @return array
+     */
+
+    public static function execute(array $query, bool $canViewEmail = false): array
+    {
+        // remove duplicate spaces
+        $q = trim(preg_replace('/\s+/', ' ', $query['query']));
+
+        if (empty($q)) {
+            return [];
+        }
+
+        if (str_starts_with($q, '+')) {
+            // Search by number
+            $person = DB::table('person')->select(self::BASE_COLUMNS)->where('id', ltrim($q, '+'))->first();
+            return [
+                [
+                    'field' => self::FIELD_ID,
+                    'total' => $person ? 1 : 0,
+                    'people' => $person ? [$person] : []
+                ]
+            ];
+        }
+
+        $search = new self();
+        $search->query = $q;
+        $search->statuses = $query['statuses'] ?? null;
+        $search->excludeStatuses = $query['exclude_statuses'] ?? null;
+        $search->offset = $query['offset'] ?? 0;
+        $search->limit = $query['limit'] ?? 10;
+
+        $searchFields = $query['search_fields'] ?? null;
+
+        $emailOnly = (stripos($q, '@') !== false);
+
+        if ($emailOnly && $canViewEmail) {
+            $search->searchEmail();
+            $search->searchOldEmail();
+        } else {
+            foreach (explode(',', $searchFields) as $field) {
+                switch ($field) {
+                    case self::FIELD_CALLSIGN:
+                        $search->searchCallsign();
+                        break;
+
+                    case self::FIELD_FKA:
+                        $search->searchFka();
+                        break;
+
+                    case self::FIELD_NAME:
+                        $search->searchName();
+                        break;
+
+                    case self::FIELD_LAST_NAME:
+                        $search->searchLastName();
+                        break;
+                }
+            }
+        }
+
+        return $search->results;
+    }
+
+    /**
+     * Search for Callsigns
+     */
+
+    public function searchCallsign(): void
+    {
+        $callsign = $this->query;
+        $sql = $this->baseSql();
+        $normalized = Person::normalizeCallsign($callsign);
+        $metaphone = metaphone(Person::spellOutNumbers($callsign));
+
+        $sql->where(function ($q) use ($normalized, $metaphone) {
+            $q->orWhere('callsign_normalized', $normalized);
+            $q->orWhere('callsign_normalized', 'like', '%' . $normalized . '%');
+            $q->orWhere('callsign_soundex', $metaphone);
+            $q->orWhere('callsign_soundex', 'like', $metaphone . '%');
+        });
+
+        /*
+         * Callsign sort priority is
+         * - Exact callsign match
+         * - Beginning of callsign match
+         * - Substring callsign match
+         * - Exact phonetic callsign match
+         * - Beginning of phonetic match
+         * - substring phonetic match
+         * - Everything else
+         */
+
+        $orderBy = "CASE";
+        $orderBy .= " WHEN callsign_normalized=" . SqlHelper::quote($normalized) . " THEN CONCAT('01', callsign)";
+        $orderBy .= " WHEN callsign_normalized like " . SqlHelper::quote($normalized . '%') . " THEN CONCAT('02', callsign)";
+        $orderBy .= " WHEN callsign_normalized like " . SqlHelper::quote('%' . $normalized . '%') . " THEN CONCAT('03', callsign)";
+        $orderBy .= " WHEN callsign_soundex=" . SqlHelper::quote($metaphone) . " THEN CONCAT('04', callsign)";
+        $orderBy .= " WHEN callsign_soundex like " . SqlHelper::quote($metaphone . '%') . " THEN CONCAT('05', callsign)";
+        $orderBy .= " WHEN callsign_soundex like " . SqlHelper::quote('%' . $metaphone . '%') . " THEN CONCAT('06', callsign)";
+        $orderBy .= " ELSE CONCAT('99', callsign) END";
+        $sql->orderBy(DB::raw($orderBy));
+
+        $this->addResult($this->runSql($sql, self::FIELD_CALLSIGN), ['callsign_normalized' => $normalized]);
+    }
+
+    /**
+     * Search for name. Search against "first last"* or "last"*.
+     */
+
+    public function searchName(): void
+    {
+        $name = $this->query;
+        $sql = $this->baseSql();
+
+        $likeName = SqlHelper::quote('%' . $name . '%');
+        $sql->where(function ($q) use ($likeName, $name) {
+            $q->whereRaw("CONCAT(first_name, ' ', last_name) LIKE " . $likeName);
+            $q->orWhere('last_name', 'like', $name . '%');
+        });
+
+        $likeLastName = SqlHelper::quote($name . '%');
+        $orderBy = "CASE";
+        $orderBy .= " WHEN CONCAT(first_name, ' ', last_name) LIKE " . $likeName . " THEN CONCAT('12', first_name, ' ', last_name)";
+        $orderBy .= " WHEN CONCAT(last_name) LIKE " . $likeLastName . " THEN CONCAT('11', 'last_name')";
+        $orderBy .= "ELSE CONCAT('99', callsign) END";
+        $sql->orderBy(DB::raw($orderBy));
+
+        $this->addResult($this->runSql($sql, self::FIELD_NAME));
+    }
+
+    /**
+     * Search on just the last name.
+     */
+
+    public function searchLastName(): void
+    {
+        $last = $this->query;
+        $sql = $this->baseSql();
+
+        $sql->where('last_name', 'like', $last . '%');
+        $sql->orderBy('last_name');
+
+        $this->addResult($this->runSql($sql, self::FIELD_LAST_NAME));
+    }
+
+
+    /**
+     * Search for Formerly Known As callsigns
+     */
+
+    public function searchFka(): void
+    {
+        $fka = $this->query;
+        $sql = $this->baseSql();
+
+        $sql->addSelect('formerly_known_as', 'callsign_normalized');
+        $sql->where('formerly_known_as', 'like', '%' . $fka . '%');
+        $sql->orderBy('callsign');
+
+        $result = $this->runSql($sql, self::FIELD_FKA, function ($person, &$result) use ($fka) {
+            foreach (Person::splitCommas($person->formerly_known_as) as $word) {
+                if (stripos($word, $fka) !== false) {
+                    $result['fka_match'] = $word;
+                    break;
+                }
+            }
+        });
+
+        $this->addResult($result);
+    }
+
+    /**
+     * For search for (current) emails.
+     */
+
+    public function searchEmail(): void
+    {
+        $sql = $this->baseSql(false);
+        $sql->where('email', $this->query);
+
+        $this->addResult(self::runSql($sql, self::FIELD_EMAIL));
+    }
+
+    /**
+     * For search for old emails - Ignore statuses filters.
+     */
+
+    public function searchOldEmail(): void
+    {
+        $sql = DB::table('email_history')
+            ->select(self::BASE_COLUMNS)
+            ->join('person', 'person.id', 'email_history.person_id')
+            ->where('email_history.email', $this->query)
+            ->orderBy('callsign');
+
+        $this->addResult(self::runSql($sql, self::FIELD_OLD_EMAIL));
+    }
+
+    /**
+     * Build up a base SQL query.
+     *
+     * @param bool $addStatuses
+     * @return Builder
+     */
+
+    public function baseSql(bool $addStatuses = true): Builder
+    {
+        $sql = DB::table('person')->select(self::BASE_COLUMNS);
+
+        if ($addStatuses) {
+            if ($this->statuses) {
+                $sql->whereIn('status', explode(',', $this->statuses));
+            }
+
+            if ($this->excludeStatuses) {
+                $sql->whereNotIn('status', explode(',', $this->excludeStatuses));
+            }
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Run the built-up query.
+     *
+     * @param Builder $sql
+     * @param string $field
+     * @param Closure|null $callback
+     * @return array
+     */
+
+    public function runSql(Builder $sql, string $field, ?Closure $callback = null): array
+    {
+        $total = $sql->count();
+        if ($total) {
+            $sql->limit($this->limit);
+            $sql->offset($this->offset);
+            $rows = $sql->get()->toArray();
+        } else {
+            $rows = [];
+        }
+
+        return [
+            'field' => $field,
+            'total' => $total,
+            'people' => array_map(function ($p) use ($callback) {
+                $result = [
+                    'id' => $p->id,
+                    'callsign' => $p->callsign,
+                    'status' => $p->status,
+                    'first_name' => $p->first_name,
+                    'last_name' => $p->last_name,
+                ];
+                if ($callback) {
+                    $callback($p, $result);
+                }
+                return $result;
+            }, $rows)
+        ];
+    }
+
+    /**
+     * Add the result to return. Skip if no records were found.
+     *
+     * @param array $result
+     * @param array|null $additional
+     * @return void
+     */
+
+    public function addResult(array $result, ?array $additional = null): void
+    {
+        if (!$result['total']) {
+            return;
+        }
+
+        if ($additional) {
+            $result = array_merge($result, $additional);
+        }
+
+        $this->results[] = $result;
+    }
+}

--- a/app/Models/EmailHistory.php
+++ b/app/Models/EmailHistory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EmailHistory extends ApiModel
+{
+    use HasFactory;
+
+    protected $table = 'email_history';
+    public $timestamps = true;
+
+    // Allow any fillable -- model is not directly accessible.
+    protected $guarded = [];
+
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public function source_person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    /**
+     * Retrieve email history records based on the given criteria.
+     *
+     * @param $query
+     * @return Collection
+     */
+
+    public static function findForQuery($query): Collection
+    {
+        $personId = $query['person_id'] ?? null;
+        $sourcePersonId = $query['source_person_id'] ?? null;
+        $email = $query['email'] ?? null;
+        $includeSource = $query['include_source_person'] ?? null;
+
+        $sql = self::query();
+
+        if ($personId) {
+            $sql->where('person_id', $personId);
+        }
+
+        if ($sourcePersonId) {
+            $sql->where('source_person_id', $personId);
+        }
+
+        if ($includeSource) {
+            $sql->with('source_person:id,callsign,status');
+        }
+
+        if ($email) {
+            $sql->where('email', $email);
+        }
+
+        return $sql->orderBy('created_at')->get();
+    }
+
+
+    public static function record(int $personId, string $email, ?int $sourcePersonId)
+    {
+        self::create([
+            'person_id' => $personId,
+            'email' => $email,
+            'source_person_id' => $sourcePersonId,
+        ]);
+    }
+}

--- a/app/Policies/EmailHistoryPolicy.php
+++ b/app/Policies/EmailHistoryPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Person;
+use App\Models\Role;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class EmailHistoryPolicy
+{
+    use HandlesAuthorization;
+
+    public function before($user)
+    {
+        if ($user->hasRole([Role::ADMIN, Role::VC, Role::VIEW_EMAIL])) {
+            return true;
+        }
+    }
+
+    /**
+     * Determine whether the user can see email histories.
+     *
+     * @param Person $user
+     * @return bool
+     */
+
+    public function index(Person $user): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/PersonPolicy.php
+++ b/app/Policies/PersonPolicy.php
@@ -12,14 +12,34 @@ class PersonPolicy
     use HandlesAuthorization;
 
     const AUTHORIZED_ROLES = [
-        Role::ADMIN, Role::MANAGE, Role::VC, Role::MENTOR, Role::TRAINER, Role::ART_TRAINER
+        Role::ADMIN,
+        Role::ART_TRAINER,
+        Role::MANAGE,
+        Role::MENTOR,
+        Role::TRAINER,
+        Role::VC,
     ];
 
-    /*
+    /**
      * Can the user view a bunch of people?
+     *
+     * @param Person $user
+     * @return bool
      */
 
     public function index(Person $user): bool
+    {
+        return $user->hasRole([ Role::ADMIN, Role::VC ]);
+    }
+
+    /**
+     * Can the user search for people?
+     *
+     * @param Person $user
+     * @return bool
+     */
+
+    public function search(Person $user) : bool
     {
         return $user->hasRole(self::AUTHORIZED_ROLES);
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -14,6 +14,7 @@ use App\Models\Award;
 use App\Models\Bmid;
 use App\Models\Broadcast;
 use App\Models\Document;
+use App\Models\EmailHistory;
 use App\Models\ErrorLog;
 use App\Models\EventDate;
 use App\Models\HandleReservation;
@@ -57,6 +58,7 @@ use App\Policies\AwardPolicy;
 use App\Policies\BmidPolicy;
 use App\Policies\BroadcastPolicy;
 use App\Policies\DocumentPolicy;
+use App\Policies\EmailHistoryPolicy;
 use App\Policies\ErrorLogPolicy;
 use App\Policies\EventDatePolicy;
 use App\Policies\HandleReservationPolicy;
@@ -111,6 +113,7 @@ class AuthServiceProvider extends ServiceProvider
         Bmid::class => BmidPolicy::class,
         Broadcast::class => BroadcastPolicy::class,
         Document::class => DocumentPolicy::class,
+        EmailHistory::class => EmailHistoryPolicy::class,
         ErrorLog::class => ErrorLogPolicy::class,
         EventDate::class => EventDatePolicy::class,
         HandleReservation::class => HandleReservationPolicy::class,

--- a/database/migrations/2023_01_20_165433_create_email_history.php
+++ b/database/migrations/2023_01_20_165433_create_email_history.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+
+    public function up(): void
+    {
+        Schema::create('email_history', function (Blueprint $table) {
+            $table->id();
+            $table->integer('person_id')->nullable(false);
+            $table->integer('source_person_id')->nullable(true);
+            $table->string('email')->nullable(false);
+            $table->index('person_id');
+            $table->index('source_person_id');
+            $table->index('email');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('email_history');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -132,6 +132,7 @@ Route::group([
     Route::get('language/speakers', 'LanguageController@speakers');
     Route::resource('language', 'LanguageController');
 
+    Route::get('email-history', 'EmailHistoryController@index');
     Route::delete('error-log/purge', 'ErrorLogController@purge');
     Route::resource('error-log', 'ErrorLogController', ['only' => 'index']);
 
@@ -191,6 +192,7 @@ Route::group([
     Route::get('person/by-status', 'PersonController@peopleByStatus');
     Route::get('person/by-status-change', 'PersonController@peopleByStatusChange');
     Route::post('person/bulk-lookup', 'PersonController@bulkLookup');
+    Route::get('person/search', 'PersonController@search');
 
     Route::get('person/{person}/alerts', 'AlertPersonController@index');
     Route::patch('person/{person}/alerts', 'AlertPersonController@update');


### PR DESCRIPTION
- New table email_history to track updates to an account's email address.
- New person/search api to replace the existing person/index api. New api breaks out the search results into different categories instead of mushing everything together. The changes are partly to support email history tracking and being able to search on up old email addresses in the search bar.