### PR TITLE
Factored out cache operations into ClubhouseCache.

### DIFF
--- a/app/Http/Controllers/PositionController.php
+++ b/app/Http/Controllers/PositionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Lib\BulkPositionGrantRevoke;
+use App\Lib\ClubhouseCache;
 use App\Lib\Reports\PeopleByPositionReport;
 use App\Lib\Reports\PeopleByTeamsReport;
 use App\Lib\Reports\SandmanQualificationReport;
@@ -10,18 +11,17 @@ use App\Models\Person;
 use App\Models\Position;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class PositionController extends ApiController
 {
     /**
-     * Display a listing of the resource.
+     * Show a lsit of positions
      *
      * @return JsonResponse
      */
 
-    public function index()
+    public function index(): JsonResponse
     {
         $params = request()->validate([
             'type' => 'sometimes|string',
@@ -50,12 +50,12 @@ class PositionController extends ApiController
             return $this->restError($position);
         }
 
-        Cache::flush();
+        ClubhouseCache::flush();
         return $this->success($position);
     }
 
     /**
-     * Display the specified resource.
+     * Show a position
      *
      * @param Position $position
      * @return JsonResponse
@@ -68,7 +68,7 @@ class PositionController extends ApiController
     }
 
     /**
-     * Update the specified resource in storage.
+     * Update a position
      *
      * @param Position $position
      * @return JsonResponse
@@ -85,12 +85,13 @@ class PositionController extends ApiController
             return $this->success($position);
         }
 
-        Cache::flush();
+        // Positions affect role permissions, dump the cache.
+        ClubhouseCache::flush();
         return $this->restError($position);
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Delete the position controller
      *
      * @param Position $position
      * @return JsonResponse
@@ -103,7 +104,7 @@ class PositionController extends ApiController
         $position->delete();
         DB::table('position_role')->where('position_id', $position->id)->delete();
         DB::table('person_position')->where('position_id', $position->id)->delete();
-        Cache::flush();
+        ClubhouseCache::flush();
         return $this->restDeleteSuccess();
     }
 

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -7,7 +7,7 @@ use App\Models\PersonRole;
 use App\Models\Role;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Cache;
+use Psr\SimpleCache\InvalidArgumentException;
 
 class RoleController extends ApiController
 {
@@ -112,7 +112,7 @@ class RoleController extends ApiController
      * Diagnostic function - Inspect the role cache for a person
      *
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|InvalidArgumentException
      */
 
     public function inspectCache(): JsonResponse
@@ -123,7 +123,7 @@ class RoleController extends ApiController
             'person_id' => 'integer|required|exists:person,id'
         ]);
 
-        $cached = Cache::get(PersonRole::getCacheKey($params['person_id']));
+        $cached = PersonRole::getCache($params['person_id']);
         if (!$cached) {
             return response()->json(['not_cached' => true]);
         }

--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Lib\ClubhouseCache;
 use App\Models\Role;
 use App\Models\Setting;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -81,7 +82,7 @@ class SettingController extends ApiController
         }
 
         // Dump the entire app cache just in case
-        Cache::flush();
+        ClubhouseCache::flush();
 
         Setting::setCached($setting->name, $setting->value);
         Setting::kickQueues();

--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Lib\ClubhouseCache;
 use App\Lib\Reports\PeopleByTeamsReport;
 use App\Models\PersonTeam;
 use App\Models\PersonTeamLog;
@@ -81,7 +82,7 @@ class TeamController extends ApiController
 
         if ($team->save()) {
             $team->loadRoles();
-            Cache::flush();
+            ClubhouseCache::flush();
             return $this->success($team);
         }
 
@@ -104,7 +105,7 @@ class TeamController extends ApiController
         PersonTeam::where('team_id', $team->id)->delete();
         PersonTeamLog::where('team_id', $team->id)->delete();
         TeamRole::where('team_id', $team->id)->delete();
-        Cache::flush();
+        ClubhouseCache::flush();
         return $this->restDeleteSuccess();
     }
 

--- a/app/Lib/ClubhouseCache.php
+++ b/app/Lib/ClubhouseCache.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Lib;
+
+use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Cache;
+use Psr\SimpleCache\InvalidArgumentException;
+
+class ClubhouseCache
+{
+
+    /**
+     * Retrieve the cache store -- use Octane for production, and the default for local (database) & testing (array).
+     *
+     * @return Repository
+     */
+
+    public static function store(): Repository
+    {
+        return Cache::store(app()->isProduction() ? 'octane' : config('cache.default'));
+    }
+
+    /**
+     * Put a cache entry
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+
+    public static function put(string $key, mixed $value): void
+    {
+        self::store()->put($key, $value);
+    }
+
+    /**
+     * Get a cache entry
+     *
+     * @param string $key
+     * @return mixed
+     * @throws InvalidArgumentException
+     */
+
+    public static function get(string $key): mixed
+    {
+        return self::store()->get($key);
+    }
+
+    /**
+     * Does the cache have a key?
+     *
+     * @param string $key
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+
+    public static function has(string $key): bool
+    {
+        return self::store()->has($key);
+    }
+
+    /**
+     * Delete a cache entry
+     *
+     * @param string $key
+     * @return void
+     */
+
+    public static function forget(string $key): void
+    {
+        self::store()->forget($key);
+    }
+
+    /**
+     * Flush/dump the entire cache
+     *
+     * @return void
+     */
+
+    public static function flush(): void
+    {
+        self::store()->flush();
+    }
+
+
+}

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -807,8 +807,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
             return;
         }
 
-        $cacheKey = PersonRole::getCacheKey($this->id);
-        $cachedRoles = Cache::get($cacheKey);
+        $cachedRoles = PersonRole::getCache($this->id);
         if ($cachedRoles) {
             $this->setCachedRoles($cachedRoles);
             return;
@@ -883,7 +882,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
 
         $this->roles = array_keys($this->rolesById);
         if (!$noCache) {
-            Cache::put($cacheKey, [$this->roles, $this->trueRoles]);
+            PersonRole::putCache($this->id, [$this->roles, $this->trueRoles]);
         }
     }
 

--- a/app/Models/PersonPosition.php
+++ b/app/Models/PersonPosition.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Lib\ClubhouseCache;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Auth;
@@ -175,7 +176,7 @@ class PersonPosition extends ApiModel
             }
         }
 
-        Cache::flush();
+        PersonRole::clearCache($personId);
     }
 
 
@@ -211,7 +212,7 @@ class PersonPosition extends ApiModel
             }
         }
 
-        Cache::flush();
+        PersonRole::clearCache($personId);
     }
 
     /**

--- a/app/Models/PersonRole.php
+++ b/app/Models/PersonRole.php
@@ -2,10 +2,10 @@
 
 namespace App\Models;
 
+use App\Lib\ClubhouseCache;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -14,9 +14,6 @@ use Illuminate\Support\Facades\DB;
  */
 class PersonRole extends ApiModel
 {
-
-    const CACHE_KEY = 'person-role-';
-
     protected $table = 'person_role';
 
     public function person(): BelongsTo
@@ -166,7 +163,7 @@ class PersonRole extends ApiModel
 
     public static function clearCache(int $personId): void
     {
-        Cache::forget(self::getCacheKey($personId));
+        ClubhouseCache::forget(self::cacheKey($personId));
     }
 
     /**
@@ -175,8 +172,32 @@ class PersonRole extends ApiModel
      * @return string
      */
 
-    public static function getCacheKey(int $personId): string
+    public static function cacheKey(int $personId): string
     {
-        return self::CACHE_KEY . $personId;
+        return 'person-role-' . $personId;
+    }
+
+    /**
+     * Obtain the cache roles for a person
+     *
+     * @param int $personId
+     * @return mixed
+     */
+
+    public static function getCache(int $personId): mixed
+    {
+        return ClubhouseCache::get(self::cacheKey($personId));
+    }
+
+    /**
+     * Put the cached roles for a person
+     *
+     * @param int $personId
+     * @param mixed $roles
+     */
+
+    public static function putCache(int $personId, mixed $roles): void
+    {
+        ClubhouseCache::put(self::cacheKey($personId), $roles);
     }
 }

--- a/app/Models/PositionRole.php
+++ b/app/Models/PositionRole.php
@@ -2,10 +2,10 @@
 
 namespace App\Models;
 
+use App\Lib\ClubhouseCache;
 use App\Traits\HasCompositePrimaryKey;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -76,8 +76,7 @@ class PositionRole extends ApiModel
      * @param ?string $reason
      */
 
-    public
-    static function add(int $positionId, int $roleId, ?string $reason): void
+    public static function add(int $positionId, int $roleId, ?string $reason): void
     {
         if ($roleId == Role::ADMIN || $roleId == Role::TECH_NINJA) {
             // Nope, don't allow unchecked privilege escalation.
@@ -86,7 +85,7 @@ class PositionRole extends ApiModel
 
         $data = ['position_id' => $positionId, 'role_id' => $roleId];
         if (self::insertOrIgnore($data) == 1) {
-            Cache::flush();
+            ClubhouseCache::flush();
             ActionLog::record(Auth::user(), 'position-role-add', $reason, $data);
         }
     }
@@ -99,12 +98,11 @@ class PositionRole extends ApiModel
      * @param string|null $reason
      */
 
-    public
-    static function remove(int $positionId, int $roleId, ?string $reason): void
+    public static function remove(int $positionId, int $roleId, ?string $reason): void
     {
         $data = ['position_id' => $positionId, 'role_id' => $roleId];
         self::where($data)->delete();
-        Cache::flush();
+        ClubhouseCache::flush();
         ActionLog::record(Auth::user(), 'position-role-remove', $reason, $data);
     }
 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Lib\ClubhouseCache;
 use Exception;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -773,17 +774,6 @@ class Setting extends ApiModel
         return $values;
     }
 
-    /**
-     * Clear the setting cache
-     *
-     * @return void
-     */
-
-    public static function clearCache()
-    {
-        self::cacheStore()->flush();
-    }
-
     public static function getCached($name, &$value, $type): bool
     {
         $cache = self::cacheStore();
@@ -802,7 +792,7 @@ class Setting extends ApiModel
 
     public static function cacheStore(): Repository
     {
-        return Cache::store(app()->isLocal() ? 'array' : config('cache.default'));
+        return app()->isLocal() ? Cache::store('array') : ClubhouseCache::store();
     }
 
     public static function storedOrDefault($row, $desc, bool $throwOnEmpty)

--- a/app/Models/TeamRole.php
+++ b/app/Models/TeamRole.php
@@ -2,10 +2,10 @@
 
 namespace App\Models;
 
+use App\Lib\ClubhouseCache;
 use App\Traits\HasCompositePrimaryKey;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class TeamRole extends ApiModel
@@ -61,7 +61,7 @@ class TeamRole extends ApiModel
 
         $data = ['team_id' => $teamId, 'role_id' => $roleId];
         if (self::insertOrIgnore($data) == 1) {
-            Cache::flush();
+            ClubhouseCache::flush();
             ActionLog::record(Auth::user(), 'team-role-add', $reason, $data);
         }
     }
@@ -79,7 +79,7 @@ class TeamRole extends ApiModel
     {
         $data = ['team_id' => $teamId, 'role_id' => $roleId];
         self::where($data)->delete();
-        Cache::flush();
+        ClubhouseCache::flush();
         ActionLog::record(Auth::user(), 'team-role-remove', $reason, $data);
     }
 }

--- a/config/cache.php
+++ b/config/cache.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    // The database is used for development, and
+    // Leave as database so schedule-only-once can work
     'default' => env('CACHE_DRIVER', 'database'),
 
     /*

--- a/tests/Feature/RoleOperationTest.php
+++ b/tests/Feature/RoleOperationTest.php
@@ -48,7 +48,7 @@ class RoleOperationTest extends TestCase
         $response = $this->get('/person/' . $this->user->id);
         $response->assertStatus(200);
 
-        $cachedRoles = Cache::get(PersonRole::getCacheKey($this->user->id));
+        $cachedRoles = PersonRole::getCache($this->user->id);
         $this->assertNotNull($cachedRoles);
 
         list ($effectiveRoles, $trueRoles) = $cachedRoles;


### PR DESCRIPTION
The laravel scheduler wants a persistent external cache like a database or Redis to prevent duplicate task executions. There appears not to be a way to configure the scheduler to use a different cache store other than the default. Because of this, the Clubhouse has use an explicitly defined store (Octane -- a super fast in-app ephemeral cache). The default cache cannot be set to Octane. Sigh.