### PR TITLE
Asset schema cleanup and added new Temporary ID asset type.

### DIFF
--- a/app/Http/Controllers/AssetController.php
+++ b/app/Http/Controllers/AssetController.php
@@ -6,6 +6,7 @@ use App\Models\Asset;
 use App\Models\AssetPerson;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
 use InvalidArgumentException;
 
 class AssetController extends ApiController
@@ -38,7 +39,7 @@ class AssetController extends ApiController
      * Create a new asset
      *
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function store(): JsonResponse
@@ -74,7 +75,7 @@ class AssetController extends ApiController
      *
      * @param Asset $asset
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function update(Asset $asset): JsonResponse
@@ -125,7 +126,7 @@ class AssetController extends ApiController
      * Checkout Asset
      *
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function checkout(): JsonResponse

--- a/app/Http/Controllers/RadioCheckoutReport.php
+++ b/app/Http/Controllers/RadioCheckoutReport.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Asset;
 use App\Models\AssetPerson;
 use App\Models\Provision;
 use Illuminate\Support\Facades\DB;
@@ -44,7 +45,7 @@ class RadioCheckoutReport
             ->join('person', 'person.id', 'asset_person.person_id')
             ->join('asset', 'asset.id', 'asset_person.asset_id')
             ->whereYear('checked_out', $year)
-            ->where('description', 'radio');
+            ->where('type', Asset::TYPE_RADIO);
 
         if ($eventSummary) {
             $sql->where(function ($q) use ($seconds) {

--- a/app/Models/AssetPerson.php
+++ b/app/Models/AssetPerson.php
@@ -67,7 +67,7 @@ class AssetPerson extends ApiModel
         return $this->belongsTo(Asset::class);
     }
 
-    public function loadRelationships()
+    public function loadRelationships(): void
     {
         $this->load(self::RELATIONSHIPS);
     }

--- a/database/migrations/2023_09_23_190121_asset_cleanup.php
+++ b/database/migrations/2023_09_23_190121_asset_cleanup.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\Asset;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('asset')->where('description', Asset::TYPE_KEY)->where('barcode', 'like', 'SAND%')->update(['description' => Asset::TYPE_GEAR]);
+        DB::table('asset')->where('description', Asset::TYPE_KEY)->where('barcode', 'like', 'SM%')->update(['description' => Asset::TYPE_GEAR]);
+        DB::table('asset')->where('description', [Asset::TYPE_AMBER, Asset::TYPE_KEY, Asset::TYPE_VEHICLE])->delete();
+        DB::table('asset')->where('create_date', '0000-00-00 00:00:00')->update(['create_date' => "2009-08-15 12:00:00"]);
+        $this->adjustDescription([
+            Asset::TYPE_AMBER,
+            Asset::TYPE_GEAR,
+            Asset::TYPE_KEY,
+            Asset::TYPE_RADIO,
+            Asset::TYPE_TEMP_ID,
+            Asset::TYPE_VEHICLE,
+        ]);
+
+        Schema::table('asset', function (Blueprint $table) {
+            $table->dropColumn(['subtype', 'model', 'color', 'style']);
+        });
+
+        Schema::table('asset', function (Blueprint $table) {
+            $table->renameColumn('description', 'type');
+            $table->renameColumn('create_date', 'created_at');
+            $table->integer('year')->nullable(false)->default(0);
+            $table->index([ 'type', 'year', 'barcode']);
+            $table->index([ 'year', 'barcode']);
+        });
+
+        DB::table('asset')->update([ 'year' => DB::raw('YEAR(created_at)')]);
+        Schema::table('asset', function (Blueprint $table) {
+            $table->renameColumn('temp_id', 'description');
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+    }
+
+    public function adjustDescription(array $enums): void
+    {
+        DB::statement("ALTER TABLE asset MODIFY COLUMN description ENUM (" . implode(',', array_map(fn($e) => "'$e'", $enums)) . ")");
+    }
+};


### PR DESCRIPTION
- Column renaming: create_date -> created_at, description -> type, temp_id -> description
- Added new column year to indicate event year.
- New enum type 'temp-id' to indicate temporary BMID.
- drop old vehicle columns - model, subtype, color, style.
- Fixed up invalidate creation dates