### PR TITLE
Created On Duty Report instead of using Timesheet::findForQuery.

### DIFF
--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -10,6 +10,7 @@ use App\Lib\Reports\ForcedSigninsReport;
 use App\Lib\Reports\FreakingYearsReport;
 use App\Lib\Reports\HoursCreditsReport;
 use App\Lib\Reports\NoShowReport;
+use App\Lib\Reports\OnDutyReport;
 use App\Lib\Reports\OnDutyShiftLeadReport;
 use App\Lib\Reports\PayrollReport;
 use App\Lib\Reports\PeopleWithUnconfirmedTimesheetsReport;
@@ -860,10 +861,29 @@ class TimesheetController extends ApiController
     }
 
     /**
+     * Who is on duty?
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function onDutyReport(): JsonResponse
+    {
+        $this->authorize('onDutyReport', [Timesheet::class]);
+        $params = request()->validate([
+            'duty_date' => 'sometimes|date',
+            'has_excessive_duration' => 'sometimes|boolean',
+        ]);
+
+        return response()->json(OnDutyReport::execute($params['duty_date'] ?? null, $params['has_excessive_duration'] ?? false));
+    }
+
+    /**
      * The On Duty Shift Lead Report
      *
      * @return JsonResponse
      * @throws AuthorizationException
+     * @throws \Exception
      */
 
     public function onDutyShiftLeadReport(): JsonResponse

--- a/app/Jobs/SignOutTimesheetsJob.php
+++ b/app/Jobs/SignOutTimesheetsJob.php
@@ -28,7 +28,7 @@ class SignOutTimesheetsJob implements ShouldQueue
             ->where('position.auto_sign_out', true)
             ->where('sign_out_hour_cap', '>', 0)
             // Give a hour grace period just in case.
-            ->whereRaw('TIMEDIFF(?, on_duty) >= ((sign_out_hour_cap * 3600)+3600)', [now()])
+            ->whereRaw('TIME_TO_SEC(TIMEDIFF(?, on_duty)) >= (sign_out_hour_cap * 3600)', [now()])
             ->with(['position:id,title,sign_out_hour_cap,auto_sign_out,contact_email', 'person:id,callsign,status'])
             ->get();
 

--- a/app/Lib/Reports/OnDutyReport.php
+++ b/app/Lib/Reports/OnDutyReport.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Lib\Reports;
+
+use App\Models\Timesheet;
+use Carbon\Carbon;
+
+class OnDutyReport
+{
+    const int DEFAULT_SHIFT_DURATION = 6 * 3600;
+
+    public static function execute(?string $onDuty, bool $hasExcessiveDuration): array
+    {
+        $sql = Timesheet::with(['position:id,title', 'person:id,callsign', 'slot:id,begins,duration,description'])
+            ->orderBy('on_duty');
+
+        if (!empty($onDuty)) {
+            $sql->whereYear('on_duty', Carbon::parse($onDuty)->year);
+            $sql->where('on_duty', '<=', $onDuty);
+            $sql->where('off_duty', '>=', $onDuty);
+        } else {
+            $sql->whereNull('off_duty');
+        }
+
+        $timesheets = $sql->get();
+        $positions = [];
+        $totalPeople = 0;
+
+        foreach ($timesheets as $timesheet) {
+            $result = [
+                'id' => $timesheet->id,
+                'person_id' => $timesheet->person_id,
+                'callsign' => $timesheet->person->callsign,
+                'on_duty' => (string)$timesheet->on_duty,
+                'off_duty' => $timesheet->off_duty ? (string)$timesheet->off_duty : null,
+                'duration' => $timesheet->duration,
+            ];
+
+            $slot = $timesheet->slot;
+            if ($slot) {
+                $result['slot'] = [
+                    'id' => $slot->id,
+                    'begins' => (string)$slot->begins,
+                    'description' => $slot->description,
+                    'duration' => $slot->duration,
+                ];
+
+                $normalDuration = $slot->duration;
+            } else {
+                $normalDuration = self::DEFAULT_SHIFT_DURATION;
+            }
+
+            $isExcessive = false;
+            if ($timesheet->duration > ($normalDuration * 1.5)) {
+                $result['excessive_duration'] = $timesheet->duration - $normalDuration;
+                $result['excessive_percentage'] = (int)(($timesheet->duration / $normalDuration * 100.0) - 100);
+                $isExcessive = true;
+            } else if ($hasExcessiveDuration) {
+                continue;
+            }
+
+            if (!isset($positions[$timesheet->position_id])) {
+                $positions[$timesheet->position_id] = [
+                    'id' => $timesheet->position_id,
+                    'title' => $timesheet->position->title,
+                    'excessive_count' => 0,
+                    'timesheets' => [],
+                ];
+            }
+
+            $positions[$timesheet->position_id]['timesheets'][] = $result;
+            if ($isExcessive) {
+                $positions[$timesheet->position_id]['excessive_count'] += 1;
+            }
+            $totalPeople++;
+        }
+
+        usort($positions, fn($a, $b) => strcasecmp($a['title'], $b['title']));
+
+        return [
+            'positions' => $positions,
+            'on_duty' => $onDuty ?? (string)now(),
+            'total_people' => $totalPeople,
+            'default_excessive_duration' => self::DEFAULT_SHIFT_DURATION,
+        ];
+    }
+}

--- a/app/Lib/Reports/OnDutyShiftLeadReport.php
+++ b/app/Lib/Reports/OnDutyShiftLeadReport.php
@@ -3,7 +3,6 @@
 namespace App\Lib\Reports;
 
 use App\Lib\SummarizeGender;
-use App\Models\Person;
 use App\Models\Position;
 use App\Models\Slot;
 use App\Models\Timesheet;
@@ -13,9 +12,9 @@ use Illuminate\Support\Facades\DB;
 
 class OnDutyShiftLeadReport
 {
-    const NON_DIRT = 'non-dirt';
-    const COMMAND = 'command';
-    const DIRT_AND_GREEN_DOT = 'dirt+green';
+    const string NON_DIRT = 'non-dirt';
+    const string COMMAND = 'command';
+    const string DIRT_AND_GREEN_DOT = 'dirt+green';
 
     /**
      * Run the ON DUTY Shift Lead report. Find on duty Rangers in positions of interest and show them to Khaki.

--- a/app/Lib/Reports/PayrollReport.php
+++ b/app/Lib/Reports/PayrollReport.php
@@ -71,7 +71,7 @@ class PayrollReport
                     'verified' => $entry->review_status == Timesheet::STATUS_VERIFIED || $entry->review_status == Timesheet::STATUS_APPROVED,
                     'orig_on_duty' => (string)$onDuty,
                     'orig_off_duty' => (string)$offDuty,
-                    'orig_duration' => $onDuty->diffInSeconds($offDuty),
+                    'orig_duration' => (int) $onDuty->diffInSeconds($offDuty),
                 ];
 
                 if (!$entry->off_duty) {
@@ -92,7 +92,7 @@ class PayrollReport
                     $offDuty = $endTime;
                 }
 
-                $durationSeconds = $onDuty->diffInSeconds($offDuty);
+                $durationSeconds = (int) $onDuty->diffInSeconds($offDuty);
                 if ($durationSeconds < 60) {
                     // Either the entry was less than a minute, or spanned two pay periods and the second half was less
                     // than a minute

--- a/app/Models/Timesheet.php
+++ b/app/Models/Timesheet.php
@@ -845,7 +845,7 @@ class Timesheet extends ApiModel
         }
 
         $offDuty = $this->off_duty ?: now();
-        $duration = $this->on_duty->diffInSeconds($offDuty);
+        $duration = (int) $this->on_duty->diffInSeconds($offDuty);
         $this->attributes['duration'] = $duration;
         return $duration;
     }

--- a/app/Models/TimesheetMissing.php
+++ b/app/Models/TimesheetMissing.php
@@ -257,7 +257,7 @@ class TimesheetMissing extends ApiModel
         $on_duty = $this->getOriginal('on_duty');
         $off_duty = $this->getOriginal('off_duty');
 
-        return Carbon::parse($on_duty)->diffInSeconds(Carbon::parse($off_duty));
+        return (int) Carbon::parse($on_duty)->diffInSeconds(Carbon::parse($off_duty));
     }
 
     /**

--- a/app/Policies/TimesheetPolicy.php
+++ b/app/Policies/TimesheetPolicy.php
@@ -264,6 +264,11 @@ class TimesheetPolicy
         return $user->hasRole(Role::MANAGE);
     }
 
+    public function onDutyReport(Person $user): bool
+    {
+        return $user->hasRole(Role::MANAGE);
+    }
+
     public function retentionReport(Person $user): bool
     {
         return false;

--- a/routes/api.php
+++ b/routes/api.php
@@ -497,6 +497,7 @@ Route::middleware('api')->group(function () {
     Route::get('timesheet/log', [TimesheetController::class, 'showLog']);
     Route::get('timesheet/no-shows-report', [TimesheetController::class, 'noShowsReport']);
     Route::get('timesheet/on-duty-shift-lead-report', [TimesheetController::class, 'onDutyShiftLeadReport']);
+    Route::get('timesheet/on-duty-report', [TimesheetController::class, 'OnDutyReport']);
     Route::get('timesheet/payroll', [TimesheetController::class, 'payrollReport']);
     Route::get('timesheet/radio-eligibility', [TimesheetController::class, 'radioEligibilityReport']);
     Route::get('timesheet/potential-shirts-earned', [TimesheetController::class, 'potentialShirtsEarnedReport']);


### PR DESCRIPTION
- Indicate when an entry exceeds 1.5x an associated shift sign up or 6 hours (i.e., 1.5*6 = 9 hours).
- Return the associated shift if any