### PR TITLE
Various tweaks.

### DIFF
--- a/app/Http/Controllers/CallsignsController.php
+++ b/app/Http/Controllers/CallsignsController.php
@@ -2,29 +2,38 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\ApiController;
 use App\Models\Person;
-use App\Models\Role;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\Rule;
+use InvalidArgumentException;
 
 class CallsignsController extends ApiController
 {
-    public function index() {
+    /**
+     * Search for a callsign. Used primarily to send messages with.
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function index(): JsonResponse
+    {
         $params = request()->validate([
             'query' => 'required|string',
-            'type' => 'required|string',
+            'type' => [
+                'required',
+                Rule::in(['message', 'contact', 'all'])
+            ],
             'limit' => 'required|integer'
         ]);
 
         $type = $params['type'];
 
-        if (!in_array($type, [ 'message', 'contact', 'all' ])) {
-            throw new \InvalidArgumentException('type parameter is invalid');
-        }
-
         if ($type == 'all') {
             $this->authorize('isAdmin');
         }
 
-        return response()->json([ 'callsigns' => Person::searchCallsigns($params['query'], $type, $params['limit']) ]);
+        return response()->json(['callsigns' => Person::searchCallsigns($params['query'], $type, $params['limit'])]);
     }
 }

--- a/app/Http/Controllers/TimesheetMissingController.php
+++ b/app/Http/Controllers/TimesheetMissingController.php
@@ -129,7 +129,7 @@ class TimesheetMissingController extends ApiController
                     'position_id' => $timesheetMissing->new_position_id,
                 ]);
 
-                if (!$timesheet->slot_id) {
+                if (!$timesheet->slot_id && $timesheet->position_id && $timesheet->on_duty) {
                     // Try to associate a slot with the sign on
                     $timesheet->slot_id = Schedule::findSlotIdSignUpByPositionTime($person->id, $timesheet->position_id, $timesheet->on_duty);
                 }

--- a/app/Models/ErrorLog.php
+++ b/app/Models/ErrorLog.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Auth;
+use Throwable;
 
 class ErrorLog extends ApiModel
 {
@@ -16,16 +18,18 @@ class ErrorLog extends ApiModel
          'data' => 'array'
      ];*/
 
-    public function person()
+    public function person(): BelongsTo
     {
         return $this->belongsTo(Person::class);
     }
 
-    /*
+    /**
      * Record an error
+     * @param string $error_type
+     * @param array $data
      */
 
-    public static function record($error_type, $data = [])
+    public static function record(string $error_type, array $data = []): void
     {
         $error = [
             'error_type' => $error_type,
@@ -46,15 +50,15 @@ class ErrorLog extends ApiModel
         self::create($error);
     }
 
-    /*
+    /**
      * Record a PHP exception
      *
-     * @param Exception $e the exception which occured
+     * @param Throwable $e the exception which occurred
      * @param string $error_type the type to record
      * @param array $extra any additional data to be logged
      */
 
-    public static function recordException($e, $error_type, $extra = [])
+    public static function recordException(Throwable $e, string $error_type, array $extra = []): void
     {
         // Inspect the exception for name, message, source location,
         // and backtrace
@@ -72,6 +76,7 @@ class ErrorLog extends ApiModel
         if ($req) {
             $data['method'] = $req->method();
             $data['url'] = $req->fullUrl();
+            $data['parameters'] = $req->all();
         }
 
         $data = array_merge($data, $extra);
@@ -101,7 +106,7 @@ class ErrorLog extends ApiModel
         }
     }
 
-    /*
+    /**
      * Find error log based on a criteria
      *
      * @param array $query
@@ -115,7 +120,7 @@ class ErrorLog extends ApiModel
      * page_size - size of page
      */
 
-    public static function findForQuery($query)
+    public static function findForQuery(array $query): array
     {
         $sql = self::query();
 

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -83,6 +83,7 @@ class Timesheet extends ApiModel
     protected $rules = [
         'person_id' => 'required|integer',
         'position_id' => 'required|integer',
+        'on_duty' => 'required|date',
         'off_duty' => 'nullable|sometimes|after_or_equal:on_duty'
     ];
 
@@ -133,11 +134,9 @@ class Timesheet extends ApiModel
          */
 
         self::saving(function ($model) {
-
             if (!$model->isDirty('slot_id')
-                && (
-                    ($model->isDirty('position_id') && $model->position_id)
-                    || ($model->isDirty('on_duty') && $model->on_duty))
+                && $model->on_duty && $model->position_id
+                && ($model->isDirty('position_id') || $model->isDirty('on_duty'))
             ) {
                 // Find new sign up to associate with
                 $model->slot_id = Schedule::findSlotIdSignUpByPositionTime($model->person_id, $model->position_id, $model->on_duty);


### PR DESCRIPTION
- Use validation rules to verify callsign lookup type
- Only try to associate a timesheet entry with a sign-up slot if position_id, and on_duty are set.
- Record parameters sent when logging an exception.