### PR TITLE
Timesheet and Position sanity checker fixes.

### DIFF
--- a/app/Lib/PositionSanityCheck/ShinnyPenniesCheck.php
+++ b/app/Lib/PositionSanityCheck/ShinnyPenniesCheck.php
@@ -3,34 +3,75 @@
 namespace App\Lib\PositionSanityCheck;
 
 use App\Models\Person;
-use App\Models\Position;
-use App\Models\PersonPosition;
 use App\Models\PersonMentor;
-
+use App\Models\PersonPosition;
+use App\Models\Position;
+use App\Models\Timesheet;
 use Illuminate\Support\Facades\DB;
 
 class ShinnyPenniesCheck extends SanityCheck
 {
     public static function issues(): array
     {
-        return DB::table('person')
-            ->where('person.status', Person::ACTIVE)
-            ->whereExists(function ($sql) {
-                $sql->from('timesheet')
-                    ->select(DB::raw(1))
-                    ->where('position_id', Position::ALPHA)
-                    ->whereYear('on_duty', current_year())
-                    ->whereColumn('person.id', 'timesheet.person_id')
-                    ->limit(1);
-            })->whereNotExists(function ($sql) {
-                $sql->from('person_position')
-                    ->select(DB::raw(1))
-                    ->whereColumn('person.id', 'person_position.person_id')
-                    ->where('person_position.position_id', Position::DIRT_SHINY_PENNY)
-                    ->limit(1);
-            })->orderBy('callsign')
-            ->get()
-            ->toArray();
+        $year = current_year();
+        $alphaIds = DB::table('timesheet')
+            ->whereYear('on_duty', current_year())
+            ->where('position_id', Position::ALPHA)
+            ->orderBy('person_id')
+            ->pluck('person_id');
+
+        if ($alphaIds->isNotEmpty()) {
+            $noPosition = DB::table('person')
+                ->select('person.id', 'person.callsign', 'person.status')
+                ->where('person.status', Person::ACTIVE)
+                ->whereIntegerInRaw('person.id', $alphaIds)
+                ->whereNotExists(function ($sql) use ($alphaIds) {
+                    $sql->from('person_position')
+                        ->select(DB::raw(1))
+                        ->whereColumn('person.id', 'person_position.person_id')
+                        ->where('person_position.position_id', Position::DIRT_SHINY_PENNY)
+                        ->limit(1);
+                })->orderBy('callsign')
+                ->get()
+                ->toArray();
+
+            foreach ($noPosition as $p) {
+                $p->has_shiny_penny = false;
+                $p->year = $year;
+            }
+        } else {
+            $noPosition = [];
+        }
+
+        $sql = DB::table('person_position')
+            ->where('position_id', Position::DIRT_SHINY_PENNY);
+
+        if ($alphaIds->isNotEmpty()) {
+            $sql->whereIntegerNotInRaw('person_id', $alphaIds);
+        }
+
+        $personIds = $sql->pluck('person_id');
+
+        if ($personIds->isNotEmpty()) {
+            $havePosition = DB::table('person')
+                ->select(
+                    'person.id', 'person.callsign', 'person.status',
+                    DB::raw('(SELECT mentor_year FROM person_mentor WHERE person_mentor.person_id=person.id ORDER BY person_mentor.mentor_year DESC LIMIT 1) as year')
+                )
+                ->whereIntegerInRaw('id', $personIds)
+                ->get()
+                ->toArray();
+            foreach ($havePosition as $p) {
+                $p->has_shiny_penny = true;
+            }
+        } else {
+            $havePosition = [];
+        }
+
+        $results = array_merge($noPosition, $havePosition);
+        usort($results, fn($a, $b) => strcasecmp($a->callsign, $b->callsign));
+
+        return $results;
     }
 
     public static function repair($peopleIds, ...$options): array
@@ -40,7 +81,7 @@ class ShinnyPenniesCheck extends SanityCheck
 
         foreach ($peopleIds as $personId) {
             $hasPenny = PersonPosition::havePosition($personId, Position::DIRT_SHINY_PENNY);
-            $isPenny = PersonMentor::retrieveYearPassed($personId) == $year;
+            $isPenny = Timesheet::findLatestForPersonPosition($personId, Position::ALPHA, $year) != null;
 
             if ($hasPenny && !$isPenny) {
                 PersonPosition::removeIdsFromPerson($personId, [Position::DIRT_SHINY_PENNY], 'position sanity checker repair');

--- a/app/Lib/Reports/TimesheetSanityCheckReport.php
+++ b/app/Lib/Reports/TimesheetSanityCheckReport.php
@@ -14,7 +14,7 @@ class TimesheetSanityCheckReport
 
     public static function execute(int $year): array
     {
-        $withBase = ['position:id,title', 'person:id,callsign', 'slot:id,description,begins,ends,timezone'];
+        $withBase = ['position:id,title', 'person:id,callsign', 'slot:id,description,begins,ends,timezone,duration'];
 
         $rows = Timesheet::whereYear('on_duty', $year)
             ->whereNull('off_duty')
@@ -132,7 +132,8 @@ class TimesheetSanityCheckReport
             ->values()
             ->toArray();
 
-        $rows = Timesheet::join('slot', 'slot.id', 'timesheet.slot_id')
+        $rows = Timesheet::select('timesheet.*')
+            ->join('slot', 'slot.id', 'timesheet.slot_id')
             ->whereYear('on_duty', $year)
             ->whereNotNull('timesheet.slot_id')
             ->whereRaw("TIMESTAMPDIFF(SECOND, on_duty, IFNULL(off_duty,'$now')) >= TIMESTAMPDIFF(SECOND, slot.begins, slot.ends)*1.5")

--- a/tests/Feature/PositionSanityCheckControllerTest.php
+++ b/tests/Feature/PositionSanityCheckControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\PersonTeam;
 use App\Models\Position;
 use App\Models\Role;
 use App\Models\Team;
+use App\Models\Timesheet;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -73,6 +74,13 @@ class PositionSanityCheckControllerTest extends TestCase
             'status' => 'pass'
         ]);
 
+        Timesheet::factory()->create([
+            'person_id' => $this->shinyPenny->id,
+            'position_id' => Position::ALPHA,
+            'on_duty' => date('Y-01-01 00:00'),
+            'off_duty' => date('Y-01-01 01:00'),
+        ]);
+
         // Trainer to test Login Management Year Round
         $this->trainer = Person::factory()->create(['callsign' => 'Trainer']);
         // person has a Login Management position but no LM role
@@ -94,7 +102,6 @@ class PositionSanityCheckControllerTest extends TestCase
         $person = $this->person;
         $personYear = $this->personYear;
         $shinyPenny = $this->shinyPenny;
-        $trainer = $this->trainer;
 
         $response = $this->json('GET', 'position/sanity-checker');
         $response->assertStatus(200);

--- a/tests/Feature/PositionSanityCheckControllerTest.php
+++ b/tests/Feature/PositionSanityCheckControllerTest.php
@@ -112,17 +112,17 @@ class PositionSanityCheckControllerTest extends TestCase
             // Response is sorted by year descending, callsign
             'shiny_pennies' => [
                 [
+                    'id' => $person->id,
+                    'callsign' => $person->callsign,
+                    'has_shiny_penny' => 1,
+                    'year' => $personYear,
+                ],
+                [
                     'id' => $shinyPenny->id,
                     'callsign' => $shinyPenny->callsign,
                     'has_shiny_penny' => 0,
                     'year' => (int)date('Y'),
                 ],
-                [
-                    'id' => $person->id,
-                    'callsign' => $person->callsign,
-                    'has_shiny_penny' => 1,
-                    'year' => $personYear,
-                ]
             ]
         ]);
     }

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -1075,7 +1075,7 @@ class TimesheetControllerTest extends TestCase
      * Test Timesheet Sanity Checker
      */
 
-    public function testTImesheetSanityChecker()
+    public function testTimesheetSanityChecker()
     {
         $this->addRole(Role::ADMIN);
         $year = current_year();


### PR DESCRIPTION
- Use active status and alpha timesheet entry to scan for dirt - shiny penny issues.
- Slot duration was not being returned for the possibly too long timesheet entries.