### PR TITLE
Missing timesheet tweaks

### DIFF
--- a/app/Http/Controllers/TimesheetMissingController.php
+++ b/app/Http/Controllers/TimesheetMissingController.php
@@ -106,7 +106,8 @@ class TimesheetMissingController extends ApiController
         if ($createNew) {
             // Verify the person may hold the position
             if (!PersonPosition::havePosition($person->id, $timesheetMissing->new_position_id)) {
-                throw new InvalidArgumentException('Person does not hold the position.');
+                $timesheetMissing->addError('new_position_id', 'Person does not hold the position.');
+                return $this->restError($timesheetMissing);
             }
         }
 

--- a/app/Models/TimesheetMissing.php
+++ b/app/Models/TimesheetMissing.php
@@ -70,14 +70,14 @@ class TimesheetMissing extends ApiModel
 
         'create_entry' => 'sometimes|boolean|nullable',
 
-        'new_on_duty' => 'date|nullable|required_if:create_entry,true',
-        'new_off_duty' => 'date|nullable|after:new_on_duty|required_if:create_entry,true',
-        'new_position_id' => 'integer|nullable|required_if:create_entry,true'
+        'new_on_duty' => 'date|nullable|required_if:create_entry,1',
+        'new_off_duty' => 'date|nullable|after:new_on_duty|required_if:create_entry,1',
+        'new_position_id' => 'integer|nullable|required_if:create_entry,1'
     ];
 
-    public ?string $new_off_duty;
-    public ?string $new_on_duty;
-    public ?int $new_position_id;
+    public ?string $new_off_duty = null;
+    public ?string $new_on_duty = null;
+    public ?int $new_position_id = null;
     public bool $create_entry = false;
 
     const PARTNER_SHIFT_STARTS_WITHIN = 30;


### PR DESCRIPTION
- Don't throw an exception if the person does not hold the position. Return as a REST error.
- Initialize the new timesheet variable (new_{off_duty,new_on_duty,position_id}) to null.