### PR TITLE
Minor tweaks.

### DIFF
--- a/app/Models/SurveyGroup.php
+++ b/app/Models/SurveyGroup.php
@@ -61,7 +61,7 @@ class SurveyGroup extends ApiModel
 
     public function survey_questions(): HasMany
     {
-        return $this->hasMany(SurveyQuestion::class);
+        return $this->hasMany(SurveyQuestion::class)->orderBy('sort_index');
     }
 
     public function survey() : BelongsTo

--- a/app/Models/SurveyQuestion.php
+++ b/app/Models/SurveyQuestion.php
@@ -7,6 +7,7 @@ use App\Attributes\BlankIfEmptyAttribute;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\DB;
 
 class SurveyQuestion extends ApiModel
@@ -64,6 +65,11 @@ class SurveyQuestion extends ApiModel
     public function survey() : BelongsTo
     {
         return $this->belongsTo(Survey::class);
+    }
+
+    public function survey_answers() : HasMany
+    {
+        return $this->hasMany(SurveyAnswer::class);
     }
 
     public static function findAllForSurvey(int $surveyId): Collection

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -198,10 +198,10 @@ class TimesheetControllerTest extends TestCase
                         'creator_callsign' => $this->user->callsign,
                         'created_at' => date("$year-08-25 06:00:00"),
                         'action' => 'signon',
-                        'data' => [
+                        'data' => json_encode([
                             'position_id' => Position::DIRT,
                             'on_duty' => (string)$this->timesheet->on_duty,
-                        ]
+                        ])
                     ]
                     ]],
             ]


### PR DESCRIPTION
- Have associated survey relationship tables be sorted by sort_index
- Use 'array' cast for TimesheetLog.data and removed json_{encode|decode}).