### PR TITLE
Various Salesforce import enhancements

### DIFF
--- a/app/Models/HandleReservation.php
+++ b/app/Models/HandleReservation.php
@@ -30,6 +30,19 @@ class HandleReservation extends ApiModel
     const TYPE_TWII_PERSON = 'twii_person';
     const TYPE_UNCATEGORIZED = 'uncategorized';
 
+    const TYPE_LABELS = [
+        self::TYPE_BRC_TERM => 'BRC Term',
+        self::TYPE_DECEASED_PERSON => 'Deceased person',
+        self::TYPE_DISMISSED_PERSON => 'Dismissed person',
+        self::TYPE_OBSCENE => 'Obscene word or phrase',
+        self::TYPE_PHONETIC_ALPHABET => 'Phonetic alphabet word',
+        self::TYPE_RADIO_JARGON => 'Radio jargon',
+        self::TYPE_RANGER_TERM => 'Ranger term',
+        self::TYPE_SLUR => 'Slur',
+        self::TYPE_TWII_PERSON => 'TWII Person',
+        self::TYPE_UNCATEGORIZED => 'Uncategorized',
+    ];
+
     protected $fillable = [
         'handle',
         'reservation_type',
@@ -173,5 +186,9 @@ class HandleReservation extends ApiModel
             'expires_on' => (string)(now()->addYears(Person::GRIEVING_PERIOD_YEARS)),
             'reason' => 'marked deceased by ' . (Auth::user()->callsign ?? 'unknown') . ' on ' . now()->format('Y-m-d'),
         ]);
+    }
+
+    public function getTypeLabel() : string {
+        return self::TYPE_LABELS[$this->reservation_type] ?? $this->reservation_type;
     }
 }


### PR DESCRIPTION
- Allow a Salesforce record with the same callsign & bpguid as an existing Clubhouse account to be imported (really sync'ed). Deals with the situation where BM employees have an existing (auditor/non-ranger/etc) Clubhouse account yet want to become a Ranger as well.
- Swap over to the Handle Reservation table from the (now defunct) Reserved Callsign list.
- Report back the Handle Reservation record type, and expiration date, if the desired callsign is on the list.