### PR TITLE
Fixed reporting on unverified timesheets.

### DIFF
--- a/app/Lib/Milestones.php
+++ b/app/Lib/Milestones.php
@@ -165,6 +165,7 @@ class Milestones
             // Timesheets!
             if (setting('TimesheetCorrectionEnable') || $person->hasRole(Role::TIMECARD_YEAR_ROUND)) {
                 $didWork = $milestones['did_work'] = Timesheet::didPersonWork($person->id, $year);
+
                 if ($didWork) {
                     $milestones['timesheets_unverified'] = Timesheet::countUnverifiedForPersonYear($person->id, $year);
                     $milestones['timesheet_confirmed'] = $event->timesheet_confirmed;

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -585,7 +585,7 @@ class Timesheet extends ApiModel
     }
 
     /**
-     * Did the given person work in a given year?
+     * Did the given person work (or walked an Alpha shift) in a given year?
      *
      * @param int $personId
      * @param int $year
@@ -596,7 +596,7 @@ class Timesheet extends ApiModel
         return DB::table('timesheet')
             ->where('person_id', $personId)
             ->whereYear('on_duty', $year)
-            ->whereNotIn('position_id', [Position::TRAINING, Position::ALPHA])
+            ->where('position_id', '!=', Position::TRAINING)
             ->limit(1)
             ->exists();
     }


### PR DESCRIPTION
Any Shiny Pennies with a single Alpha shift and no other work will not be reported as needing their timesheet confirmed.