### PR TITLE
Scheduling performance work.

### DIFF
--- a/app/Http/Controllers/SlotController.php
+++ b/app/Http/Controllers/SlotController.php
@@ -18,6 +18,7 @@ use App\Models\TraineeNote;
 use App\Models\TraineeStatus;
 use App\Models\TrainerStatus;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
@@ -218,6 +219,9 @@ class SlotController extends ApiController
                     $target->active = $activate;
                     $target->auditReason = 'slot copy';
                     $target->timezone = $source->timezone;
+                    if (!$this->validateRestrictions($target)) {
+                        throw new UnexpectedValueException("One more or slots occur in the pre-event period and require Admin permissions to create. Check with the Logistics Manager to approve.");
+                    }
                     $target->saveOrThrow();
                     $results[] = $target;
                 }
@@ -330,6 +334,7 @@ class SlotController extends ApiController
      *
      * @return JsonResponse
      * @throws AuthorizationException
+     * @throws Exception
      */
 
     public function shiftLeadReport(): JsonResponse

--- a/app/Lib/BMIDManagement.php
+++ b/app/Lib/BMIDManagement.php
@@ -298,7 +298,7 @@ class BMIDManagement
 
             case 'signedup':
                 // Find any vets who are signed up and/or passed training
-                $slotIds = Slot::whereYear('begins', $year)
+                $slotIds = Slot::where('begins_year', $year)
                     ->where('begins', '>=', "$year-08-10")
                     ->pluck('id');
 

--- a/app/Lib/Reports/ScheduleByCallsignReport.php
+++ b/app/Lib/Reports/ScheduleByCallsignReport.php
@@ -13,7 +13,7 @@ class ScheduleByCallsignReport
 
     public static function execute(int $year): array
     {
-        $slots = Slot::whereYear('slot.begins', $year)
+        $slots = Slot::where('slot.begins_year', $year)
             ->with('position:id,title,active')
             ->orderBy('begins')
             ->get();

--- a/app/Lib/Scheduling.php
+++ b/app/Lib/Scheduling.php
@@ -7,6 +7,7 @@ use App\Models\Person;
 use App\Models\PersonOnlineTraining;
 use App\Models\PersonPhoto;
 use App\Models\Schedule;
+use App\Models\Training;
 
 class Scheduling
 {
@@ -55,7 +56,8 @@ class Scheduling
         if ($isAuditor && setting('OnlineTrainingOnlyForAuditors')) {
             return [
                 'online_training_only' => true,
-                'online_training_enabled' => $otEnabled
+                'online_training_enabled' => $otEnabled,
+                'needs_full_training' => true,
             ];
         }
 
@@ -131,6 +133,8 @@ class Scheduling
             $canSignUpForAllShifts = false;
         }
 
+        list ($needsFullTraining, $isBinary) = Training::doesRequireInPersonTrainingFullDay($person);
+
         return [
             // Can the person sign up for all (except training) shifts?
             'all_signups_allowed' => $canSignUpForAllShifts,
@@ -139,6 +143,7 @@ class Scheduling
             'training_signups_allowed' => $canSignUpForTraining,
             'requirements' => $requirements,
             'recommend_burn_weekend_shift' => self::recommendBurnWeekendShift($person),
+            'needs_full_training' => $needsFullTraining,
         ];
     }
 

--- a/app/Models/ApiModel.php
+++ b/app/Models/ApiModel.php
@@ -55,6 +55,8 @@ abstract class ApiModel extends Model
     protected $resourceSingle;
     protected $resourceCollection;
 
+    protected $virtualColumns;
+
     public static function boot()
     {
         parent::boot();
@@ -172,6 +174,10 @@ abstract class ApiModel extends Model
     {
         if (!$this->validate()) {
             return false;
+        }
+
+        if (!empty($this->virtualColumns)) {
+            $this->attributes = array_diff_key($this->attributes, array_flip($this->virtualColumns));
         }
 
         return parent::save($options);

--- a/app/Models/Slot.php
+++ b/app/Models/Slot.php
@@ -3,10 +3,12 @@
 namespace App\Models;
 
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Psr\SimpleCache\InvalidArgumentException;
 
 /**
  * @property Carbon $begins
@@ -55,12 +57,19 @@ class Slot extends ApiModel
         'url',
     ];
 
+    // Computed from the other fields
+    protected $guarded = [
+        'begins_time',
+        'begins_year',
+        'duration',
+        'ends_time',
+        'timezone_abbr',
+    ];
+
     protected $appends = [
         'credits',
         'has_started',
         'has_ended',
-        'duration',
-        'timezone_abbr'
     ];
 
     protected $rules = [
@@ -82,6 +91,7 @@ class Slot extends ApiModel
     public $auditExclude = [
         'signed_up'
     ];
+
 
     public function trainer_slot(): BelongsTo
     {
@@ -108,10 +118,41 @@ class Slot extends ApiModel
         return $this->belongsTo(Position::class, 'position_id');
     }
 
-    public function loadRelationships()
+    public function loadRelationships(): void
     {
         $this->load(self::WITH_POSITION_TRAINER);
     }
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        self::saving(function ($model) {
+            // Compute the timezone abbreviation. Have to use the begins time because it could be PDT or PST.
+            if (($model->isDirty('begins') || $model->isDirty('timezone')) && $model->begins) {
+                $tz = $model->begins_adjusted->format('T');
+                if (str_starts_with($tz, '+') || str_starts_with($tz, '-')) {
+                    $tz = 'UTC' . $tz;
+                }
+
+                $model->timezone_abbr = $tz;
+            }
+
+            if ($model->isDirty('begins')) {
+                $model->begins_year = $model->begins->year;
+                $model->begins_time = $model->begins_adjusted->timestamp;
+            }
+
+            if ($model->isDirty('ends')) {
+                $model->ends_time = $model->ends_adjusted->timestamp;
+            }
+
+            if ($model->isDirty('begins') || $model->isDirty('ends')) {
+                $model->duration = $model->ends_time - $model->begins_time;
+            }
+        });
+    }
+
 
     /**
      * Find slots based on the given criteria
@@ -158,7 +199,7 @@ class Slot extends ApiModel
 
     public static function findWithSignupsForYear(int $year): \Illuminate\Database\Eloquent\Collection
     {
-        return self::whereYear('begins', $year)
+        return self::where('begins_year', $year)
             ->where('signed_up', '>', 0)
             ->with('position:id,title')
             ->orderBy('begins')
@@ -229,7 +270,7 @@ class Slot extends ApiModel
             $q->where('person_slot.person_id', $personId);
         })->where('position_id', $positionId)
             ->where('slot.active', true)
-            ->whereYear('begins', $year)
+            ->where('begins_year', $year)
             ->where('slot.position_id', $positionId)
             ->orderBy('begins')
             ->first();
@@ -243,9 +284,9 @@ class Slot extends ApiModel
 
     public static function findYears(): array
     {
-        return self::selectRaw('YEAR(begins) as year')
-            ->groupBy(DB::raw('YEAR(begins)'))
-            ->pluck('year')
+        return self::select('begins_year')
+            ->groupBy('begins_year')
+            ->pluck('begins_year')
             ->toArray();
     }
 
@@ -259,7 +300,7 @@ class Slot extends ApiModel
 
     public static function haveActiveForPosition(int $positionId): bool
     {
-        return self::whereYear('begins', current_year())
+        return self::where('begins_year', current_year())
             ->where('position_id', $positionId)
             ->where('active', true)
             ->exists();
@@ -275,8 +316,8 @@ class Slot extends ApiModel
     public static function retrieveDirtTimes(int $year): Collection
     {
         $rows = DB::table('slot')
-            ->select('position_id', 'begins', 'ends', DB::raw('timestampdiff(second, begins, ends) as duration'))
-            ->whereYear('begins', $year)
+            ->select('position_id', 'begins', 'ends', 'duration')
+            ->where('begins_year', $year)
             ->whereIn('position_id', [Position::DIRT, Position::DIRT_PRE_EVENT, Position::DIRT_POST_EVENT])
             ->orderBy('begins')
             ->get();
@@ -300,12 +341,13 @@ class Slot extends ApiModel
      * Retrieve the credits potential for the slot
      *
      * @return float
+     * @throws InvalidArgumentException
      */
 
     public function getCreditsAttribute(): float
     {
         if ($this->position_id) {
-            return PositionCredit::computeCredits($this->position_id, $this->begins->timestamp, $this->ends->timestamp, $this->begins->year);
+            return PositionCredit::computeCredits($this->position_id, $this->begins->timestamp, $this->ends->timestamp, $this->begins_year);
         }
 
         return 0.0;
@@ -363,7 +405,7 @@ class Slot extends ApiModel
 
     public function getHasStartedAttribute(): bool
     {
-        return $this->begins_adjusted->lt(now());
+        return $this->begins_adjusted?->lt(now()) ?? false;
     }
 
     /**
@@ -374,80 +416,32 @@ class Slot extends ApiModel
 
     public function getHasEndedAttribute(): bool
     {
-        return $this->ends_adjusted->lte(now());
+        return $this->ends_adjusted?->lte(now()) ?? false;
     }
 
     /**
-     * Set the timezone, set null if the string is empty.
+     * Set the timezone, default to Pacific timezone if blank.
      *
-     * @param string|null $timezone
-     * @return void
+     * @return Attribute
      */
 
-    public function setTimezoneAttribute(?string $timezone): void
+    public function timezone(): Attribute
     {
-        $this->attributes['timezone'] = empty($timezone) ? 'America/Los_Angeles' : $timezone;
+        return Attribute::make(
+            set: fn ($timezone) =>  empty($timezone) ? 'America/Los_Angeles' : $timezone
+        );
     }
 
     /**
      * Adjust the timezone if one was given.
      *
-     * @param Carbon $time
-     * @return Carbon
+     * @param ?Carbon $time
+     * @return ?Carbon
      */
 
-    public function adjustTimezone(Carbon $time): Carbon
+    public function adjustTimezone(?Carbon $time): ?Carbon
     {
-        return $time->clone()->shiftTimezone($this->timezone);
-    }
-
-    /**
-     * Get the beginning time timestamp
-     *
-     * @return int
-     */
-
-    public function getBeginsTimeAttribute(): int
-    {
-        return $this->begins_adjusted->timestamp;
-    }
-
-    /**
-     * Get the ending time timestamp
-     *
-     * @return int
-     */
-
-    public function getEndsTimeAttribute(): int
-    {
-        return $this->ends_adjusted->timestamp;
-    }
-
-    /**
-     * Obtain the timezone abbreviation
-     *
-     * @return string
-     */
-
-    public function getTimezoneAbbrAttribute(): string
-    {
-        $tz = $this->begins_adjusted->format('T');
-        if (str_starts_with($tz, '+') || str_starts_with($tz, '-')) {
-            return 'UTC'.$tz;
-        } else {
-            return $tz;
-        }
-    }
-
-    /**
-     * Calculate the slot duration (in seconds)
-     *
-     * @return int
-     */
-
-    public function getDurationAttribute(): int
-    {
-        return $this->ends->timestamp - $this->begins->timestamp;
+        return $time?->clone()->shiftTimezone($this->timezone);
     }
 
     /**
@@ -461,15 +455,16 @@ class Slot extends ApiModel
         return max(now()->timestamp - $this->ends_adjusted->timestamp, 0);
     }
 
-    public function getBeginsAdjustedAttribute(): Carbon
+    public function getBeginsAdjustedAttribute(): ?Carbon
     {
         return $this->adjustTimezone($this->begins);
     }
 
-    public function getEndsAdjustedAttribute(): Carbon
+    public function getEndsAdjustedAttribute(): ?Carbon
     {
         return $this->adjustTimezone($this->ends);
     }
+
 
     /**
      * Check to see if the slot begins within the pre-event period and is not a training slot
@@ -484,6 +479,7 @@ class Slot extends ApiModel
             return false;
         }
 
+        // Note: don't use begins_year since it may have not been set yet.
         $eventDate = EventDate::findForYear($this->begins->year);
 
         if (!$eventDate || !$eventDate->pre_event_slot_start || !$eventDate->pre_event_slot_end) {

--- a/app/Models/TrainerStatus.php
+++ b/app/Models/TrainerStatus.php
@@ -16,7 +16,7 @@ class TrainerStatus extends ApiModel
     const PENDING = 'pending';
     const NO_SHOW = 'no-show';
 
-    protected $guarded = [ 'id' ];
+    protected $guarded = ['id'];
 
     public function slot(): BelongsTo
     {
@@ -82,12 +82,12 @@ class TrainerStatus extends ApiModel
      * Retrieve all the sessions the person may have taught
      *
      * @param int $personId the person to check
-     * @param  $positionIds the positions to check (Trainer / Trainer Assoc. / Uber /etc)
+     * @param array $positionIds positions to check (Trainer / Trainer Assoc. / Uber /etc)
      * @param int $year the year to check
      * @return Collection
      */
 
-    public static function retrieveSessionsForPerson(int $personId, $positionIds, int $year): Collection
+    public static function retrieveSessionsForPerson(int $personId, array $positionIds, int $year): Collection
     {
         return DB::table('slot')
             ->select('slot.id', 'slot.begins', 'slot.ends', 'slot.description', 'slot.position_id', DB::raw('IFNULL(trainer_status.status, "pending") as status'))

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -556,7 +556,7 @@ class Training extends Position
                 'slot_id' => $row->id,
                 'slot_description' => $row->description,
                 'slot_begins' => (string)$row->begins,
-                'slot_year' => $row->begins->year,
+                'slot_year' => $row->begins_year,
                 'slot_tz' => $row->timezone,
                 'slot_tz_abbr' => $row->timezone_abbr,
                 'slot_has_ended' => $row->has_ended,
@@ -567,6 +567,24 @@ class Training extends Position
         }
 
         return collect($trainings)->groupBy('person_id');
+    }
+
+    /**
+     * Does the person require full training and/or are they a binary?
+     */
+
+    public static function doesRequireInPersonTrainingFullDay(Person $person): array
+    {
+        if ($person->status == Person::ACTIVE) {
+            $isBinary = Timesheet::isPersonBinary($person);
+            // Binaries have to take the full day's training
+            $fullDay = $isBinary;
+        } else {
+            $fullDay = true;
+            $isBinary = false;
+        }
+
+        return [$fullDay, $isBinary];
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,7 +21,7 @@ class AppServiceProvider extends ServiceProvider
         ini_set('upload_max_filesize', '32M');
         ini_set('post_max_size', '32M');
 
-        if (env('APP_DEBUG')) {
+        if (env('APP_SQL_DEBUG')) {
             DB::listen(function ($query) {
                 $placeholder = preg_quote('?', '/');
                 $sql = $query->sql;

--- a/composer.json
+++ b/composer.json
@@ -36,12 +36,13 @@
     "twilio/sdk": "^6.36.0"
   },
   "require-dev": {
-    "spatie/laravel-ignition": "^2.0",
     "fakerphp/faker": "^1.20",
     "filp/whoops": "^2.14.5",
+    "itsgoingd/clockwork": "^5.1",
     "mockery/mockery": "~1.5.1",
     "nunomaduro/collision": "^7.0",
-    "phpunit/phpunit": "^10.0"
+    "phpunit/phpunit": "^10.0",
+    "spatie/laravel-ignition": "^2.0"
   },
   "autoload": {
     "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e09f6cc80b61c3c6bc0b0020d71c607c",
+    "content-hash": "8a9a817a841f5baefbb4f021087e5b47",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -7257,6 +7257,74 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "itsgoingd/clockwork",
+            "version": "v5.1.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/itsgoingd/clockwork.git",
+                "reference": "c9dbdbb1f0efd19bb80f1080ef63f1b9b1bc3b1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/itsgoingd/clockwork/zipball/c9dbdbb1f0efd19bb80f1080ef63f1b9b1bc3b1b",
+                "reference": "c9dbdbb1f0efd19bb80f1080ef63f1b9b1bc3b1b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Clockwork\\Support\\Laravel\\ClockworkServiceProvider"
+                    ],
+                    "aliases": {
+                        "Clockwork": "Clockwork\\Support\\Laravel\\Facade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Clockwork\\": "Clockwork/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "itsgoingd",
+                    "email": "itsgoingd@luzer.sk",
+                    "homepage": "https://twitter.com/itsgoingd"
+                }
+            ],
+            "description": "php dev tools in your browser",
+            "homepage": "https://underground.works/clockwork",
+            "keywords": [
+                "Devtools",
+                "debugging",
+                "laravel",
+                "logging",
+                "lumen",
+                "profiling",
+                "slim"
+            ],
+            "support": {
+                "issues": "https://github.com/itsgoingd/clockwork/issues",
+                "source": "https://github.com/itsgoingd/clockwork/tree/v5.1.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/itsgoingd",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-13T00:04:12+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/database/factories/SlotFactory.php
+++ b/database/factories/SlotFactory.php
@@ -19,6 +19,21 @@ class SlotFactory extends Factory
             'description' => 'slot',
             'signed_up' => 0,
             'timezone' => 'America/Los_Angeles',
+            'timezone_abbr' => 'PST',
         ];
+    }
+
+    /**
+     * Configure the model factory.
+     */
+
+    public function configure(): static
+    {
+        return $this->afterMaking(function ($slot) {
+            $slot->begins_year = $slot->begins->year;
+            $slot->begins_time = $slot->begins_adjusted->timestamp;
+            $slot->ends_time = $slot->ends_adjusted->timestamp;
+            $slot->duration = $slot->ends_time - $slot->begins_time;
+        });
     }
 }

--- a/database/migrations/2023_05_03_223354_add_start_year_to_position_credit.php
+++ b/database/migrations/2023_05_03_223354_add_start_year_to_position_credit.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('position_credit', function (Blueprint $table) {
+            $table->integer('start_year')->storedAs("year(start_time)");
+            $table->integer('end_year')->storedAs("year(end_time)");
+            $table->index(['start_year']);
+            $table->index(['start_year', 'end_year']);
+            $table->index(['start_year', 'position_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('position_credit', function (Blueprint $table) {
+            $table->dropIndex(['start_year', 'position_id']);
+            $table->dropIndex(['start_year', 'end_year']);
+            $table->dropIndex(['start_year']);
+
+            $table->dropColumn(['start_year', 'end_year']);
+        });
+    }
+};

--- a/database/migrations/2023_05_04_123634_add_timezone_abbr_to_slot.php
+++ b/database/migrations/2023_05_04_123634_add_timezone_abbr_to_slot.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Slot;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('slot', function (Blueprint $table) {
+            $table->string('timezone_abbr');
+        });
+
+        $rows = Slot::all();
+        foreach ($rows as $row) {
+            $tz = $row->begins_adjusted->format('T');
+            if (str_starts_with($tz, '+') || str_starts_with($tz, '-')) {
+                $tz = 'UTC' . $tz;
+            }
+            DB::table('slot')->where('id', $row->id)->update([ 'timezone_abbr' => $tz]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('slot', function (Blueprint $table) {
+            $table->dropColumn('timezone_abbr');
+        });
+    }
+};

--- a/database/migrations/2023_05_04_155212_add_virutal_columns_to_slot.php
+++ b/database/migrations/2023_05_04_155212_add_virutal_columns_to_slot.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('slot', function (Blueprint $table) {
+            $table->integer("begins_year")->nullable(false)->default(0);
+            $table->integer("duration")->nullable(false)->default(0);
+            $table->integer("begins_time")->nullable(false)->default(0);
+            $table->integer("ends_time")->nullable(false)->default(0);
+            $table->index(['begins_year', 'position_id']);
+        });
+
+        DB::table('slot')->update([
+            'begins_year' => DB::raw('year(begins)'),
+            'begins_time' => DB::raw('UNIX_TIMESTAMP(CONVERT_TZ(CONVERT_TZ(begins, timezone, "+00:00"), "+00:00", @@time_zone))'),
+            'ends_time' => DB::raw('UNIX_TIMESTAMP(CONVERT_TZ(CONVERT_TZ(ends, timezone, "+00:00"), "+00:00", @@time_zone))'),
+            'duration' => DB::raw("TIMESTAMPDIFF(second,begins,ends)"),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('slot', function (Blueprint $table) {
+            $table->dropColumn(['begins_year', 'duration', 'begins_time', 'ends_time']);
+        });
+    }
+};

--- a/php-inis/xdebug.ini
+++ b/php-inis/xdebug.ini
@@ -17,7 +17,7 @@ zend_extension=/opt/homebrew/Cellar/php/8.2.5/pecl/20220829/xdebug.so
 xdebug.mode=debug
 #xdebug.mode = profile
 xdebug.start_with_request = yes
-xdebug.use_compression=false
+xdebug.use_compression=true
 xdebug.profiler_output_name=cachegrind.out.%R.%u
 xdebug.output_dir=/tmp
 

--- a/resources/views/emails/welcome.blade.php
+++ b/resources/views/emails/welcome.blade.php
@@ -77,7 +77,7 @@
         <p>
             The general locations of Ranger Trainings are posted at this link:
             <a href="https://rangers.burningman.org/training">rangers.burningman.org/training</a>,
-            which will continue to be updated through the end of May, as
+            which will continue to be updated through the end of Spring, as
             new trainings are announced. Specific location information will be released by email
             closer to the training date to those Rangers signed up for that date. Stay tuned to
             Ranger Applicant News as new trainings are posted. Please sign up for a training by June


### PR DESCRIPTION
- Boosted scheduling retrieval performance by 50% to 70%.
- New slot columns: begins_year, begins_time, ends_time, timezone_abbr to aid slot retrieval performance.
- Switched app/Models/Schedule from a pseudo ApiModel to a pure php class. (faster serialization)
- Bulk compute slot credits instead of using magic methods and hitting the position credit cache over & over.
- Return the burn weekend recommendation when removing a slot sign up. (trying to reduce the number of API calls on the frontend.)
- Use the new slot.begins_year column for faster queries instead of year(slot.begins)
- Added virtual columns start_year & end_year to position_credit for faster queries.
- Refactored full day training detection (more api call reduction.)
- Added clockwork package to aid development.