### PR TITLE
Parent/Child slot signup work.

### DIFF
--- a/app/Http/Controllers/PersonScheduleController.php
+++ b/app/Http/Controllers/PersonScheduleController.php
@@ -25,7 +25,7 @@ class PersonScheduleController extends ApiController
      *
      * @param Person $person
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|\Psr\SimpleCache\InvalidArgumentException
      */
 
     public function index(Person $person): JsonResponse
@@ -183,9 +183,6 @@ class PersonScheduleController extends ApiController
 
             return response()->json($response);
         }
-
-        // Person might be active next (this) event.
-        $person->update(['active_next_event' => 1]);
 
         $forcedReasons = [];
 

--- a/app/Http/Filters/PersonFilter.php
+++ b/app/Http/Filters/PersonFilter.php
@@ -101,7 +101,6 @@ class PersonFilter
     ];
 
     const EVENT_FIELDS = [
-        'active_next_event',
         'on_site',
     ];
 

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -194,7 +194,6 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
     ];
 
     protected $casts = [
-        'active_next_event' => 'boolean',
         'behavioral_agreement' => 'boolean',
         'callsign_approved' => 'boolean',
         'created_at' => 'datetime',
@@ -219,7 +218,6 @@ class Person extends ApiModel implements JWTSubject, AuthenticatableContract, Au
      */
 
     protected $fillable = [
-        'active_next_event',
         'alt_phone',
         'apt',
         'behavioral_agreement',

--- a/database/migrations/2023_11_11_140558_add_dependent_signup_to_slot.php
+++ b/database/migrations/2023_11_11_140558_add_dependent_signup_to_slot.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('slot', function (Blueprint $table) {
+            $table->integer('parent_signup_slot_id')->nullable(true);
+            $table->index('parent_signup_slot_id');
+        });
+
+        Schema::table('person', function (Blueprint $table) {
+            $table->dropColumn('active_next_event');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('slot', function (Blueprint $table) {
+            $table->dropColumn('parent_signup_slot_id');
+        });
+    }
+};


### PR DESCRIPTION
A parent/child slot relationship can be established so the signup counts work together. Primary target is the Troubleshooters where the TS Mentor (aka child slot) signups counts against the related TS shift (aka parent slot) signup counts.

e.g., if a TS Mentor shift has 2 signups, and the corresponding TS shift has 3 signups, then the TS shift will have an effective signup count of 5.