### PR TITLE
Track who actually checked in & out an asset.

### DIFF
--- a/app/Helpers/GlobalHelpers.php
+++ b/app/Helpers/GlobalHelpers.php
@@ -68,7 +68,7 @@ if (!function_exists('mail_to')) {
 }
 
 if (!function_exists('mail_to_person')) {
-    function mail_to_person(Person $person, Mailable $message, bool $queueMail = false)
+    function mail_to_person(Person $person, Mailable $message, bool $queueMail = false): bool
     {
         return mail_to($person->email, $message, $queueMail, $person->id);
     }

--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -163,6 +163,7 @@ class AssetController extends ApiController
             'attachment_id' => $params['attachment_id'] ?? null,
             'checked_out' => now(),
             'person_id' => $params['person_id'],
+            'check_out_person_id' => $this->user->id,
         ]);
 
         if (!$row->save()) {
@@ -189,6 +190,7 @@ class AssetController extends ApiController
         }
 
         $asset_person->checked_in = now();
+        $asset_person->check_in_person_id = $this->user->id;
 
         if (!$asset_person->save()) {
             return $this->restError($asset);

--- a/app/Http/Controllers/ProvisionController.php
+++ b/app/Http/Controllers/ProvisionController.php
@@ -206,6 +206,7 @@ class ProvisionController extends ApiController
             }
 
             $prov->status = Provision::USED;
+            $prov->consumed_year = maintenance_year();
             $prov->addComment($reason, $user);
             $prov->auditReason = $reason;
             $this->saveProvision($prov, $provisions);
@@ -230,6 +231,7 @@ class ProvisionController extends ApiController
         foreach ($rows as $row) {
             if ($bmids->has($row->person_id) || $row->status == Provision::SUBMITTED || $row->status == Provision::CLAIMED) {
                 $row->status = Provision::USED;
+                $row->consumed_year = maintenance_year();
                 $row->addComment($reasonUsed, $user);
                 $row->auditReason = $reasonUsed;
             } else {
@@ -403,6 +405,7 @@ class ProvisionController extends ApiController
             // Mark the provision as used if the person has a printed BMID, or the provision was submitted or claimed
             if ($bmids->has($row->person_id) || $row->status == Provision::SUBMITTED || $row->status == Provision::CLAIMED) {
                 $row->status = Provision::USED;
+                $row->consumed_year = maintenance_year();
                 $row->addComment($reasonUsed, $user);
                 $row->auditReason = $reasonUsed;
             } else {
@@ -446,6 +449,9 @@ class ProvisionController extends ApiController
 
         foreach ($rows as $row) {
             $row->status = $status;
+            if ($status == Provision::CLAIMED) {
+                $row->consumed_year = current_year();
+            }
             $row->saveWithoutValidation();
         }
 

--- a/database/migrations/2023_02_26_173705_add_people_to_asset_person.php
+++ b/database/migrations/2023_02_26_173705_add_people_to_asset_person.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('asset_person', function (Blueprint $table) {
+            $table->integer('check_out_person_id')->nullable(true);
+            $table->integer('check_in_person_id')->nullable(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('asset_person', function (Blueprint $table)  {
+            $table->dropColumn([ 'check_out_person_id', 'check_in_person_id']);
+        });
+    }
+};

--- a/database/migrations/2023_02_27_095240_add_consumed_year_to_provision.php
+++ b/database/migrations/2023_02_27_095240_add_consumed_year_to_provision.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\Provision;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('provision', function (Blueprint $table) {
+            $table->integer('consumed_year')->nullable(true);
+        });
+
+        DB::table('provision')->where('status', Provision::USED)->update(['consumed_year' => 2022]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('provision', function (Blueprint $table) {
+            $table->dropColumn('consumed_year');
+        });
+    }
+};


### PR DESCRIPTION
- New column provision.consumed_year to track what year the provision was used.
- New columns asset_person.check_{in,out}_person_id to track who handed out and received the asset.
- Fixed the eligibility indicator on the radio check out report. (was using the only radio_eligibly table, not the new provision one) 