### PR TITLE
Tidied up the unqualified sign in position reporting.

### DIFF
--- a/app/Lib/TimesheetManagement.php
+++ b/app/Lib/TimesheetManagement.php
@@ -77,7 +77,7 @@ class TimesheetManagement
             $positionRequired = Position::retrieveTitle($requiredPositionId);
             if ($canForceSignon) {
                 $signonForced = true;
-                $unqualifiedReason = Position::UNQUALIFIED_UNTRAINED;
+                $unqualifiedReason =  Position::UNQUALIFIED_UNTRAINED;
             } else {
                 $response = [
                     'status' => 'not-trained',
@@ -93,10 +93,10 @@ class TimesheetManagement
             if ($canForceSignon) {
                 $signonForced = true;
             } else {
-                $response = [
+                 $response = [
                     'status' => 'not-qualified',
                     'unqualified_reason' => $unqualifiedReason,
-                    'unqualified_message' => Position::UNQUALIFIED_MESSAGES[$unqualifiedReason]
+                    'unqualified_message' => Position::UNQUALIFIED_MESSAGES[$unqualifiedReason],
                 ];
                 return false;
             }

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -256,8 +256,8 @@ class Position extends ApiModel
 
     const UNQUALIFIED_MESSAGES = [
         self::UNQUALIFIED_UNSIGNED_SANDMAN_AFFIDAVIT => 'Sandman Affidavit not signed',
-        self::UNQUALIFIED_NO_BURN_PERIMETER_EXP => 'No Burn Perimeter experience',
-        self::UNQUALIFIED_UNTRAINED => 'Not trained',
+        self::UNQUALIFIED_NO_BURN_PERIMETER_EXP => 'No Burn Perimeter, nor Sandman, shift has been worked within the last ' . self::SANDMAN_YEAR_CUTOFF . ' years',
+        self::UNQUALIFIED_UNTRAINED => 'In-Person Training not completed.',
     ];
 
     const SANDMAN_QUALIFIED_POSITIONS = [

--- a/app/Models/Training.php
+++ b/app/Models/Training.php
@@ -117,10 +117,13 @@ class Training extends Position
              */
 
             $positionId = $position->id;
-            $trainingId = match ($positionId) {
-                Position::DIRT, Position::DIRT_PRE_EVENT, Position::DIRT_POST_EVENT => Position::TRAINING,
-                default => $position->training_position_id,
-            };
+            if ($position->no_training_required) {
+                $trainingId = null;
+            } else if ($position->training_position_id) {
+                $trainingId = $position->training_position_id;
+            } else if ($position->type != Position::TYPE_TRAINING) {
+                $trainingId = Position::TRAINING;
+            }
 
             // See if the person taught a training session required by the position
             $trainer = null;


### PR DESCRIPTION
- Report back the Sandman disqualification year cut off.
- Consider all positions as requiring an In-Person Training except those with the no_training_required flag set.