### PR TITLE
fix date ranges for Shift Lead Report

### DIFF
--- a/app/Lib/Reports/ShiftLeadReport.php
+++ b/app/Lib/Reports/ShiftLeadReport.php
@@ -319,16 +319,15 @@ class ShiftLeadReport
                 ['ends', '>=', $shiftEnd]
             ]);
             // or starting within 1 hour before
-            $q->orWhere([
-                ['begins', '>=', $shiftStart->clone()->addHours(-1)],
-                ['begins', '<', $shiftEnd->clone()->addHours(-1)]
-            ]);
-
+            $q->orWhere(function ($q) use ($shiftStart, $shiftEnd) {
+                $q->where('begins', '>=', $shiftStart->clone()->addHours(-1));
+                $q->where('begins', '<', $shiftEnd->clone()->addHours(-1));
+            });
             // or.. starting within after X minutes
-            $q->orWhere([
-                ['ends', '>=', $shiftStart->clone()->addMinutes($minAfterStart)],
-                ['ends', '<=', $shiftEnd]
-            ]);
+            $q->orWhere(function ($q) use ($shiftStart, $shiftEnd, $minAfterStart) {
+                $q->where('ends', '>=', $shiftStart->clone()->addMinutes($minAfterStart));
+                $q->where('ends', '<=', $shiftEnd);
+            });
         });
     }
 


### PR DESCRIPTION
as Cane Toad observed, the report was previously pulling in data for all shifts, rather than just the selected one.

That was because these two blocks were ORing rather than ANDing, creating situations which were almost always true.

The root problem was a breaking change in Laravel: https://github.com/laravel/framework/issues/53184