### PR TITLE
New Position Sanity Checker functionality.

### DIFF
--- a/app/Lib/PositionSanityCheck.php
+++ b/app/Lib/PositionSanityCheck.php
@@ -19,6 +19,8 @@ class PositionSanityCheck
         'team_membership' => 'App\Lib\PositionSanityCheck\TeamMembershipCheck',
         'deactivated_teams' => 'App\Lib\PositionSanityCheck\DeactivatedTeamsCheck',
         'lmyr' => 'App\Lib\PositionSanityCheck\LoginManagementYearRoundCheck',
+        'deactivated_accounts' => 'App\Lib\PositionSanityCheck\DeactivatedAccounts',
+        'retired_accounts' => 'App\Lib\PositionSanityCheck\RetiredAccounts',
     ];
 
     public static function issues(): array

--- a/app/Lib/PositionSanityCheck/DeactivatedAccounts.php
+++ b/app/Lib/PositionSanityCheck/DeactivatedAccounts.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Lib\PositionSanityCheck;
+
+use App\Models\Person;
+use App\Models\PersonPosition;
+use Illuminate\Support\Facades\DB;
+
+class DeactivatedAccounts
+{
+    const NO_POSITIONS_STATUSES = [
+        Person::BONKED,
+        Person::DECEASED,
+        Person::DISMISSED,
+        Person::PAST_PROSPECTIVE,
+        Person::RESIGNED,
+        Person::UBERBONKED
+    ];
+
+    public static function issues(): array
+    {
+        return DB::table('person')
+            ->select('id', 'callsign', 'status')
+            ->whereIn('status', self::NO_POSITIONS_STATUSES)
+            ->whereExists(function ($q) {
+                $q->from('person_position')
+                    ->select(DB::raw(1))
+                    ->whereColumn('person_position.person_id', 'person.id')
+                    ->limit(1);
+            })
+            ->orderBy('callsign')
+            ->get()
+            ->toArray();
+    }
+
+    public static function repair($peopleIds, ...$options): array
+    {
+        $results = [];
+
+        foreach ($peopleIds as $personId) {
+            PersonPosition::resetPositions($personId, 'position sanity checker - deactivated account', Person::REMOVE_ALL);
+            $results[] = ['id' => $personId, 'messages' => ['Positions revoked']];
+        }
+        return $results;
+    }
+}

--- a/app/Lib/PositionSanityCheck/RetiredAccounts.php
+++ b/app/Lib/PositionSanityCheck/RetiredAccounts.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Lib\PositionSanityCheck;
+
+use App\Models\Person;
+use App\Models\PersonPosition;
+use Illuminate\Support\Facades\DB;
+
+class RetiredAccounts
+{
+    public static function issues(): array
+    {
+        $positionIds = DB::table('position')->where('active', true)->where('new_user_eligible', true)->pluck('id');
+
+        if ($positionIds->isEmpty()) {
+            // Highly unlikely but ya never know.
+            return [];
+        }
+
+        return DB::table('person')
+            ->select('id', 'callsign', 'status')
+            ->where('status', Person::RETIRED)
+            ->whereExists(function ($q) use ($positionIds) {
+                $q->from('person_position')
+                    ->select(DB::raw(1))
+                    ->whereColumn('person_position.person_id', 'person.id')
+                    ->whereNotIn('person_position.position_id', $positionIds)
+                    ->limit(1);
+            })
+            ->orderBy('callsign')
+            ->get()
+            ->toArray();
+    }
+
+    public static function repair($peopleIds, ...$options): array
+    {
+        $results = [];
+
+        foreach ($peopleIds as $personId) {
+            PersonPosition::resetPositions($personId, 'position sanity checker - retired account', Person::ADD_NEW_USER);
+            $results[] = ['id' => $personId, 'messages' => ['Positions adjusted']];
+        }
+        return $results;
+    }
+
+}

--- a/app/Models/PersonPosition.php
+++ b/app/Models/PersonPosition.php
@@ -136,7 +136,7 @@ class PersonPosition extends ApiModel
 
         if ($action == Person::ADD_NEW_USER) {
             $addIds = [];
-            $ids = Position::where('new_user_eligible', true)->pluck('id')->toArray();
+            $ids = Position::where('active', true)->where('new_user_eligible', true)->pluck('id')->toArray();
             foreach ($ids as $positionId) {
                 $key = array_search($positionId, $removeIds);
                 if ($key !== false) {


### PR DESCRIPTION
- Ensure retired accounts only have the new user eligible flagged positions (similar to a prospective or auditor)
- Revoke all positions for deactivated accounts (bonked/uberbonked, dismissed, resigned, past prospective)