### PR TITLE
New Timecard Year Round permission.

### DIFF
--- a/app/Lib/Milestones.php
+++ b/app/Lib/Milestones.php
@@ -167,7 +167,7 @@ class Milestones
             }
 
             // Timesheets!
-            if (setting('TimesheetCorrectionEnable')) {
+            if (setting('TimesheetCorrectionEnable') || $person->hasRole(Role::TIMECARD_YEAR_ROUND)) {
                 $didWork = $milestones['did_work'] = Timesheet::didPersonWork($person->id, $year);
                 if ($didWork) {
                     $milestones['timesheets_unverified'] = Timesheet::countUnverifiedForPersonYear($person->id, $year);

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -63,6 +63,7 @@ class Position extends ApiModel
     const DOUBLE_OH_7_STANDBY = 110;
 
     const DPW_RANGER = 105;
+    const NVO_RANGER = 168;
 
     const DEEP_FREEZE = 38;
 

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -38,7 +38,7 @@ class Role extends ApiModel
     const REGIONAL_MANAGEMENT = 114;    // Person can access Regional Ranger liaison features.
     const PAYROLL = 115;                // Can access payroll features
     const VEHICLE_MANAGEMENT = 116;     // Can access vehicle fleet management features
-
+    const TIMECARD_YEAR_ROUND = 117;    // Paid folks who can self check in/out, and submit timesheet corrections year round.
     const TECH_NINJA = 1000;    // godlike powers granted - access to dangerous maintenance functions, raw database access.
 
     protected $casts = [

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -527,7 +527,7 @@ class Setting extends ApiModel
         ],
 
         'TimesheetCorrectionEnable' => [
-            'description' => 'Allow users to submit Timesheet Corrections',
+            'description' => 'Allow users to submit Timesheet Corrections. Note: The Timecard Year Round permission allows access year round.',
             'type' => self::TYPE_BOOL,
         ],
 

--- a/app/Policies/TimesheetPolicy.php
+++ b/app/Policies/TimesheetPolicy.php
@@ -51,7 +51,7 @@ class TimesheetPolicy
 
     public function updatePosition(Person $user, Timesheet $timesheet): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return $user->hasRole(Role::MANAGE) || ($user->hasRole(Role::TIMECARD_YEAR_ROUND) && $user->id == $timesheet->person_id);
     }
 
     /*
@@ -70,7 +70,8 @@ class TimesheetPolicy
     public function destroy(Person $user, Timesheet $timesheet): bool
     {
         // Allow a timesheet to be deleted if the duration is too short - i.e., accidental shift start.
-        if ($user->hasRole(Role::MANAGE) && $timesheet->duration < Timesheet::TOO_SHORT_LENGTH) {
+        if (($user->hasRole(Role::MANAGE) || ($user->hasRole(Role::TIMECARD_YEAR_ROUND) && $timesheet->person_id == $user->id))
+            && $timesheet->duration < Timesheet::TOO_SHORT_LENGTH) {
             return true;
         }
         return false;
@@ -87,7 +88,7 @@ class TimesheetPolicy
 
     public function deleteMistake(Person $user, Timesheet $timesheet): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return $user->hasRole(Role::MANAGE) || ($user->hasRole(Role::TIMECARD_YEAR_ROUND) && $timesheet->person_id == $user->id);
     }
 
     /**
@@ -96,7 +97,7 @@ class TimesheetPolicy
 
     public function signin(Person $user): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return $user->hasRole([ Role::MANAGE, Role::TIMECARD_YEAR_ROUND]);
     }
 
     /**
@@ -114,7 +115,7 @@ class TimesheetPolicy
 
     public function signoff(Person $user, Timesheet $timesheet): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return $user->hasRole([ Role::MANAGE, Role::TIMECARD_YEAR_ROUND ]);
     }
 
     /**

--- a/database/migrations/2023_07_24_163001_add_timecard_year_round_to_role.php
+++ b/database/migrations/2023_07_24_163001_add_timecard_year_round_to_role.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('role')->insert(
+            [
+                'id' => Role::TIMECARD_YEAR_ROUND,
+                'title' => 'Timecard Year Round',
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('role')->where('id', Role::TIMECARD_YEAR_ROUND)->delete();
+    }
+};


### PR DESCRIPTION
- Allows users to self clock in/out without requiring LMYR/LMOP. Intended for NVO / DPW Rangers who are working earlier in the summer.