### PR TITLE
Timesheet administration work

### DIFF
--- a/app/Attributes/BlankIfEmptyAttribute.php
+++ b/app/Attributes/BlankIfEmptyAttribute.php
@@ -6,8 +6,13 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class BlankIfEmptyAttribute
 {
-    public static function make() : Attribute
+    public static function make(): Attribute
     {
-        return Attribute::make(set: fn ($value) => (empty($value) || empty(trim($value))) ? '' : $value);
+        return Attribute::make(set: function ($value) {
+            if (!empty($value)) {
+                $value = trim($value);
+            }
+            return empty($value) ? '' : $value;
+        });
     }
 }

--- a/app/Attributes/NullIfEmptyAttribute.php
+++ b/app/Attributes/NullIfEmptyAttribute.php
@@ -1,12 +1,18 @@
 <?php
 
 namespace App\Attributes;
+
 use Illuminate\Database\Eloquent\Casts\Attribute;
 
 class NullIfEmptyAttribute
 {
-    public static function make() : Attribute
+    public static function make(): Attribute
     {
-        return Attribute::make(set: fn ($value) => empty($value) ? null : $value);
+        return Attribute::make(set: function ($value) {
+            if (!empty($value)) {
+                $value = trim($value);
+            }
+            return empty($value) ? null : $value;
+        });
     }
 }

--- a/app/Http/Filters/TimesheetFilter.php
+++ b/app/Http/Filters/TimesheetFilter.php
@@ -8,23 +8,25 @@ use App\Models\Timesheet;
 
 class TimesheetFilter
 {
-    protected $record;
-
-    public function __construct(Timesheet $record)
+    public function __construct(public Timesheet $record)
     {
-        $this->record = $record;
     }
 
     const USER_FIELDS = [
         'additional_notes',
-        'review_status',
     ];
 
     const MANAGE_FIELDS = [
-        'additional_reviewer_notes',
-        'is_non_ranger',
+        'additional_worker_notes',
+        'review_status',
         'off_duty',
         'on_duty',
+    ];
+
+    const WRANGLER_FIELDS = [
+        'additional_admin_notes',
+        'additional_wrangler_notes',
+        'is_non_ranger',
         'person_id',
         'position_id',
         'suppress_duration_warning'
@@ -32,13 +34,16 @@ class TimesheetFilter
 
     public function deserialize(Person $user = null): array
     {
-        if ($user->hasRole([Role::ADMIN, Role::TIMESHEET_MANAGEMENT]))
-            return array_merge(self::USER_FIELDS, self::MANAGE_FIELDS);
+        $fields = [self::USER_FIELDS];
 
-        if ($this->record->person_id == $user->id || $user->hasRole(Role::MANAGE)) {
-            return self::USER_FIELDS;
+        if ($user->hasRole(Role::MANAGE)) {
+            $fields[] = self::MANAGE_FIELDS;
         }
 
-        return []; // Should never be hit.
+        if ($user->hasRole([Role::ADMIN, Role::TIMESHEET_MANAGEMENT])) {
+            $fields[] = self::WRANGLER_FIELDS;
+        }
+
+        return array_merge(...$fields);
     }
 }

--- a/app/Http/Filters/TimesheetMissingFilter.php
+++ b/app/Http/Filters/TimesheetMissingFilter.php
@@ -8,11 +8,8 @@ use App\Models\TimesheetMissing;
 
 class TimesheetMissingFilter
 {
-    protected $record;
-
-    public function __construct(TimesheetMissing $record)
+    public function __construct(public TimesheetMissing $record)
     {
-        $this->record = $record;
     }
 
     const USER_FIELDS = [
@@ -25,19 +22,31 @@ class TimesheetMissingFilter
     ];
 
     const MANAGE_FIELDS = [
-        'review_status',
-        'additional_reviewer_notes',
         'create_entry',
         'new_off_duty',
         'new_on_duty',
         'new_position_id',
+        'review_status',
     ];
+
+    const WRANGLER_FIELDS = [
+        'additional_admin_notes',
+        'additional_wrangler_notes',
+    ];
+
 
     public function deserialize(Person $user = null): array
     {
-        if ($user->hasRole([ Role::ADMIN, Role::TIMESHEET_MANAGEMENT ]))
-            return array_merge(self::USER_FIELDS, self::MANAGE_FIELDS);
+        $fields = [self::USER_FIELDS];
 
-        return self::USER_FIELDS;
+        if ($user->hasRole(Role::MANAGE)) {
+            $fields[] = self::MANAGE_FIELDS;
+        }
+
+        if ($user->hasRole([Role::ADMIN, Role::TIMESHEET_MANAGEMENT])) {
+            $fields[] = self::WRANGLER_FIELDS;
+        }
+
+        return array_merge(...$fields);
     }
 }

--- a/app/Models/TimesheetMissingNote.php
+++ b/app/Models/TimesheetMissingNote.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TimesheetMissingNote extends ApiModel
+{
+    use HasFactory;
+
+    protected $table = 'timesheet_missing_note';
+    protected bool $auditModel = true;
+
+    const TYPE_USER = 'user';
+    const TYPE_HQ_WORKER = 'hq-worker';
+    const TYPE_WRANGLER = 'wrangler';
+    const TYPE_ADMIN = 'admin';
+
+
+    // Notes are not directly updatable by the user.
+    public $fillable = [];
+
+    public function timesheet_missing(): BelongsTo
+    {
+        return $this->belongsTo(TimesheetMissing::class);
+    }
+
+    public function create_person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    /**
+     * Record a timesheet note
+     *
+     * @param int $timesheetMissingId
+     * @param int|null $personId null indicates the note was left by a bot
+     * @param ?string $note
+     * @param string $type
+     * @return void
+     */
+
+    public static function record(int $timesheetMissingId, ?int $personId, ?string $note, string $type): void
+    {
+        if (!empty($note)) {
+            $notes = trim($note);
+        }
+
+        if (empty($note)) {
+            return;
+        }
+
+
+        self::insert([
+            'timesheet_missing_id' => $timesheetMissingId,
+            'create_person_id' => $personId,
+            'note' => $note,
+            'type' => $type,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Models/TimesheetNote.php
+++ b/app/Models/TimesheetNote.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TimesheetNote extends ApiModel
+{
+    use HasFactory;
+
+    protected $table = 'timesheet_note';
+
+    const TYPE_USER = 'user';
+    const TYPE_HQ_WORKER = 'hq-worker';
+    const TYPE_WRANGLER = 'wrangler';
+    const TYPE_ADMIN = 'admin';
+
+    public bool $auditModel = true;
+
+    // Notes are not directly updatable by the user.
+    public $fillable = [];
+
+    public function timesheet(): BelongsTo
+    {
+        return $this->belongsTo(Timesheet::class);
+    }
+
+    public function create_person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    public $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    /**
+     * Record a timesheet note
+     *
+     * @param int $timesheetId
+     * @param int|null $personId null indicates the note was left by a bot
+     * @param ?string $note
+     * @param string $type
+     * @return void
+     */
+
+    public static function record(int $timesheetId, ?int $personId, ?string $note, string $type): void
+    {
+        if (!empty($note)) {
+            $notes = trim($note);
+        }
+
+        if (empty($note)) {
+            return;
+        }
+
+
+        self::insert([
+            'timesheet_id' => $timesheetId,
+            'create_person_id' => $personId,
+            'note' => $note,
+            'type' => $type,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Policies/TimesheetPolicy.php
+++ b/app/Policies/TimesheetPolicy.php
@@ -298,4 +298,9 @@ class TimesheetPolicy
     {
         return false;
     }
+
+    public function checkForOverlaps(Person $user, $personId) : bool
+    {
+        return $personId == $user->id;
+    }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -176,6 +176,9 @@ class AuthServiceProvider extends ServiceProvider
             return $user->hasRole(Role::VC);
         });
 
+        Gate::define('isTimesheetManager', function (Person $user) {
+           return $user->hasRole([ Role::ADMIN, Role::TIMESHEET_MANAGEMENT]);
+        });
         Gate::resource('person', 'PersonPolicy');
     }
 }

--- a/database/migrations/2023_10_26_142118_create_timesheet_note_tables.php
+++ b/database/migrations/2023_10_26_142118_create_timesheet_note_tables.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\TimesheetMissingNote;
+use App\Models\TimesheetNote;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('timesheet_note', function (Blueprint $table) {
+            $table->id();
+            $table->integer('timesheet_id')->nullable(false);
+            $table->text('note')->nullable(false);
+            $table->integer('create_person_id')->nullable(true);
+
+            $table->enum('type', [TimesheetNote::TYPE_USER, TimesheetNote::TYPE_HQ_WORKER, TimesheetNote::TYPE_WRANGLER, TimesheetNote::TYPE_ADMIN])->nullable(false)->default(TimesheetNote::TYPE_USER);
+            $table->datetime('created_at')->nullable(false);
+        });
+
+        Schema::create('timesheet_missing_note', function (Blueprint $table) {
+            $table->id();
+            $table->integer('timesheet_missing_id')->nullable(false);
+            $table->enum('type', [TimesheetMissingNote::TYPE_USER, TimesheetMissingNote::TYPE_HQ_WORKER, TimesheetMissingNote::TYPE_WRANGLER, TimesheetMissingNote::TYPE_ADMIN])->nullable(false)->default(TimesheetNote::TYPE_USER);
+            $table->text('note')->nullable(false);
+            $table->integer('create_person_id')->nullable(true);
+            $table->datetime('created_at')->nullable(false);
+        });
+
+        $this->importMissingNotes();
+    }
+
+    public function importMissingNotes(): void
+    {
+        function patch($str): string
+        {
+            $lines = explode("\n", $str);
+            $header = array_shift($lines);
+            if (!str_starts_with($header, 'From ') && !preg_match('/^\d+\/\d+\/\d+/', $header)) {
+                return $str;
+            }
+            return trim(implode("\n", $lines));
+        }
+
+        DB::table('action_logs')
+            ->select('action_logs.*', 'timesheet_missing.id as has_request')
+            ->leftJoin('timesheet_missing', 'timesheet_missing.id', DB::raw('json_value(data, "$.id")'))
+            ->whereIn('event', ['timesheet-missing-create', 'timesheet-missing-update'])
+            ->whereRaw('json_extract(data, "$.notes") is not null or json_extract(data, "$.reviewer_notes") is not null')
+            ->orderBy('id')
+            ->chunk(2000, function ($rows) {
+                foreach ($rows as $row) {
+                    if (!$row->has_request) {
+                        continue;
+                    }
+
+                    $data = json_decode($row->data);
+
+                    if (isset($data->reviewer_notes)) {
+                        $type = TimesheetNote::TYPE_WRANGLER;
+                        $note = $row->event == 'timesheet-missing-create' ? $data->reviewer_notes : $data->reviewer_notes[1];
+                    } else {
+                        $note = ($row->event == 'timesheet-missing-create' ? $data->notes : $data->notes[1]);
+                        $type = ($row->person_id == $row->target_person_id) ? TimesheetNote::TYPE_USER : TimesheetNote::TYPE_HQ_WORKER;
+                    }
+
+                    $note = patch($note);
+                    DB::table('timesheet_missing_note')
+                        ->insert([
+                            'timesheet_missing_id' => $data->id,
+                            'create_person_id' => $row->person_id,
+                            'type' => $type,
+                            'note' => $note,
+                            'created_at' => $row->created_at,
+                        ]);
+                }
+            });
+    }
+
+    public function importNotes()
+    {
+        DB::table('timesheet_log')
+            ->select('timesheet_log.*', 'timesheet.id as has_timesheet')
+            ->leftJoin('timesheet', 'timesheet.id', 'timesheet_log.timesheet_id')
+            ->whereRaw('json_extract(data, "$.notes") is not null or json_extract(data, "$.reviewer_notes") is not null')
+            ->orderBy('id')
+            ->chunk(1000, function ($rows) {
+                error_log("Chunk");
+                foreach ($rows as $row) {
+                    if (!$row->has_timesheet) {
+                        continue;
+                    }
+
+                    $data = json_decode($row->data);
+
+                    if (isset($data->reviewer_notes)) {
+                        $type = TimesheetNote::TYPE_WRANGLER;
+                        $note = $data->reviewer_notes;
+                    } else {
+                        $note = $data->notes;
+                        $type = ($row->create_person_id == $row->person_id) ? TimesheetNote::TYPE_USER : TimesheetNote::TYPE_HQ_WORKER;
+                    }
+
+                    DB::table('timesheet_note')
+                        ->insert([
+                            'timesheet_id' => $row->timesheet_id,
+                            'create_person_id' => $row->create_person_id,
+                            'type' => $type,
+                            'note' => $note,
+                            'created_at' => $row->created_at,
+                        ]);
+                }
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('timesheet_note');
+        Schema::dropIfExists('timesheet_missing_note');
+    }
+};

--- a/php-inis/xdebug.ini
+++ b/php-inis/xdebug.ini
@@ -12,7 +12,7 @@
 memory_limit = 4096M
 
 [xdebug]
-zend_extension=/opt/homebrew/Cellar/php/8.2.6/pecl/20220829/xdebug.so
+zend_extension=/opt/homebrew/Cellar/php/8.2.11/pecl/20220829/xdebug.so
 
 xdebug.mode=debug
 #xdebug.mode = profile

--- a/routes/api.php
+++ b/routes/api.php
@@ -169,7 +169,6 @@ Route::group([
     Route::post('online-course/{online_course}/set-name', 'OnlineCourseController@setName');
     Route::resource('online-course', 'OnlineCourseController');
 
-
     Route::post('person-online-course/{person}/change', 'PersonOnlineCourseController@change');
     Route::get('person-online-course/{person}/course-info', 'PersonOnlineCourseController@courseInfo');
     Route::get('person-online-course/{person}/info', 'PersonOnlineCourseController@getInfo');
@@ -386,6 +385,7 @@ Route::group([
     Route::patch('ticketing/{person}/wapso', 'TicketingController@storeWAPSO');
 
     Route::post('timesheet/bulk-sign-in-out', 'TimesheetController@bulkSignInOut');
+    Route::get('timesheet/check-overlap', 'TimesheetController@checkForOverlaps');
     Route::get('timesheet/correction-requests', 'TimesheetController@correctionRequests');
     Route::get('timesheet/correction-statistics', 'TimesheetController@correctionStatistics');
     Route::post('timesheet/confirm', 'TimesheetController@confirm');


### PR DESCRIPTION
- New api timesheet/check-overlaps, check to see if the given date time range overlaps with any existing timesheet entries.
- Deprecated {timesheet,timesheet_missing}.{notes,reviewer_notes} and replaced with new tables timesheet_note, and timesheet_missing_note.
- Support creating a new timesheet at the same time a new timesheet missing request is created.