### PR TITLE
Position Sanity Checker changes.

### DIFF
--- a/app/Lib/PositionSanityCheck/DeactivatedTeamsCheck.php
+++ b/app/Lib/PositionSanityCheck/DeactivatedTeamsCheck.php
@@ -2,6 +2,7 @@
 
 namespace App\Lib\PositionSanityCheck;
 
+use App\Models\Person;
 use App\Models\PersonPosition;
 use App\Models\PersonTeam;
 use App\Models\Team;
@@ -26,6 +27,7 @@ class DeactivatedTeamsCheck
                 'people' => DB::table('person_team')
                     ->select('person.id', 'person.callsign', 'person.status', 'person_team.team_id')
                     ->join('person', 'person.id', 'person_team.person_id')
+                    ->whereNotIn('person.status', Person::DEACTIVATED_STATUSES)
                     ->where('person_team.team_id', $team->id)
                     ->orderBy('callsign')
                     ->get()

--- a/app/Lib/PositionSanityCheck/TeamMembershipCheck.php
+++ b/app/Lib/PositionSanityCheck/TeamMembershipCheck.php
@@ -2,6 +2,7 @@
 
 namespace App\Lib\PositionSanityCheck;
 
+use App\Models\Person;
 use App\Models\PersonPosition;
 use App\Models\PersonTeam;
 use App\Models\Position;
@@ -90,6 +91,7 @@ class TeamMembershipCheck extends SanityCheck
                     $j->on('person_team.person_id', 'person_position.person_id');
                     $j->where('person_team.team_id', $team->id);
                 })
+                ->whereNotIn('person.status', Person::DEACTIVATED_STATUSES)
                 ->whereNotNull('position.team_id')
                 ->whereIn('person_position.position_id', $positionIds)
                 ->whereNull('person_team.person_id');

--- a/app/Lib/PositionSanityCheck/TeamPositionsCheck.php
+++ b/app/Lib/PositionSanityCheck/TeamPositionsCheck.php
@@ -2,6 +2,7 @@
 
 namespace App\Lib\PositionSanityCheck;
 
+use App\Models\Person;
 use App\Models\PersonPosition;
 use App\Models\Position;
 use Illuminate\Support\Collection;
@@ -94,6 +95,7 @@ class TeamPositionsCheck extends SanityCheck
                 $j->on('person_position.position_id', 'position.id');
                 $j->whereColumn('person_position.person_id', 'person.id');
             })->whereNull('person_position.position_id')
+            ->whereNotIn('person.status', Person::DEACTIVATED_STATUSES)
             ->orderBy('person.callsign')
             ->orderBy('team.title')
             ->orderBy('position.title');

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -134,6 +134,15 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         self::RETIRED,
     ];
 
+    const DEACTIVATED_STATUSES = [
+        Person::BONKED,
+        Person::DECEASED,
+        Person::DISMISSED,
+        Person::PAST_PROSPECTIVE,
+        Person::RESIGNED,
+        Person::UBERBONKED
+    ];
+
     /*
      * Gender identities.
      */


### PR DESCRIPTION
- Added team membership check & removal for deactivated accounts
- Ignore all other PSC checks for deactivated accounts.