### PR TITLE
New Developer commands.

### DIFF
--- a/app/Console/Commands/AccountSnatchCommand.php
+++ b/app/Console/Commands/AccountSnatchCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Person;
+use Illuminate\Console\Command;
+
+class AccountSnatchCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'clubhouse:account-snatch
+        {--id= : Person id to grant all the roles to}
+        {--callsign= : Callsign of account to grant all the roles to}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Reset an account password to abcdef (developer command)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (config('clubhouse.DeploymentEnvironment') == 'Production') {
+            $this->error('This command is not available in the production environment.');
+            exit(-1);
+        }
+
+        $id = $this->option('id');
+        $callsign = $this->option('callsign');
+
+        if (!$id && !$callsign) {
+            $this->error('Neither the --id nor --callsign option was given.');
+            exit(-1);
+        }
+
+        if ($id) {
+            $person = Person::find($id);
+        } else {
+            $person = Person::findByCallsign($callsign);
+        }
+
+        if (!$person) {
+            if ($id) {
+                $this->error("The person record id #{$id} was not found.");
+            } else {
+                $this->error("The callsign '{$callsign}' was not found.");
+            }
+            exit(-1);
+        }
+
+        if (!$this->confirm("Are you absolutely sure you want to reset the password for '{$person->callsign}' to abcdef?")) {
+            $this->error('Aborted - password untouched');
+            exit(-1);
+        }
+
+        $person->changePassword('abcdef');
+        $this->info('Password was successfully set.');
+        exit(0);
+    }
+}

--- a/app/Console/Commands/GrantAllRolesCommand.php
+++ b/app/Console/Commands/GrantAllRolesCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Person;
+use App\Models\PersonRole;
+use App\Models\Role;
+use Illuminate\Console\Command;
+use JetBrains\PhpStorm\NoReturn;
+
+class GrantAllRolesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'clubhouse:grant-all-roles 
+        {--id= : Person id to grant all the roles to}
+        {--callsign= : Callsign of account to grant all the roles to}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Grant all the roles to an account (developer command)';
+
+    /**
+     * Execute the console command.
+     */
+
+    #[NoReturn]
+    public function handle(): void
+    {
+        if (config('clubhouse.DeploymentEnvironment') == 'Production') {
+            $this->error('This command is not available in the production environment.');
+            exit(-1);
+        }
+
+        $id = $this->option('id');
+        $callsign = $this->option('callsign');
+
+        if (!$id && !$callsign) {
+            $this->error('Neither the --id nor --callsign option was given.');
+            exit(-1);
+        }
+
+        if ($id) {
+            $person = Person::find($id);
+        } else {
+            $person = Person::findByCallsign($callsign);
+        }
+
+        if (!$person) {
+            if ($id) {
+                $this->error("The person record id #{$id} was not found.");
+            } else {
+                $this->error("The callsign '{$callsign}' was not found.");
+            }
+            exit(-1);
+        }
+
+        if (!$this->confirm("Are you absolutely sure you want to grant all the roles to '{$person->callsign}' (id #{$person->id})?")) {
+            $this->error('Aborting - no roles were granted.');
+            exit(0);
+        }
+
+        PersonRole::addIdsToPerson($person->id, Role::pluck('id')->toArray(), 'granted via grant all roles command');
+
+        $this->info('All the roles have been granted.');
+        exit(0);
+    }
+}


### PR DESCRIPTION
- clubhouse:grant-all-roles to help bootstrap a new developer by granting all the roles to an account.
- clubhouse:account-snatch to set an account password to abcdef. Useful to debug an account locally.

Both commands cannot be run in production.