### PR TITLE
RBS Team Support, new Megaphone permissions.

### DIFF
--- a/app/Http/Controllers/ErrorLogController.php
+++ b/app/Http/Controllers/ErrorLogController.php
@@ -55,8 +55,8 @@ class ErrorLogController extends ApiController
             'person_id' => 'sometimes|integer',
             'sort' => 'sometimes|string',
 
-            'starts_at' => 'sometimes|datetime',
-            'ends_at' => 'sometimes|datetime',
+            'starts_at' => 'sometimes|date',
+            'ends_at' => 'sometimes|date',
 
             'error_type' => 'sometimes|string',
 

--- a/app/Jobs/RBSTransmitClubhouseMessageJob.php
+++ b/app/Jobs/RBSTransmitClubhouseMessageJob.php
@@ -2,41 +2,31 @@
 
 namespace App\Jobs;
 
+use App\Lib\RBS;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
-use App\Lib\RBS;
-
 class RBSTransmitClubhouseMessageJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
-    public $alert;
-    public $broadcastId;
-    public $userId;
-    public $people;
-    public $from;
-    public $subject;
-    public $message;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($alert, $broadcastId, $userId, $people, $from, $subject, $message)
+    public function __construct(public $alert,
+                                public $broadcastId,
+                                public $userId,
+                                public $people,
+                                public $from,
+                                public $subject,
+                                public $message,
+                                public $expiresAt)
     {
-        $this->alert = $alert;
-        $this->broadcastId = $broadcastId;
-        $this->userId = $userId;
-        $this->people = $people;
-        $this->from = $from;
-        $this->subject = $subject;
-        $this->message = $message;
-
     }
 
     /**
@@ -44,9 +34,16 @@ class RBSTransmitClubhouseMessageJob implements ShouldQueue
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
-        RBS::broadcastClubhouse($this->alert, $this->broadcastId,
-            $this->userId, $this->people, $this->from, $this->subject, $this->message);
+        RBS::broadcastClubhouse($this->alert,
+            $this->broadcastId,
+            $this->userId,
+            $this->people,
+            $this->from,
+            $this->subject,
+            $this->message,
+            $this->expiresAt
+        );
     }
 }

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -900,9 +900,11 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
         $this->trueRoles = array_keys($this->rolesById);
 
         $haveManage = $this->rolesById[Role::MANAGE] ?? false;
+        $lmopEnabled = setting('LoginManageOnPlayaEnabled');
+
         if (!$haveManage
             && isset($this->rolesById[Role::MANAGE_ON_PLAYA])
-            && setting('LoginManageOnPlayaEnabled')) {
+            && $lmopEnabled) {
             $this->rolesById[Role::MANAGE] = true;
             $haveManage = true;
         }
@@ -911,6 +913,12 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
             && isset($this->rolesById[Role::TRAINER_SEASONAL])
             && setting('TrainingSeasonalRoleEnabled')) {
             $this->rolesById[Role::TRAINER] = true;
+        }
+
+        foreach ([ Role::MEGAPHONE_EMERGENCY_ONPLAYA, Role::MEGAPHONE_TEAM_ONPLAYA] as $role) {
+            if (isset($this->rolesById[$role]) && !$lmopEnabled) {
+                unset($this->rolesById[$role]);
+            }
         }
 
         $this->rawRolesById = $this->rolesById;

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -42,6 +42,8 @@ class Role extends ApiModel
     const SALESFORCE_IMPORT = 118;      // Allowed to import new accounts from Salesforce
     const MESSAGE_MANAGEMENT = 119;     // Allow access to Clubhouse Messages year round regardless of LMOP Enabled setting.
     const EDIT_CLOTHING = 120;   // Can edit a clothing fields.
+    const MEGAPHONE_TEAM_ONPLAYA = 121;  // On-Playa Megaphone permission
+    const MEGAPHONE_EMERGENCY_ONPLAYA = 122;    // Allows access to the broadcast all emergency
     const TECH_NINJA = 1000;    // godlike powers granted - access to dangerous maintenance functions, raw database access.
 
 

--- a/app/Models/TeamManager.php
+++ b/app/Models/TeamManager.php
@@ -49,6 +49,18 @@ class TeamManager extends ApiModel
     }
 
     /**
+     * Can the person manage this position?
+     *
+     */
+
+    public static function canManagePosition(int $personId, int $positionId) : bool {
+        return self::join('position', 'position.team_id', 'team_manager.team_id')
+            ->where('team_manager.person_id', $personId)
+            ->where('position.id', $positionId)
+            ->exists();
+
+    }
+    /**
      * Retrieve the teams a person if a manager.
      *
      * @param int $personId

--- a/app/Policies/BroadcastPolicy.php
+++ b/app/Policies/BroadcastPolicy.php
@@ -22,7 +22,7 @@ class BroadcastPolicy
      * Can a user view their own messages?
      */
 
-    public function messages(Person $user, $personId)
+    public function messages(Person $user, $personId): bool
     {
         return ($user->id == $personId);
     }
@@ -40,7 +40,7 @@ class BroadcastPolicy
      * Can a user see the stats
      */
 
-    public function stats(Person $user)
+    public function stats(Person $user): false
     {
         return false;
     }
@@ -49,7 +49,7 @@ class BroadcastPolicy
      * Can a user retry a broadcast
      */
 
-    public function retry(Person $user)
+    public function retry(Person $user): false
     {
         return false;
     }
@@ -58,27 +58,27 @@ class BroadcastPolicy
      * Can a user see the unknown phones
      */
 
-    public function unknownPhones(Person $user): bool
+    public function unknownPhones(Person $user): false
     {
         return false;
+    }
+
+    public function details(Person $user): bool
+    {
+        return $user->hasRole([Role::MEGAPHONE, Role::MEGAPHONE_TEAM_ONPLAYA, Role::MEGAPHONE_EMERGENCY_ONPLAYA]);
     }
 
     /*
      * Is the user allowed to interact with the broadcast type?
      */
 
-    public function typeAllowed(Person $user, $type)
+    public function typeAllowed(Person $user, $type): bool
     {
-        if ($user->hasRole(Role::MEGAPHONE)) {
-            return true;
+        if ($type == Broadcast::TYPE_EMERGENCY) {
+            return $user->hasRole(Role::MEGAPHONE_EMERGENCY_ONPLAYA);
         }
 
-        if ($user->hasRole(Role::EDIT_SLOTS)
-            && ($type == Broadcast::TYPE_SLOT || $type == Broadcast::TYPE_SLOT_EDIT)) {
-            return true;
-        }
-
-        return false;
+        return $user->hasRole([Role::MEGAPHONE, Role::MEGAPHONE_TEAM_ONPLAYA, Role::MEGAPHONE_EMERGENCY_ONPLAYA]);
     }
 
     /**
@@ -88,7 +88,8 @@ class BroadcastPolicy
      * @return bool
      */
 
-    public function transmit(Person $user) : bool {
-        return $user->hasRole(Role::MEGAPHONE);
+    public function transmit(Person $user): bool
+    {
+        return $user->hasRole([Role::MEGAPHONE, Role::MEGAPHONE_TEAM_ONPLAYA, Role::MEGAPHONE_EMERGENCY_ONPLAYA]);
     }
 }

--- a/database/migrations/2023_11_09_184006_megaphone_roles.php
+++ b/database/migrations/2023_11_09_184006_megaphone_roles.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('role', function (Blueprint $table) {
+            $table->string('title')->nullable(false)->change();
+        });
+
+        DB::table('role')->insert([
+            'id' => Role::MEGAPHONE_TEAM_ONPLAYA,
+            'title' => 'Megaphone Team On Playa'
+        ]);
+        DB::table('role')->insert([
+            'id' => Role::MEGAPHONE_EMERGENCY_ONPLAYA,
+            'title' => 'Megaphone Emergency On Playa'
+        ]);
+        Schema::table('person_message', function (Blueprint $table) {
+            $table->datetime('expires_at')->nullable(true);
+        });
+        Schema::table('broadcast', function (Blueprint $table) {
+            $table->datetime('expires_at')->nullable(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('role')->whereIn('id', [Role::MEGAPHONE_TEAM_ONPLAYA, Role::MEGAPHONE_EMERGENCY_ONPLAYA])->delete();
+        Schema::table('person_message', function (Blueprint $table) {
+            $table->dropColumn('expires_at');
+        });
+        Schema::table('broadcast', function (Blueprint $table) {
+            $table->dropColumn('expires_at');
+        });
+    }
+};


### PR DESCRIPTION
- existing Megaphone permission considered year round now, and allows access to all broadcasts types, except the emergency broadcast feature. All positions are available to be messaged.
- New Megaphone Team On Playa permission: restricted access to the RBS, only allows messaging the positions the user is a Clubhouse Team Manager for.
- New Megaphone Emergency On Playa: access to the emergency broadcast.
- Broadcasts have an expiration associated, use to attach to a Clubhouse Message.
- Clubhouse Messages have an optional expiration date, only messages generated thru the RBS uses this.