### PR TITLE
Provision and ticketing work.

### DIFF
--- a/app/Http/Controllers/ProvisionController.php
+++ b/app/Http/Controllers/ProvisionController.php
@@ -252,7 +252,7 @@ class ProvisionController extends ApiController
      * We don't check expiration here, that's handled elsewhere.
      *
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function bankProvisions(): JsonResponse
@@ -282,7 +282,7 @@ class ProvisionController extends ApiController
      * Expire old provisions.
      *
      * @return JsonResponse
-     * @throws AuthorizationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function expireProvisions(): JsonResponse

--- a/app/Lib/TicketAndProvisionsPackage.php
+++ b/app/Lib/TicketAndProvisionsPackage.php
@@ -84,7 +84,11 @@ class TicketAndProvisionsPackage
 
     public static function buildProvisions(int $personId, &$result): void
     {
-        $provisions = Provision::findForQuery(['person_id' => $personId]);
+        $provisions = Provision::findForQuery([
+            'person_id' => $personId,
+            // Remove below if we decided to have bankable radios again.
+            'exclude_radio' => true
+        ]);
         $result['provision_records'] = $provisions;
 
         $mealMatrix = [];

--- a/app/Models/Provision.php
+++ b/app/Models/Provision.php
@@ -185,6 +185,7 @@ class Provision extends ApiModel
         $year = $query['year'] ?? null;
         $type = $query['type'] ?? null;
         $includePerson = $query['include_person'] ?? false;
+        $excludeRadio = $query['exclude_radio'] ?? false;
 
         $sql = self::query()->orderBy('type')->orderBy('source_year');
 
@@ -210,6 +211,10 @@ class Provision extends ApiModel
 
         if ($year) {
             $sql->where('source_year', $year);
+        }
+
+        if ($excludeRadio) {
+            $sql->where('type', '!=', Provision::EVENT_RADIO);
         }
 
         $rows = $sql->get();

--- a/tests/Feature/BulkUploadControllerTest.php
+++ b/tests/Feature/BulkUploadControllerTest.php
@@ -517,7 +517,7 @@ class BulkUploadControllerTest extends TestCase
                 [
                     'person_id' => $this->user->id,
                     // LSD & Gift default to the current year for source.
-                    'source_year' => ($adType == AccessDocument::LSD || $adType == AccessDocument::GIFT || $adType == AccessDocument::VEHICLE_PASS_GIFT) ? $year : $year - 1,
+                    'source_year' => ($adType == AccessDocument::LSD || $adType == AccessDocument::GIFT || $adType == AccessDocument::VEHICLE_PASS_GIFT || $adType == AccessDocument::WAP) ? $year : $year - 1,
                     // LSD tickets are claimed.
                     'status' => ($adType == AccessDocument::LSD) ? AccessDocument::CLAIMED : AccessDocument::QUALIFIED,
                     'type' => $adType


### PR DESCRIPTION
- Have Bulk Uploader verify the source and expiry years are actually years and not garbage.
- For the ticketing package, don't include the event radios.
- Explicit set the source and expiry year on all allocated provisions to the current year of upload.