### PR TITLE
Restructured policies, introduced new permissions.

### DIFF
--- a/app/Http/Controllers/PodController.php
+++ b/app/Http/Controllers/PodController.php
@@ -41,7 +41,6 @@ class PodController extends ApiController
      *
      * @return JsonResponse
      * @throws AuthorizationException
-     * @throws ValidationException
      */
 
     public function store(): JsonResponse
@@ -131,7 +130,6 @@ class PodController extends ApiController
      * @param Pod $pod
      * @return JsonResponse
      * @throws AuthorizationException
-     * @throws ValidationException
      */
 
     public function update(Pod $pod): JsonResponse

--- a/app/Http/Controllers/SwagController.php
+++ b/app/Http/Controllers/SwagController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Lib\Reports\PotentialEarnedShirtsReport;
 use App\Lib\Reports\PotentialSwagReport;
-use App\Models\PersonSwag;
 use App\Models\Swag;
+use App\Models\Timesheet;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Validation\ValidationException;
 
 class SwagController extends ApiController
 {
@@ -30,7 +32,7 @@ class SwagController extends ApiController
      * Create a swag
      *
      * @return JsonResponse
-     * @throws AuthorizationException|\Illuminate\Validation\ValidationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function store(): JsonResponse
@@ -64,7 +66,7 @@ class SwagController extends ApiController
      *
      * @param Swag $swag
      * @return JsonResponse
-     * @throws AuthorizationException|\Illuminate\Validation\ValidationException
+     * @throws AuthorizationException|ValidationException
      */
 
     public function update(Swag $swag): JsonResponse
@@ -117,5 +119,27 @@ class SwagController extends ApiController
         $this->authorize('potentialSwagReport', Swag::class);
 
         return response()->json(PotentialSwagReport::execute());
+    }
+
+    /**
+     * Potential T-Shirts Earned Report
+     *
+     * @return JsonResponse
+     * @throws AuthorizationException
+     */
+
+    public function potentialShirtsEarnedReport(): JsonResponse
+    {
+        $this->authorize('potentialShirtsEarnedReport', [Timesheet::class]);
+
+        $year = $this->getYear();
+        $thresholdLS = setting('ShirtLongSleeveHoursThreshold', true);
+        $thresholdSS = setting('ShirtShortSleeveHoursThreshold', true);
+
+        return response()->json([
+            'people' => PotentialEarnedShirtsReport::execute($year, $thresholdSS, $thresholdLS),
+            'threshold_ss' => $thresholdSS,
+            'threshold_ls' => $thresholdLS,
+        ]);
     }
 }

--- a/app/Http/Controllers/TimesheetController.php
+++ b/app/Http/Controllers/TimesheetController.php
@@ -14,7 +14,6 @@ use App\Lib\Reports\OnDutyReport;
 use App\Lib\Reports\OnDutyShiftLeadReport;
 use App\Lib\Reports\PayrollReport;
 use App\Lib\Reports\PeopleWithUnconfirmedTimesheetsReport;
-use App\Lib\Reports\PotentialEarnedShirtsReport;
 use App\Lib\Reports\RadioEligibilityReport;
 use App\Lib\Reports\RangerRetentionReport;
 use App\Lib\Reports\SpecialTeamsWorkReport;
@@ -37,6 +36,7 @@ use App\Models\PositionCredit;
 use App\Models\Role;
 use App\Models\Timesheet;
 use App\Models\TimesheetLog;
+use Exception;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Gate;
@@ -661,27 +661,6 @@ class TimesheetController extends ApiController
         return response()->json(TimesheetSanityCheckReport::execute($year));
     }
 
-    /**
-     * Potential T-Shirts Earned Report
-     *
-     * @return JsonResponse
-     * @throws AuthorizationException
-     */
-
-    public function potentialShirtsEarnedReport(): JsonResponse
-    {
-        $this->authorize('potentialShirtsEarnedReport', [Timesheet::class]);
-
-        $year = $this->getYear();
-        $thresholdLS = setting('ShirtLongSleeveHoursThreshold', true);
-        $thresholdSS = setting('ShirtShortSleeveHoursThreshold', true);
-
-        return response()->json([
-            'people' => PotentialEarnedShirtsReport::execute($year, $thresholdSS, $thresholdLS),
-            'threshold_ss' => $thresholdSS,
-            'threshold_ls' => $thresholdLS,
-        ]);
-    }
 
     /**
      * Freaking years report!
@@ -883,7 +862,7 @@ class TimesheetController extends ApiController
      *
      * @return JsonResponse
      * @throws AuthorizationException
-     * @throws \Exception
+     * @throws Exception
      */
 
     public function onDutyShiftLeadReport(): JsonResponse

--- a/app/Http/Filters/PersonFilter.php
+++ b/app/Http/Filters/PersonFilter.php
@@ -79,7 +79,6 @@ class PersonFilter
     ];
 
     const array HQ_INFO = [
-        'on_site',
         'camp_location',
     ];
 
@@ -163,7 +162,7 @@ class PersonFilter
         [self::CLOTHING_FIELDS, true, [Role::VIEW_PII, Role::VC, Role::EDIT_CLOTHING]],
         [self::HQ_INFO, true, [Role::MANAGE, Role::VIEW_PII, Role::VC]],
         [self::AGREEMENT_FIELDS],
-        [self::EVENT_FIELDS, true, [Role::VIEW_PII, Role::MANAGE, Role::VC, Role::TRAINER, Role::EDIT_BMIDS]],
+        [self::EVENT_FIELDS, true, [Role::MANAGE]],
         [self::BPGUID_FIELD, true, [Role::VIEW_PII, Role::MANAGE, Role::VC, Role::MENTOR, Role::EDIT_BMIDS]],
         [self::LMS_FIELDS, false, [Role::ADMIN]],
         // Note: self is not allowed to see mentor notes
@@ -187,7 +186,7 @@ class PersonFilter
         [self::CLOTHING_FIELDS, true, [Role::VC, Role::EDIT_CLOTHING]],
         [self::HQ_INFO, true, [Role::MANAGE, Role::VIEW_PII, Role::VC]],
         [self::AGREEMENT_FIELDS, true, [Role::ADMIN]],
-        [self::EVENT_FIELDS, false, [Role::MANAGE, Role::VC, Role::TRAINER, Role::MENTOR]],
+        [self::EVENT_FIELDS, false, [Role::SHIFT_MANAGEMENT]],
         [self::BPGUID_FIELD, true, [Role::EDIT_BMIDS]],
         [self::LMS_FIELDS, false, [Role::ADMIN]],
         [self::INTAKE_FIELDS, false, [Role::INTAKE, Role::VC]],

--- a/app/Http/Filters/TimesheetFilter.php
+++ b/app/Http/Filters/TimesheetFilter.php
@@ -39,7 +39,7 @@ class TimesheetFilter
     {
         $fields = [self::USER_FIELDS];
 
-        if ($user->hasRole(Role::SHIFT_MANAGEMENT)) {
+        if ($user->hasRole([Role::ADMIN, Role::SHIFT_MANAGEMENT])) {
             $fields[] = self::MANAGE_FIELDS;
         }
 

--- a/app/Http/Filters/TimesheetFilter.php
+++ b/app/Http/Filters/TimesheetFilter.php
@@ -12,7 +12,7 @@ class TimesheetFilter
     {
     }
 
-    const USER_FIELDS = [
+    const array USER_FIELDS = [
         'additional_notes',
         'desired_position_id',
         'desired_on_duty',
@@ -20,13 +20,13 @@ class TimesheetFilter
         'review_status'
     ];
 
-    const MANAGE_FIELDS = [
+    const array MANAGE_FIELDS = [
         'additional_worker_notes',
         'off_duty',
         'on_duty',
     ];
 
-    const WRANGLER_FIELDS = [
+    const array WRANGLER_FIELDS = [
         'additional_admin_notes',
         'additional_wrangler_notes',
         'is_non_ranger',
@@ -35,11 +35,11 @@ class TimesheetFilter
         'suppress_duration_warning'
     ];
 
-    public function deserialize(Person $user = null): array
+    public function deserialize(?Person $user = null): array
     {
         $fields = [self::USER_FIELDS];
 
-        if ($user->hasRole(Role::MANAGE)) {
+        if ($user->hasRole(Role::SHIFT_MANAGEMENT)) {
             $fields[] = self::MANAGE_FIELDS;
         }
 

--- a/app/Lib/Milestones.php
+++ b/app/Lib/Milestones.php
@@ -190,7 +190,7 @@ class Milestones
         }
 
         // Timesheets!
-        if (setting('TimesheetCorrectionEnable') || $person->hasRole(Role::TIMECARD_YEAR_ROUND)) {
+        if (setting('TimesheetCorrectionEnable') || $person->hasRole(Role::SHIFT_MANAGEMENT_SELF)) {
             $didWork = $milestones['did_work'] = Timesheet::didPersonWork($personId, $year);
 
             if ($didWork) {

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -978,6 +978,11 @@ class Person extends ApiModel implements AuthenticatableContract, AuthorizableCo
             $this->rolesById[Role::TRAINER] = true;
         }
 
+        if (!setting('ShiftManagementSelfEnabled')
+        && isset($this->rolesById[Role::SHIFT_MANAGEMENT_SELF])) {
+            unset($this->rolesById[Role::SHIFT_MANAGEMENT_SELF]);
+        }
+
         foreach ([Role::MEGAPHONE_EMERGENCY_ONPLAYA, Role::MEGAPHONE_TEAM_ONPLAYA] as $role) {
             if (isset($this->rolesById[$role]) && !$lmopEnabled) {
                 unset($this->rolesById[$role]);

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -39,13 +39,16 @@ class Role extends ApiModel
     const int REGIONAL_MANAGEMENT = 114;    // Person can access Regional Ranger liaison features.
     const int PAYROLL = 115;                // Can access payroll features
     const int VEHICLE_MANAGEMENT = 116;     // Can access vehicle fleet management features
-    const int TIMECARD_YEAR_ROUND = 117;    // Paid folks who can self check in/out, and submit timesheet corrections year round.
+    const int SHIFT_MANAGEMENT_SELF = 117;    // Paid folks who can self check in/out, and submit timesheet corrections year round.
     const int SALESFORCE_IMPORT = 118;      // Allowed to import new accounts from Salesforce
     const int MESSAGE_MANAGEMENT = 119;     // Allow access to Clubhouse Messages year round regardless of LMOP Enabled setting.
     const int EDIT_CLOTHING = 120;   // Can edit a clothing fields.
     const int MEGAPHONE_TEAM_ONPLAYA = 121;  // On-Playa Megaphone permission
     const int MEGAPHONE_EMERGENCY_ONPLAYA = 122;    // Allows access to the broadcast all emergency
     const int ANNOUNCEMENT_MANAGEMENT = 123;    // Allow announcements to be created and deleted.
+    const int QUARTERMASTER = 124;  // Allows access to Quartermaster reports
+    const int SHIFT_MANAGEMENT = 125;   // Allows shift check-in / out, timesheet correction submissions, etc.
+    const int POD_MANAGEMENT = 126; // Access to Cruise Direction interface
 
     const int TECH_NINJA = 1000;    // godlike powers granted - access to dangerous maintenance functions, raw database access.
 
@@ -61,10 +64,10 @@ class Role extends ApiModel
     const int SURVEY_MANAGEMENT_BASE = 0x2000000;
     const int ART_GRADUATE_BASE = 0x30000000;
 
-    const array ART_BASE_ROLES = [
-        self::ART_GRADUATE_BASE => 'ART Graduate',
-        self::ART_TRAINER_BASE => ['ART', 'ART Trainer'],
-        self::SURVEY_MANAGEMENT_BASE => ['ART Survey Mgmt', 'ART Survey Management'],
+    const array ART_ROLE_SUFFIXES = [
+        self::ART_GRADUATE_BASE => 'Graduate',
+        self::ART_TRAINER_BASE => 'Interface',
+        self::SURVEY_MANAGEMENT_BASE => 'Survey Mgmt',
     ];
 
     protected $appends = [
@@ -163,7 +166,7 @@ class Role extends ApiModel
 
         $added = [];
         $existing = [];
-        foreach (self::ART_BASE_ROLES as $base => $rolePrefixs) {
+        foreach (self::ART_ROLE_SUFFIXES as $base => $suffix) {
             $role = $base | $positionId;
             if ($existingRole = Role::find($role)) {
                 $existing[] = [
@@ -173,15 +176,9 @@ class Role extends ApiModel
                 continue;
             }
 
-            if (is_array($rolePrefixs)) {
-                $prefix = $rolePrefixs[0];
-            } else {
-                $prefix = $rolePrefixs;
-            }
-
             $newRole = new Role;
             $newRole->id = $role;
-            $newRole->title = $prefix . ' ' . $title;
+            $newRole->title = 'ART '.$title.' '.$suffix;
             $newRole->new_user_eligible = false;
             $newRole->save();
             $added[] = [
@@ -209,7 +206,7 @@ class Role extends ApiModel
             return null;
         }
 
-        $prefixes = self::ART_BASE_ROLES[$base] ?? null;
+        $prefixes = self::ART_ROLE_SUFFIXES[$base] ?? null;
         if ($prefixes === null) {
             $title = "Unknown base {$base}";
         } else if (is_array($prefixes)) {

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -407,8 +407,14 @@ class Setting extends ApiModel
             'type' => self::TYPE_BOOL,
         ],
 
+        'ShiftManagementSelfEnabled' => [
+            'description' => 'Enable Shift Management Self permission',
+            'type' => self::TYPE_BOOL,
+            'default' => false,
+        ],
+
         'ShiftSignupFromEmail' => [
-            'description' => 'From email  address for shift sign up messages',
+            'description' => 'From email address for shift sign up messages',
             'type' => self::TYPE_EMAIL,
         ],
 

--- a/app/Policies/PersonCertificationPolicy.php
+++ b/app/Policies/PersonCertificationPolicy.php
@@ -11,9 +11,17 @@ class PersonCertificationPolicy
 {
     use HandlesAuthorization;
 
-    public function peopleReport(Person $user)
+    public function before(Person $user): ?true
     {
-        return $user->hasRole(Role::MANAGE);
+        if ($user->hasRole([Role::CERTIFICATION_MGMT, Role::ADMIN])) {
+            return true;
+        }
+        return null;
+    }
+
+    public function peopleReport(Person $user): bool
+    {
+        return false;
     }
 
     /**
@@ -26,7 +34,7 @@ class PersonCertificationPolicy
 
     public function index(Person $user, $personId): bool
     {
-        return $personId == $user->id || $user->hasRole([Role::CERTIFICATION_MGMT, Role::MANAGE]);
+        return $personId == $user->id || $user->hasRole(Role::MANAGE);
     }
 
     /**
@@ -35,7 +43,7 @@ class PersonCertificationPolicy
 
     public function show(Person $user, PersonCertification $certification): bool
     {
-        return $user->id == $certification->person_id || $user->hasRole([Role::CERTIFICATION_MGMT, Role::MANAGE]);
+        return $user->id == $certification->person_id || $user->hasRole(Role::MANAGE);
     }
 
     /**
@@ -44,7 +52,7 @@ class PersonCertificationPolicy
 
     public function store(Person $user, $personId): bool
     {
-        return $user->id == $personId || $user->hasRole([Role::CERTIFICATION_MGMT, Role::ADMIN]);
+        return false;
     }
 
     /**
@@ -53,7 +61,7 @@ class PersonCertificationPolicy
 
     public function update(Person $user, PersonCertification $certification): bool
     {
-        return ($user->id == $certification->person_id) || $user->hasRole([Role::CERTIFICATION_MGMT, Role::ADMIN]);
+        return false;
     }
 
     /**
@@ -62,6 +70,6 @@ class PersonCertificationPolicy
 
     public function destroy(Person $user, PersonCertification $certification): bool
     {
-        return ($user->id == $certification->person_id) || $user->hasRole([Role::CERTIFICATION_MGMT, Role::ADMIN]);
+        return false;
     }
 }

--- a/app/Policies/PersonPolicy.php
+++ b/app/Policies/PersonPolicy.php
@@ -180,17 +180,17 @@ class PersonPolicy
 
     public function alphaShirts(Person $user): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return $user->hasRole([ Role::QUARTERMASTER, Role::MENTOR]);
     }
 
     public function peopleByLocation(Person $user): bool
     {
-        return $user->hasRole([Role::ADMIN, Role::VIEW_PII, Role::MANAGE]);
+        return $user->hasRole([Role::ADMIN, Role::MENTOR, Role::TRAINER, Role::VC]);
     }
 
     public function peopleByStatus(Person $user): bool
     {
-        return $user->hasRole([Role::ADMIN, Role::MANAGE]);
+        return $user->hasRole(Role::ADMIN);
     }
 
     public function peopleByStatusChange(Person $user): bool

--- a/app/Policies/PersonSwagPolicy.php
+++ b/app/Policies/PersonSwagPolicy.php
@@ -11,11 +11,13 @@ class PersonSwagPolicy
 {
     use HandlesAuthorization;
 
-    public function before(Person $user)
+    public function before(Person $user) : ?true
     {
-        if ($user->hasRole([Role::ADMIN, Role::MANAGE])) {
+        if ($user->hasRole([Role::ADMIN, Role::QUARTERMASTER])) {
             return true;
         }
+
+        return null;
     }
 
     /**

--- a/app/Policies/PodPolicy.php
+++ b/app/Policies/PodPolicy.php
@@ -12,7 +12,7 @@ class PodPolicy
 
     public function before(Person $user): bool|null
     {
-        if ($user->hasRole([Role::ADMIN, Role::MENTOR, Role::MANAGE])) {
+        if ($user->hasRole([Role::ADMIN, Role::MENTOR, Role::POD_MANAGEMENT])) {
             return true;
         }
 

--- a/app/Policies/PositionPolicy.php
+++ b/app/Policies/PositionPolicy.php
@@ -99,7 +99,7 @@ class PositionPolicy
 
     public function sanityChecker(Person $user): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return false;
     }
 
     /**

--- a/app/Policies/RolePolicy.php
+++ b/app/Policies/RolePolicy.php
@@ -85,7 +85,7 @@ class RolePolicy
 
     public function peopleByRole(Person $user): bool
     {
-        return $user->hasRole([Role::ADMIN, Role::MANAGE]);
+        return $user->hasRole(Role::ADMIN);
     }
 
     /**

--- a/app/Policies/SwagPolicy.php
+++ b/app/Policies/SwagPolicy.php
@@ -11,11 +11,13 @@ class SwagPolicy
 {
     use HandlesAuthorization;
 
-    public function before($user)
+    public function before($user) : ?true
     {
         if ($user->hasRole([Role::ADMIN, Role::EDIT_SWAG])) {
             return true;
         }
+
+        return null;
     }
 
     /**
@@ -28,7 +30,7 @@ class SwagPolicy
 
     public function view(Person $user, Swag $swag): bool
     {
-        return true;
+        return $user->hasRole(Role::QUARTERMASTER);
     }
 
     /**
@@ -77,7 +79,7 @@ class SwagPolicy
 
     public function personSwags(Person $user, Person $person): bool
     {
-        return $user->id == $person->id || $user->hasRole(Role::MANAGE);
+        return $user->id == $person->id || $user->hasRole(Role::QUARTERMASTER);
     }
 
     /**
@@ -89,6 +91,6 @@ class SwagPolicy
 
     public function potentialSwagReport(Person $user): bool
     {
-        return $user->hasRole(Role::MANAGE);
+        return $user->hasRole(Role::QUARTERMASTER);
     }
 }

--- a/database/migrations/2025_02_17_110308_create_more_roles.php
+++ b/database/migrations/2025_02_17_110308_create_more_roles.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Role;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    const array NEW_ROLES = [
+        Role::QUARTERMASTER => 'Quartermaster',
+        Role::SHIFT_MANAGEMENT => 'Shift Management',
+        Role::POD_MANAGEMENT => 'Pod Management',
+    ];
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('role')->where('id', Role::SHIFT_MANAGEMENT_SELF)->update(['title'=> 'Shift Management Self']);
+        
+        foreach (self::NEW_ROLES as $id => $title) {
+            DB::table('role')->insert([
+                'id' => $id,
+                'title' => $title,
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+
+    public function down(): void
+    {
+        foreach (self::NEW_ROLES as $id => $title) {
+            DB::table('role')->where('id', $id)->delete();
+        }
+    }
+};

--- a/database/schema/mysql-schema.dump
+++ b/database/schema/mysql-schema.dump
@@ -1944,7 +1944,7 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (175,'2023_05_26_10
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (176,'2023_06_04_081908_add_deselect_on_join_to_position',96);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (177,'2023_06_10_161617_add_no_payroll_meal_adjustment_to_position',97);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (178,'2023_06_23_152037_add_info_to_pod',98);
-INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (179,'2023_07_24_163001_add_timecard_year_round_to_role',99);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (179,'2023_07_24_163001_add_SHIFT_MANAGEMENT_SELF_to_role',99);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (180,'2023_07_26_145320_add_no_training_requirement_to_position',100);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (181,'2023_09_17_115650_replace_rpt_with_spt',101);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (182,'2023_09_18_091018_add_salesforce_import_permission',102);

--- a/database/schema/mysql_testing-schema.dump
+++ b/database/schema/mysql_testing-schema.dump
@@ -1944,7 +1944,7 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (175,'2023_05_26_10
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (176,'2023_06_04_081908_add_deselect_on_join_to_position',96);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (177,'2023_06_10_161617_add_no_payroll_meal_adjustment_to_position',97);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (178,'2023_06_23_152037_add_info_to_pod',98);
-INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (179,'2023_07_24_163001_add_timecard_year_round_to_role',99);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (179,'2023_07_24_163001_add_SHIFT_MANAGEMENT_SELF_to_role',99);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (180,'2023_07_26_145320_add_no_training_requirement_to_position',100);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (181,'2023_09_17_115650_replace_rpt_with_spt',101);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (182,'2023_09_18_091018_add_salesforce_import_permission',102);

--- a/routes/api.php
+++ b/routes/api.php
@@ -461,6 +461,7 @@ Route::middleware('api')->group(function () {
     Route::post('swag/bulk-grant-swag', [SwagController::class, 'bulkGrantSwag']);
     Route::get('swag/potential-swag', [SwagController::class, 'potentialSwagReport']);
     Route::get('swag/shirts', [SwagController::class, 'shirts']);
+    Route::get('swag/potential-shirts-earned', [SwagController::class, 'potentialShirtsEarnedReport']);
     Route::resource('swag', SwagController::class);
 
     Route::get('team/directory', [TeamController::class, 'directory']);
@@ -510,7 +511,6 @@ Route::middleware('api')->group(function () {
     Route::get('timesheet/on-duty-report', [TimesheetController::class, 'OnDutyReport']);
     Route::get('timesheet/payroll', [TimesheetController::class, 'payrollReport']);
     Route::get('timesheet/radio-eligibility', [TimesheetController::class, 'radioEligibilityReport']);
-    Route::get('timesheet/potential-shirts-earned', [TimesheetController::class, 'potentialShirtsEarnedReport']);
     Route::get('timesheet/sanity-checker', [TimesheetController::class, 'sanityChecker']);
     Route::post('timesheet/signin', [TimesheetController::class, 'signin']);
     Route::get('timesheet/shift-drop-report', [TimesheetController::class, 'shiftDropReport']);

--- a/tests/Feature/PersonControllerTest.php
+++ b/tests/Feature/PersonControllerTest.php
@@ -1271,7 +1271,7 @@ class PersonControllerTest extends TestCase
 
     public function testPeopleByLocationNoEmail()
     {
-        $this->addRole(Role::MANAGE);
+        $this->addRole(Role::ADMIN);
 
         $personUS = Person::factory()->create([
             'country' => 'US',
@@ -1347,7 +1347,7 @@ class PersonControllerTest extends TestCase
         // New roles may have seeder migrations, and we don't want that here.
         DB::table('role')->delete();
 
-        $this->addRole(Role::MANAGE);
+        $this->addRole(Role::ADMIN);
 
         $adminRole = Role::factory()->create([
             'id' => Role::ADMIN,
@@ -1359,11 +1359,11 @@ class PersonControllerTest extends TestCase
             'title' => 'Manage'
         ]);
 
-        $adminPerson = Person::factory()->create();
+        $mgmtPerson = Person::factory()->create();
 
         PersonRole::factory()->create([
-            'person_id' => $adminPerson->id,
-            'role_id' => Role::ADMIN
+            'person_id' => $mgmtPerson->id,
+            'role_id' => Role::MANAGE
         ]);
 
         $response = $this->json('GET', 'role/people-by-role');
@@ -1376,8 +1376,8 @@ class PersonControllerTest extends TestCase
                     'title' => 'Admin',
                     'people' => [
                         [
-                            'id' => $adminPerson->id,
-                            'callsign' => $adminPerson->callsign
+                            'id' => $this->user->id,
+                            'callsign' => $this->user->callsign
                         ]
                     ]
                 ],
@@ -1386,8 +1386,8 @@ class PersonControllerTest extends TestCase
                     'title' => 'Manage',
                     'people' => [
                         [
-                            'id' => $this->user->id,
-                            'callsign' => $this->user->callsign
+                            'id' => $mgmtPerson->id,
+                            'callsign' => $mgmtPerson->callsign
                         ]
                     ]
                 ]
@@ -1401,7 +1401,7 @@ class PersonControllerTest extends TestCase
 
     public function testPeopleByStatus()
     {
-        $this->addRole(Role::MANAGE);
+        $this->addRole(Role::ADMIN);
 
         $deceased = Person::factory()->create(['status' => 'deceased']);
         $inactive = Person::factory()->create(['status' => 'inactive']);

--- a/tests/Feature/PositionSanityCheckControllerTest.php
+++ b/tests/Feature/PositionSanityCheckControllerTest.php
@@ -97,7 +97,7 @@ class PositionSanityCheckControllerTest extends TestCase
 
     public function testPositionSanityCheckerInspection()
     {
-        $this->addRole(Role::MANAGE);
+        $this->addRole(Role::ADMIN);
 
         $person = $this->person;
         $personYear = $this->personYear;
@@ -153,7 +153,7 @@ class PositionSanityCheckControllerTest extends TestCase
             'position_id' => Position::HQ_RUNNER
         ]);
 
-        $this->addRole(Role::MANAGE);
+        $this->addRole(Role::ADMIN);
 
         $person = $this->person;
 

--- a/tests/Feature/TimesheetControllerTest.php
+++ b/tests/Feature/TimesheetControllerTest.php
@@ -285,6 +285,7 @@ class TimesheetControllerTest extends TestCase
     {
         $timesheetId = $this->timesheet->id;
 
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $response = $this->json('PUT', "timesheet/{$timesheetId}", [
             'timesheet' => [
                 'position_id' => Position::HQ_WINDOW,
@@ -317,6 +318,7 @@ class TimesheetControllerTest extends TestCase
 
     public function testSigninForTrained()
     {
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $this->createTrainingSession(true);
         $targetPersonId = $this->targetPerson->id;
 
@@ -341,6 +343,7 @@ class TimesheetControllerTest extends TestCase
 
     public function testSigninForOnlineCourseOnly()
     {
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $this->createTrainingSession(false);
         $targetPersonId = $this->targetPerson->id;
 
@@ -369,6 +372,7 @@ class TimesheetControllerTest extends TestCase
 
     public function testNoSignInForUntrainedPerson()
     {
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $this->createTrainingSession(false);
         $targetPersonId = $this->targetPerson->id;
 
@@ -389,6 +393,7 @@ class TimesheetControllerTest extends TestCase
 
     public function testNoSignInForNoOnlineCourse()
     {
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $this->createTrainingSession(false);
         $targetPersonId = $this->targetPerson->id;
         $this->setting('OnlineCourseOnlyForBinaries', true);
@@ -449,6 +454,7 @@ class TimesheetControllerTest extends TestCase
 
     public function testSigninPreventionForIneligiblePosition()
     {
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $this->createTrainingSession(true);
         $targetPersonId = $this->targetPerson->id;
         $this->addPosition(Position::TRAINING, $this->targetPerson);
@@ -473,6 +479,7 @@ class TimesheetControllerTest extends TestCase
             'position_id' => Position::DIRT,
         ]);
 
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $response = $this->json('POST', "timesheet/{$timesheet->id}/signoff");
         $response->assertStatus(200);
 
@@ -502,6 +509,7 @@ class TimesheetControllerTest extends TestCase
 
     public function testAlreadySignedout()
     {
+        $this->addRole(Role::SHIFT_MANAGEMENT);
         $response = $this->json('POST', "timesheet/{$this->timesheet->id}/signoff");
         $response->assertStatus(200);
         $response->assertJson(['status' => 'already-signed-off']);
@@ -621,6 +629,7 @@ class TimesheetControllerTest extends TestCase
             'additional_notes' => 'Give me hours!',
         ]);
 
+        $this->addRole(Role::TIMESHEET_MANAGEMENT);
         $response = $this->json('GET', 'timesheet/correction-requests', ['year' => $year]);
         $response->assertStatus(200);
 
@@ -653,6 +662,7 @@ class TimesheetControllerTest extends TestCase
         // The test person will be unconfirmed.
         $person = $this->targetPerson;
 
+        $this->addRole(Role::TIMESHEET_MANAGEMENT);
         $response = $this->json('GET', 'timesheet/unconfirmed-people', ['year' => $this->year]);
         $response->assertStatus(200);
         $response->assertJson([
@@ -762,7 +772,8 @@ class TimesheetControllerTest extends TestCase
             'slot_id' => $slot->id
         ]);
 
-        $response = $this->json('GET', 'timesheet/potential-shirts-earned', ['year' => $year]);
+        $this->addRole(Role::QUARTERMASTER);
+        $response = $this->json('GET', 'swag/potential-shirts-earned', ['year' => $year]);
         $response->assertStatus(200);
 
         // Should return the settings
@@ -813,6 +824,7 @@ class TimesheetControllerTest extends TestCase
             'off_duty' => "$prevYear-08-25 01:00:00",
         ]);
 
+        $this->addRole(Role::ADMIN);
         $response = $this->json('GET', 'timesheet/freaking-years', ['year' => $this->year]);
         $response->assertStatus(200);
         $this->assertCount(1, $response->json()['freaking']);
@@ -895,6 +907,7 @@ class TimesheetControllerTest extends TestCase
 
         PersonSlot::factory()->create(['person_id' => $personB->id, 'slot_id' => $slot->id]);
 
+        $this->addRole(Role::ADMIN);
         $response = $this->json('GET', 'timesheet/radio-eligibility', ['year' => $this->year]);
         $response->assertStatus(200);
 
@@ -1225,6 +1238,7 @@ class TimesheetControllerTest extends TestCase
             'off_duty' => date("$year-m-d 02:00:00"),
         ]);
 
+        $this->addRole(Role::ADMIN);
         $response = $this->json('GET', 'timesheet/thank-you', ['year' => $year, 'password' => $password]);
         $response->assertStatus(200);
 
@@ -1271,6 +1285,7 @@ class TimesheetControllerTest extends TestCase
             'off_duty' => date("$year-08-25 01:00:00"),
         ]);
 
+        $this->addRole(Role::ADMIN);
         $response = $this->json('GET', 'timesheet/by-callsign', ['year' => $year]);
         $response->assertStatus(200);
         $response->assertJson([
@@ -1326,6 +1341,7 @@ class TimesheetControllerTest extends TestCase
             'position_id' => Position::HQ_WINDOW
         ]);
 
+        $this->addRole(Role::ADMIN);
         $response = $this->json('GET', 'timesheet/totals', ['year' => $year]);
         $response->assertStatus(200);
 


### PR DESCRIPTION
- Renamed Timecard Year Round to Shift Management Self
- New permission Quartermaster: for QM reports, and swag access.
- New permission Shift Management: to control who can do shift check in/outs. Removed from Login Management.
- New permission Pod Management: to control access to the Cruise Direction Interface / Pod apis.