### PR TITLE
Rename schedule imminent endpoint to upcoming.

### DIFF
--- a/app/Http/Controllers/PersonScheduleController.php
+++ b/app/Http/Controllers/PersonScheduleController.php
@@ -336,20 +336,19 @@ class PersonScheduleController extends ApiController
     }
 
     /**
-     * Find one or more about to start shifts - used to suggest starting position.
+     * Find one or more about to start shifts and future shifts - used to suggest starting position and
+     * suggest marking a person off site.
      *
      * @param Person $person
      * @return JsonResponse
      * @throws AuthorizationException
      */
 
-    public function imminent(Person $person): JsonResponse
+    public function upcoming(Person $person): JsonResponse
     {
         $this->authorize('view', [Schedule::class, $person]);
 
-        return response()->json([
-            'slots' => Schedule::retrieveStartingSlotsForPerson($person->id)
-        ]);
+        return response()->json(Schedule::retrieveStartingSlotsForPerson($person->id));
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -212,7 +212,7 @@ Route::group([
     Route::get('person/{person}/timesheet-summary', 'PersonController@timesheetSummary');
     Route::get('person/{person}/schedule/permission', 'PersonScheduleController@permission');
     Route::get('person/{person}/schedule/recommendations', 'PersonScheduleController@recommendations');
-    Route::get('person/{person}/schedule/imminent', 'PersonScheduleController@imminent');
+    Route::get('person/{person}/schedule/upcoming', 'PersonScheduleController@upcoming');
     Route::get('person/{person}/schedule/expected', 'PersonScheduleController@expected');
     Route::get('person/{person}/schedule/summary', 'PersonScheduleController@scheduleSummary');
     Route::get('person/{person}/schedule/log', 'PersonScheduleController@scheduleLog');


### PR DESCRIPTION
- Include all future shifts, not just the imminent ones, and return the time parameters used to determine imminent and early starting shifts.