### PR TITLE
Have the People By Special Teams report filter out problematic statuses.

### DIFF
--- a/app/Lib/Reports/SpecialTeamsWorkReport.php
+++ b/app/Lib/Reports/SpecialTeamsWorkReport.php
@@ -36,6 +36,7 @@ class SpecialTeamsWorkReport
                 $q->whereYear('on_duty', '<=', $endYear);
                 $q->whereIn('timesheet.position_id', $positionIds);
             })
+            ->whereNotIn('person.status', Person::LOCKED_STATUSES)
             ->where(function ($q) {
                 $q->whereNotNull('timesheet.id');
                 $q->orWhereNotNull('person_position.position_id');


### PR DESCRIPTION
- Deceased, dismissed, uberbonked, and suspended are filtered out.