### PR TITLE
stop daily report from barking when photo upload is disabled

### DIFF
--- a/resources/views/emails/daily-report.blade.php
+++ b/resources/views/emails/daily-report.blade.php
@@ -339,7 +339,7 @@
         <tr>
             <td>Photo Uploading</td>
             <td>
-                {!! ($settings['PhotoUploadEnable'] ?? false) ? "Enabled (normal)" : '<b style="color: red">DISABLED (NOT NORMAL)</b>' !!}
+                {{($settings['PhotoUploadEnable'] ?? false) ? "Enabled" : "Disabled"}}
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
it's pretty typical for photo uploading to be disabled for much of the year, and it's not really something that should concern the Tech Cadre.