### PR TITLE
Loosened the restrictions on position and team management.

### DIFF
--- a/app/Http/Controllers/TeamController.php
+++ b/app/Http/Controllers/TeamController.php
@@ -8,6 +8,7 @@ use App\Lib\Reports\TeamMembershipReport;
 use App\Models\Team;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
 
 class TeamController extends ApiController
 {
@@ -32,7 +33,7 @@ class TeamController extends ApiController
      * Create a new team.
      *
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function store(): JsonResponse
@@ -68,12 +69,12 @@ class TeamController extends ApiController
      *
      * @param Team $team
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function update(Team $team): JsonResponse
     {
-        $this->authorize('update', Team::class);
+        $this->authorize('update', $team);
         $this->fromRest($team);
 
         if ($team->save()) {
@@ -94,7 +95,7 @@ class TeamController extends ApiController
 
     public function destroy(Team $team): JsonResponse
     {
-        $this->authorize('delete', Team::class);
+        $this->authorize('delete', $team);
         $team->delete();
         return $this->restDeleteSuccess();
     }
@@ -148,7 +149,7 @@ class TeamController extends ApiController
      * @throws AuthorizationException
      */
 
-    public function membership(Team $team) : JsonResponse
+    public function membership(Team $team): JsonResponse
     {
         $this->authorize('membership', $team);
 

--- a/app/Lib/Membership.php
+++ b/app/Lib/Membership.php
@@ -10,6 +10,7 @@ use App\Models\PositionRole;
 use App\Models\Team;
 use App\Models\TeamManager;
 use App\Models\TeamRole;
+use Illuminate\Auth\Access\AuthorizationException;
 
 class Membership
 {
@@ -56,6 +57,7 @@ class Membership
      * @param array|null $revokeIds
      * @param string $reason
      * @param bool $isAdmin
+     * @throws AuthorizationException
      */
 
     public static function updatePositionsForPerson(int    $userId,
@@ -77,7 +79,6 @@ class Membership
 
         if ($positionIds !== null) {
             [$newIds, $deleteIds] = self::determineGrantRevokes($positions, $positionIds, 'id');
-
             if (!$isAdmin) {
                 // Need to check on each position to see if it's allowed
                 $newIds = self::canManagePositions($newIds, $manageIds);

--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -376,10 +376,11 @@ class Position extends ApiModel
         parent::boot();
 
         self::saved(function ($model) {
-            if (is_array($model->role_ids)) {
+            if (is_array($model->role_ids) && Auth::user()?->hasRole(Role::TECH_NINJA)) {
                 // Update Position Roles
                 Membership::updatePositionRoles($model->id, $model->role_ids, '');
             }
+            ClubhouseCache::flush();
         });
 
         self::deleted(function ($model) {

--- a/app/Models/PositionRole.php
+++ b/app/Models/PositionRole.php
@@ -78,11 +78,6 @@ class PositionRole extends ApiModel
 
     public static function add(int $positionId, int $roleId, ?string $reason): void
     {
-        if ($roleId == Role::ADMIN || $roleId == Role::TECH_NINJA) {
-            // Nope, don't allow unchecked privilege escalation.
-            return;
-        }
-
         $data = ['position_id' => $positionId, 'role_id' => $roleId];
         if (self::insertOrIgnore($data) == 1) {
             ClubhouseCache::flush();

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -65,7 +66,7 @@ class Team extends ApiModel
 
         self::saved(function ($model) {
             // Don't use empty() because the array might be empty indicating no roles are to be assigned
-            if (is_array($model->role_ids)) {
+            if (is_array($model->role_ids) && Auth::user()?->hasRole(Role::TECH_NINJA)) {
                 // Update Position Roles
                 Membership::updateTeamRoles($model->id, $model->role_ids, $model->auditReason ?? '');
             }

--- a/app/Models/TeamRole.php
+++ b/app/Models/TeamRole.php
@@ -54,11 +54,6 @@ class TeamRole extends ApiModel
 
     public static function add(int $teamId, int $roleId, ?string $reason): void
     {
-        if ($roleId == Role::ADMIN || $roleId == Role::TECH_NINJA) {
-            // Nope, don't allow unchecked privilege escalation.
-            return;
-        }
-
         $data = ['team_id' => $teamId, 'role_id' => $roleId];
         if (self::insertOrIgnore($data) == 1) {
             ClubhouseCache::flush();

--- a/app/Policies/PersonPolicy.php
+++ b/app/Policies/PersonPolicy.php
@@ -11,7 +11,7 @@ class PersonPolicy
 {
     use HandlesAuthorization;
 
-    const AUTHORIZED_ROLES = [
+    const array AUTHORIZED_ROLES = [
         Role::ADMIN,
         Role::ART_TRAINER,
         Role::MANAGE,
@@ -85,9 +85,9 @@ class PersonPolicy
      *
      * @param Person $user
      * @param Person $person
-     * @return mixed
+     * @return bool|Response
      */
-    public function update(Person $user, Person $person): mixed
+    public function update(Person $user, Person $person): bool|Response
     {
         /*
          * Do not allow a person to be updated when the status is problematic.
@@ -170,6 +170,11 @@ class PersonPolicy
     public function mentors(Person $user, Person $person): bool
     {
         return ($user->id == $person->id || $user->hasRole([Role::ADMIN, Role::VC, Role::MENTOR]));
+    }
+
+    public function eventInfo(Person $user, Person $person): bool
+    {
+        return $user->id == $person->id || $user->hasRole([Role::ADMIN, Role::MANAGE]);
     }
 
     public function alphaShirts(Person $user): bool

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -13,11 +13,9 @@ class PositionPolicy
 {
     use HandlesAuthorization;
 
-    public function before($user)
+    public function before(Person $user): ?bool
     {
-        if ($user->hasRole(Role::TECH_NINJA)) {
-            return true;
-        }
+        return $user->hasRole([Role::ADMIN, Role::TECH_NINJA]) ? true : null;
     }
 
     /**
@@ -36,9 +34,10 @@ class PositionPolicy
      * Determine whether the user can create positions.
      *
      * @param Person $user
-     * @return false
+     * @return bool
      */
-    public function store(Person $user): mixed
+
+    public function store(Person $user): bool
     {
         return false;
     }
@@ -76,7 +75,7 @@ class PositionPolicy
 
     public function sandmanQualified(Person $user): bool
     {
-        return $user->hasRole([ Role::ADMIN, Role::MANAGE]);
+        return $user->hasRole(Role::MANAGE);
     }
 
     /**
@@ -88,7 +87,7 @@ class PositionPolicy
 
     public function peopleByTeamsReport(Person $user): bool
     {
-        return $user->hasRole([ Role::ADMIN, Role::MANAGE]);
+        return $user->hasRole(Role::MANAGE);
     }
 
     /**
@@ -100,7 +99,7 @@ class PositionPolicy
 
     public function sanityChecker(Person $user): bool
     {
-        return $user->hasRole([ Role::ADMIN, Role::MANAGE]);
+        return $user->hasRole(Role::MANAGE);
     }
 
     /**
@@ -113,7 +112,7 @@ class PositionPolicy
     public function repair(Person $user): bool
     {
         // Only admins  are allowed to run it.
-        return $user->hasRole(Role::ADMIN);
+        return false;
     }
 
     /**
@@ -142,7 +141,7 @@ class PositionPolicy
      *
      */
 
-    public function peopleByPosition(Person $user) : bool
+    public function peopleByPosition(Person $user): bool
     {
         return $user->hasRole(Role::MANAGE);
     }
@@ -154,7 +153,7 @@ class PositionPolicy
      * @return bool
      */
 
-    public function grants(Person $user) : bool
+    public function grants(Person $user): bool
     {
         return $user->hasRole(Role::MANAGE);
     }

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -12,11 +12,9 @@ class TeamPolicy
 {
     use HandlesAuthorization;
 
-    public function before($user)
+    public function before(Person $user): ?bool
     {
-        if ($user->hasRole(Role::TECH_NINJA)) {
-            return true;
-        }
+        return $user->hasRole(Role::TECH_NINJA) ? true : null;
     }
 
     /**
@@ -41,7 +39,7 @@ class TeamPolicy
 
     public function store(Person $user): bool
     {
-        return false;
+        return $user->isAdmin();
     }
 
     /**
@@ -54,7 +52,7 @@ class TeamPolicy
 
     public function update(Person $user, Team $team): bool
     {
-        return false;
+        return $user->isAdmin();
     }
 
     /**
@@ -67,7 +65,7 @@ class TeamPolicy
 
     public function delete(Person $user, Team $team): bool
     {
-        return false;
+        return $user->isAdmin();
     }
 
     /**

--- a/tests/Feature/PersonControllerTest.php
+++ b/tests/Feature/PersonControllerTest.php
@@ -12,6 +12,7 @@ use App\Models\PersonRole;
 use App\Models\PersonSlot;
 use App\Models\Position;
 use App\Models\PositionCredit;
+use App\Models\PositionRole;
 use App\Models\Role;
 use App\Models\Slot;
 use App\Models\Timesheet;
@@ -636,7 +637,7 @@ class PersonControllerTest extends TestCase
 
 
     /**
-     * Test updating personing positions
+     * Test updating person positions
      */
 
 
@@ -696,6 +697,41 @@ class PersonControllerTest extends TestCase
             [
                 'person_id' => $personId,
                 'position_id' => $oldPosition->id,
+            ]
+        );
+    }
+
+    /**
+     * Test updating person positions
+     */
+
+
+    public function test_update_failure_for_tech_ninja_associated()
+    {
+        $this->addRole(Role::ADMIN);
+        $personId = $this->user->id;
+
+        $position = Position::factory()->create();
+        PositionRole::factory()->create([
+           'position_id' => $position->id,
+           'role_id' => Role::TECH_NINJA,
+        ]);
+
+        $response = $this->json(
+            'POST',
+            "person/$personId/positions",
+            [
+                'position_ids' => [$position->id],
+                'team_manager_ids' => [],
+            ]
+        );
+
+        $response->assertStatus(403);
+        $this->assertDatabaseMissing(
+            'person_position',
+            [
+                'person_id' => $personId,
+                'position_id' => $position->id,
             ]
         );
     }

--- a/tests/Feature/PositionControllerTest.php
+++ b/tests/Feature/PositionControllerTest.php
@@ -74,7 +74,6 @@ class PositionControllerTest extends TestCase
         ];
 
         $response = $this->json('POST', 'position', ['position' => $data]);
-
         $response->assertStatus(200);
         $this->assertDatabaseHas('position', $data);
     }
@@ -85,7 +84,7 @@ class PositionControllerTest extends TestCase
 
     public function testUpdatePosition()
     {
-        $this->addRole(Role::TECH_NINJA);
+        $this->addRole(Role::ADMIN);
         $position = Position::factory()->create();
 
         $response = $this->json('PATCH', "position/{$position->id}", [
@@ -96,6 +95,41 @@ class PositionControllerTest extends TestCase
         $this->assertDatabaseHas('position',
             ['id' => $position->id, 'title' => 'Something Title', 'active' => false]);
     }
+
+    /**
+     * Try to successfully update the position roles
+     */
+
+    public function testUpdatePositionRoles()
+    {
+        $this->addRole(Role::TECH_NINJA);
+        $position = Position::factory()->create();
+
+        $response = $this->json('PATCH', "position/{$position->id}", [
+            'position' => ['role_ids' => [Role::MANAGE]]
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('position_role', [ 'position_id' => $position->id, 'role_id' => Role::MANAGE ]);
+    }
+
+    /**
+     * Try to update the position roles without the right permissions
+     */
+
+    public function testUpdatePositionRolesForNonTechNinja()
+    {
+        $this->addRole(Role::ADMIN);
+        $position = Position::factory()->create();
+
+        $response = $this->json('PATCH', "position/{$position->id}", [
+            'position' => ['role_ids' => [Role::ADMIN]]
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('position_role', [ 'position_id' => $position->id, 'role_id' => Role::ADMIN ]);
+    }
+
 
     /*
      * Delete a position
@@ -229,7 +263,7 @@ class PositionControllerTest extends TestCase
         $this->createBulkPeople();
         $person1 = $this->person1;
 
-        $response = $this->json('POST', 'position/'.Position::DIRT_GREEN_DOT.'/bulk-grant-revoke', [
+        $response = $this->json('POST', 'position/' . Position::DIRT_GREEN_DOT . '/bulk-grant-revoke', [
             'callsigns' => $person1->callsign,
             'grant' => 1,
             'commit' => 0
@@ -259,7 +293,7 @@ class PositionControllerTest extends TestCase
         $this->createBulkPeople();
         $person1 = $this->person1;
 
-        $response = $this->json('POST', 'position/'.Position::DIRT_GREEN_DOT.'/bulk-grant-revoke', [
+        $response = $this->json('POST', 'position/' . Position::DIRT_GREEN_DOT . '/bulk-grant-revoke', [
             'callsigns' => $person1->callsign,
             'grant' => 1,
             'commit' => 1
@@ -291,7 +325,7 @@ class PositionControllerTest extends TestCase
         $this->addRole(Role::ADMIN);
         $this->createBulkPeople();
 
-        $response = $this->json('POST', 'position/'.Position::HQ_WINDOW.'/bulk-grant-revoke', [
+        $response = $this->json('POST', 'position/' . Position::HQ_WINDOW . '/bulk-grant-revoke', [
             'callsigns' => 'nosuchcallsign',
             'grant' => 1,
             'commit' => 0
@@ -318,7 +352,7 @@ class PositionControllerTest extends TestCase
         $this->createBulkPeople();
         $person1 = $this->person1;
 
-        $response = $this->json('POST', 'position/'.Position::HQ_WINDOW.'/bulk-grant-revoke', [
+        $response = $this->json('POST', 'position/' . Position::HQ_WINDOW . '/bulk-grant-revoke', [
             'callsigns' => $person1->callsign,
             'grant' => 1,
             'commit' => 0


### PR DESCRIPTION
- Allow Admin & Tech Ninja permissions be associated with teams & positions.
- Only an Admin, regardless of the user being a team manager, can grant a team with the Admin permission associated.
- Only a Tech Ninja, regardless of the user being a team manager, can grant a team with the Tech Ninja permission associated.
- Allow teams and positions be editable by Admins. Tech Ninja may only adjust the associated permissions.