### PR TITLE
Salesforce import work.

### DIFF
--- a/app/Http/Controllers/HandleController.php
+++ b/app/Http/Controllers/HandleController.php
@@ -58,7 +58,7 @@ class HandleController extends ApiController
         return response()->json(['data' => $result]);
     }
 
-    private function jsonHandle(string $name, string $entityType, array $person = null)
+    private function jsonHandle(string $name, string $entityType, array $person = null): array
     {
         $result = ['name' => $name, 'entityType' => $entityType];
         if ($person) {

--- a/app/Lib/PotentialClubhouseAccountFromSalesforce.php
+++ b/app/Lib/PotentialClubhouseAccountFromSalesforce.php
@@ -107,7 +107,7 @@ class PotentialClubhouseAccountFromSalesforce
         $this->applicant_type = self::sanitizeField($sobj, 'Ranger_Applicant_Type__c');
         $this->firstname = self::sanitizeField($rInfo, 'FirstName');
         $this->lastname = self::sanitizeField($rInfo, 'LastName');
-        $this->street1 = self::sanitizeStreet($rInfo->MailingStreet ?? '');
+        $this->street1 = self::sanitizeStreet($rInfo);
         $this->city = self::sanitizeField($rInfo, 'MailingCity');
         $this->state = self::sanitizeField($rInfo, 'MailingState');
         $this->zip = self::sanitizeField($rInfo, 'MailingPostalCode');
@@ -300,6 +300,7 @@ class PotentialClubhouseAccountFromSalesforce
 
     public static function sanitizeStreet($s): string
     {
+        $s = $s->MailingStreet ?? '';
         $s = str_replace("\r", "", $s);
         $s = str_replace("\n", " ", $s);
         return trim($s);

--- a/app/Lib/SalesforceClubhouseInterface.php
+++ b/app/Lib/SalesforceClubhouseInterface.php
@@ -180,7 +180,7 @@ class SalesforceClubhouseInterface
         }
 
         $r = $this->sf->soqlQuery($q);
-        if ($r == false
+        if (!$r
             || (is_array($r) && $r[0]->message != "")) {
             $this->sf->errorMessage = "Salesforce API query failed for $q: {$this->sf->errorMessage}";
             return false;
@@ -190,11 +190,13 @@ class SalesforceClubhouseInterface
     }
 
     /**
-     * Set the Clubbouse import status message in Salesforce for this account.
+     * Set the Clubhouse import status message in Salesforce for this account.
+     *
      * @param $pca
+     * @param $isNew
      */
 
-    public function updateSalesforceClubhouseImportStatusMessage($pca, $isNew)
+    public function updateSalesforceClubhouseImportStatusMessage($pca, $isNew): void
     {
         $status = $pca->status;
         $message = $pca->message;
@@ -222,7 +224,7 @@ class SalesforceClubhouseInterface
      * @param $isNew
      */
 
-    public function updateSalesforceVCStatus($pca, $isNew)
+    public function updateSalesforceVCStatus($pca, $isNew): void
     {
         switch ($pca->status) {
             case "succeeded":
@@ -250,7 +252,7 @@ class SalesforceClubhouseInterface
      * @param $pca
      */
 
-    public function updateSalesforceClubhouseUserID($pca)
+    public function updateSalesforceClubhouseUserID($pca): void
     {
         if ($pca->status != "succeeded") {
             return;
@@ -269,7 +271,7 @@ class SalesforceClubhouseInterface
      * @param $value
      */
 
-    public function updateSalesforceField($id, $field, $value)
+    public function updateSalesforceField($id, $field, $value): void
     {
         if (setting('SFEnableWritebacks')) {
             $this->sf->objUpdate("Ranger__c", $id, [$field => $value]);

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -343,7 +343,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
 
     protected $rules = self::ALL_VALIDATIONS;
 
-    public $has_reviewed_pi;
+    public bool $has_reviewed_pi = false;
 
     /**
      * The roles the person holds
@@ -506,7 +506,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
 
     public static function findByCallsign(string $callsign): ?Person
     {
-        return self::where('callsign', $callsign)->first();
+        return self::where('callsign_normalized', self::normalizeCallsign($callsign))->first();
     }
 
     /**
@@ -518,7 +518,7 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
 
     public static function findIdByCallsign(string $callsign): ?int
     {
-        $row = self::select('id')->where('callsign', $callsign)->first();
+        $row = self::select('id')->where('callsign_normalized', self::normalizeCallsign($callsign))->first();
         if ($row) {
             return $row->id;
         }


### PR DESCRIPTION
- Allow retired & resigned account non-vintage handles to be recycled for new applicants.
- Use normalize callsign lookup instead of raw comparison.