### PR TITLE
Reworked FKA handling.

### DIFF
--- a/app/Http/Controllers/PersonFkaController.php
+++ b/app/Http/Controllers/PersonFkaController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\PersonFka;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
+
+class PersonFkaController extends ApiController
+{
+    /**
+     * Retrieve a list of records based on a criteria
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function index(): JsonResponse
+    {
+        $params = request()->validate([
+            'person_id' => 'required|integer|exists:person,id'
+        ]);
+
+        $this->authorize('index', [PersonFka::class, $params['person_id']]);
+
+        return $this->success(PersonFka::findForQuery($params), null, 'person_fka');
+    }
+
+    /***
+     * Create a person fka record
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException|ValidationException
+     */
+
+    public function store(): JsonResponse
+    {
+        $person_fka = new PersonFka;
+        $this->fromRest($person_fka);
+
+        $this->authorize('store', $person_fka);
+
+        if ($person_fka->save()) {
+            return $this->success($person_fka);
+        }
+
+        return $this->restError($person_fka);
+    }
+
+    /**
+     * Update the specified person fka in storage.
+     *
+     * @param PersonFka $person_fka
+     * @return JsonResponse
+     * @throws AuthorizationException|ValidationException
+     */
+
+    public function update(PersonFka $person_fka): JsonResponse
+    {
+        $this->authorize('update', $person_fka);
+        $this->fromRest($person_fka);
+
+        if ($person_fka->save()) {
+            return $this->success($person_fka);
+        }
+
+        return $this->restError($person_fka);
+    }
+
+    /**
+     * Delete a person fka record
+     *
+     * @param PersonFka $person_fka
+     * @return JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function destroy(PersonFka $person_fka): JsonResponse
+    {
+        $this->authorize('destroy', $person_fka);
+        $person_fka->delete();
+        return $this->restDeleteSuccess();
+    }
+}

--- a/app/Http/Filters/PersonFilter.php
+++ b/app/Http/Filters/PersonFilter.php
@@ -15,12 +15,12 @@ class PersonFilter
     {
     }
 
-    const STATUS_FIELDS = [
+    const array STATUS_FIELDS = [
         'status',
         'status_date',
     ];
 
-    const ACCOUNT_FIELDS = [
+    const array ACCOUNT_FIELDS = [
         'created_at',
         'date_verified',
         'employee_id',
@@ -32,7 +32,7 @@ class PersonFilter
         'vintage',
     ];
 
-    const NAME_GENDER_FIELDS = [
+    const array NAME_GENDER_FIELDS = [
         'first_name',
         'mi',
         'last_name',
@@ -44,19 +44,18 @@ class PersonFilter
         'pronouns_custom',
     ];
 
-    const CALLSIGNS_FIELDS = [
+    const array CALLSIGNS_FIELDS = [
         'callsign',
         'callsign_approved',
-        'formerly_known_as',
         'used_vanity_change',
         'vanity_changed_at'
     ];
 
-    const EMAIL_FIELDS = [
+    const array EMAIL_FIELDS = [
         'email',
     ];
 
-    const PERSONAL_INFO_FIELDS = [
+    const array PERSONAL_INFO_FIELDS = [
         'street1',
         'street2',
         'apt',
@@ -74,54 +73,54 @@ class PersonFilter
         'has_reviewed_pi', // pseudo field
     ];
 
-    const CLOTHING_FIELDS = [
+    const array CLOTHING_FIELDS = [
         'tshirt_swag_id',
         'tshirt_secondary_swag_id',
         'long_sleeve_swag_id',
     ];
 
-    const HQ_INFO = [
+    const array HQ_INFO = [
         'on_site',
         'camp_location',
     ];
 
-    const EMERGENCY_CONTACT = [
+    const array EMERGENCY_CONTACT = [
         'emergency_contact'
     ];
 
-    const AGREEMENT_FIELDS = [
+    const array AGREEMENT_FIELDS = [
         'behavioral_agreement',
     ];
 
-    const RANGER_ADMIN_FIELDS = [
+    const array RANGER_ADMIN_FIELDS = [
         'vehicle_blacklisted',
     ];
 
-    const EVENT_FIELDS = [
+    const array EVENT_FIELDS = [
         'on_site',
     ];
 
-    const BMID_FIELDS = [
+    const array BMID_FIELDS = [
         'bpguid',
     ];
 
     // Learning Management System fields
-    const LMS_FIELDS = [
+    const array LMS_FIELDS = [
         'lms_id',
         'lms_username'
     ];
 
-    const INTAKE_FIELDS = [
+    const array INTAKE_FIELDS = [
         'known_rangers',
         'known_pnvs'
     ];
 
-    const SMS_FIELDS = [
+    const array SMS_FIELDS = [
         'sms_on_playa',
         'sms_off_playa',
     ];
 
-    const SMS_ADMIN_FIELDS = [
+    const array SMS_ADMIN_FIELDS = [
         'sms_on_playa_verified',
         'sms_off_playa_verified',
         'sms_on_playa_stopped',
@@ -130,12 +129,12 @@ class PersonFilter
         'sms_off_playa_code',
     ];
 
-    const MESSAGE_FIELDS = [
+    const array MESSAGE_FIELDS = [
         'message',
         'message_updated_at'
     ];
 
-    const PERSONNEL_FIELDS = [
+    const array PERSONNEL_FIELDS = [
         'has_note_on_file',
     ];
 
@@ -146,7 +145,7 @@ class PersonFilter
     // 2: which roles are allowed the field (if null, allow any)
     // 3: Only allowed if LoginManagementOnPlayaEnabled is turned on.
 
-    const FIELDS_SERIALIZE = [
+    const array FIELDS_SERIALIZE = [
         [self::NAME_GENDER_FIELDS],
         [self::STATUS_FIELDS],
         [self::ACCOUNT_FIELDS],
@@ -169,7 +168,7 @@ class PersonFilter
         [self::EMERGENCY_CONTACT, true, [Role::VIEW_PII, Role::VC], true],
     ];
 
-    const FIELDS_DESERIALIZE = [
+    const array FIELDS_DESERIALIZE = [
         [self::NAME_GENDER_FIELDS, true, [Role::VC]],
         [self::ACCOUNT_FIELDS, false, [Role::ADMIN]],
         [self::MESSAGE_FIELDS, false, [Role::ADMIN, Role::VC]],

--- a/app/Lib/Intake.php
+++ b/app/Lib/Intake.php
@@ -254,7 +254,10 @@ class Intake
         $alphaEntries = Timesheet::retrieveAllForPositionIds($pnvIds, Position::ALPHA);
 
         // Find the people
-        $people = Person::whereIntegerInRaw('id', $pnvIds)->orderBy('callsign')->get();
+        $people = Person::whereIntegerInRaw('id', $pnvIds)
+            ->orderBy('callsign')
+            ->with('person_fka')
+            ->get();
 
         $pnvs = [];
         foreach ($people as $person) {

--- a/app/Models/PersonFka.php
+++ b/app/Models/PersonFka.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PersonFka extends ApiModel
+{
+    protected $table = 'person_fka';
+
+    public bool $auditModel = true;
+    public $timestamps = false;
+
+    protected $fillable = [
+        'person_id',
+        'fka'
+    ];
+
+    const string IRRELEVANT_REGEXP = '/\d{2,4}[B]?(\(NR\))?$/';
+
+    public $rules = [
+        'fka' => 'required|string|max:255',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+        'is_irrelevant' => 'bool',
+    ];
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        self::creating(function ($model) {
+            $model->created_at = now();
+        });
+    }
+
+    public function person(): BelongsTo
+    {
+        return $this->belongsTo(Person::class);
+    }
+
+    /**
+     * Find FKA records based on the given criteria
+     *
+     * @param $query
+     * @return Collection
+     */
+
+    public static function findForQuery($query): Collection
+    {
+        $personId = $query['person_id'] ?? null;
+
+        $sql = self::query();
+
+        if ($personId) {
+            $sql->where('person_id', $personId);
+        }
+
+        return $sql->orderBy('person_id')->orderBy('fka_normalized')->get();
+    }
+
+    /**
+     * Update the FKA callsign list.
+     */
+
+    public static function addFkaToPerson(int $personId, ?string $oldCallsign): void
+    {
+        if (empty($oldCallsign)) {
+            return;
+        }
+
+        $query = ['person_id' => $personId, 'fka' => $oldCallsign];
+        if (self::where($query)->exists()) {
+            return;
+        }
+
+        $row = new PersonFka;
+        $row->fka = $oldCallsign;
+        $row->person_id = $personId;
+        $row->saveWithoutValidation();
+    }
+
+    /**
+     * Set the fka, and update the normalized version.
+     * @param string|null $value
+     * @return void
+     */
+    public function setFkaAttribute(?string $value): void
+    {
+        if (empty($value)) {
+            $value = '';
+        } else {
+            $value = trim($value);
+        }
+
+        $this->attributes['fka'] = $value;
+        $this->fka_normalized = Person::normalizeCallsign($value);
+        $this->is_irrelevant = (bool)preg_match(self::IRRELEVANT_REGEXP, $value);
+        $this->attributes['fka_soundex'] = metaphone(Person::spellOutNumbers($this->fka_normalized));
+    }
+
+    /**
+     * Filter out irrelevant callsigns from an array.
+     * i.e., bonked callsigns - <name>B<YY>, past prospective callsign <name><YY>, auditor callsigns <name> (NR)
+     *
+     * @param $names
+     * @return array
+     */
+
+    public static function filterOutIrrelevant($names): array
+    {
+        if (empty($names)) {
+            return [];
+        }
+
+        return array_values(array_filter($names, fn($name) => !preg_match(self::IRRELEVANT_REGEXP, $name)));
+    }
+}

--- a/app/Models/PersonLanguage.php
+++ b/app/Models/PersonLanguage.php
@@ -23,6 +23,7 @@ class PersonLanguage extends ApiModel
     protected $table = 'person_language';
 
     public $timestamps = false;
+    public bool $auditModel = true;
 
     protected $guarded = [];
 

--- a/app/Policies/PersonFkaPolicy.php
+++ b/app/Policies/PersonFkaPolicy.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Person;
+use App\Models\PersonFka;
+use App\Models\Role;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class PersonFkaPolicy
+{
+    use HandlesAuthorization;
+
+    public function before($user): ?bool
+    {
+        if ($user->hasRole([Role::ADMIN, Role::MENTOR, Role::VC])) {
+            return true;
+        }
+
+        return null;
+    }
+
+    /**
+     * Can the person see a list of records?
+     * @param Person $user
+     * @param $personId
+     * @return bool
+     */
+
+    public function index(Person $user, $personId): bool
+    {
+        return $user->id == $personId || $user->hasRole(Role::MANAGE);
+    }
+
+    /**
+     * Can the person create a fka record
+     *
+     * @param Person $user
+     * @param PersonFka $person_fka
+     * @return true
+     */
+
+    public function show(Person $user, PersonFka $person_fka): true
+    {
+        return $user->id == $person_fka->person_id || $user->hasRole(Role::MANAGE);
+    }
+
+    /**
+     * Can the person create a fka record
+     *
+     * @param Person $user
+     * @param PersonFka $person_fka
+     * @return false
+     */
+
+    public function store(Person $user, PersonFka $person_fka): false
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the record.
+     * @param Person $user
+     * @param PersonFka $person_fka
+     * @return false
+     */
+
+    public function update(Person $user, PersonFka $person_fka): false
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete a record
+     * @param Person $user
+     * @param PersonFka $person_fka
+     * @return false
+     */
+
+    public function destroy(Person $user, PersonFka $person_fka): false
+    {
+        return false;
+    }
+}

--- a/database/migrations/2024_03_30_103631_add_person_fka_table.php
+++ b/database/migrations/2024_03_30_103631_add_person_fka_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Models\Person;
+use App\Models\PersonFka;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('person_fka', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('person_id')->nullable(false);
+            $table->datetime('created_at')->nullable(true);
+            $table->string('fka')->nullable(false);
+            $table->string('fka_normalized')->nullable(false);
+            $table->string('fka_soundex')->nullable(false);
+            $table->boolean('is_irrelevant')->nullable(false)->default(false);
+            $table->index(['person_id', 'fka']);
+            $table->index(['person_id', 'fka_normalized']);
+            $table->index(['person_id', 'fka_soundex']);
+        });
+
+        Person::select('id', 'formerly_known_as')
+            ->whereNotNull('formerly_known_as')
+            ->where('formerly_known_as', '!=', '')
+            ->chunk(500, function ($rows) {
+                $data = [];
+                foreach ($rows as $row) {
+                    $fkas = Person::splitCommas($row->formerly_known_as);
+                    if (empty($fkas)) {
+                        continue;
+                    }
+                    foreach ($fkas as $fka) {
+                        $data[] = [
+                            'person_id' => $row->id,
+                            'fka' => $fka,
+                            'fka_normalized' => Person::normalizeCallsign($fka),
+                            'fka_soundex' => metaphone(Person::spellOutNumbers($fka)),
+                            'is_irrelevant' => (bool)preg_match(PersonFka::IRRELEVANT_REGEXP, $fka),
+                        ];
+                    }
+                }
+                if (!empty($data)) {
+                    DB::table('person_fka')->insert($data);
+                }
+            });
+
+        Schema::table('person', function (Blueprint $table) {
+            $table->dropColumn('formerly_known_as');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('person_fka');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,7 +38,6 @@ use App\Http\Controllers\FileController;
 use App\Http\Controllers\HandleReservationController;
 use App\Http\Controllers\HelpController;
 use App\Http\Controllers\IntakeController;
-use App\Http\Controllers\PersonLanguageController;
 use App\Http\Controllers\MailLogController;
 use App\Http\Controllers\MaintenanceController;
 use App\Http\Controllers\MentorController;
@@ -50,6 +49,8 @@ use App\Http\Controllers\PersonAwardController;
 use App\Http\Controllers\PersonCertificationController;
 use App\Http\Controllers\PersonController;
 use App\Http\Controllers\PersonEventController;
+use App\Http\Controllers\PersonFkaController;
+use App\Http\Controllers\PersonLanguageController;
 use App\Http\Controllers\PersonMessageController;
 use App\Http\Controllers\PersonOnlineCourseController;
 use App\Http\Controllers\PersonPhotoController;
@@ -200,6 +201,8 @@ Route::middleware('api')->group(function () {
     Route::get('debug/db-test', [DebugController::class, 'dbTest']);
     Route::get('debug/phpinfo', [DebugController::class, 'phpInfo']);
     Route::get('debug/cpuinfo', [DebugController::class, 'cpuInfo']);
+
+    Route::resource('person-fka', PersonFkaController::class);
 
     Route::get('person-language/common-languages', [PersonLanguageController::class, 'commonLanguages']);
     Route::get('person-language/search', [PersonLanguageController::class, 'search']);


### PR DESCRIPTION
- Moved person.formerly_known_as into it's own table person_fka.
- New Person FKA controller.
- Better irrelevant FKAs (old auditor callsigns, bonked, or past prospective formatted) filtering on various reports.
- FKA searching improved thanks to metaphone searches (something not possible when the FKAs was one long string.)