### PR TITLE
Only append the screened handles on individual record lookup.

### DIFF
--- a/app/Models/ProspectiveApplication.php
+++ b/app/Models/ProspectiveApplication.php
@@ -112,7 +112,7 @@ class ProspectiveApplication extends ApiModel
     protected $appends = [
         'api_error',
         'contact_id',
-        'screened_handles',
+        //   'screened_handles', -- only appended on individual record show.
     ];
 
 
@@ -515,6 +515,7 @@ class ProspectiveApplication extends ApiModel
     public function screenHandles(): void
     {
         $this->buildScreenedHandles(fn($normalized) => HandleReservation::retrieveAllByNormalizedHandle($normalized) ?? null);
+        $this->append('screened_handles');
     }
 
     public function buildScreenedHandles(callable $findReserved): void


### PR DESCRIPTION
The ProspectiveApplication::index method was slow because it screened handles for all records. This screening should only occur when retrieving individual records.