### PR TITLE
Don't rely on auth:sanctum for authentication.

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -33,7 +33,6 @@ class Handler
         CommandRuntimeException::class,
         InvalidArgumentException::class,
         ModelNotFoundException::class,
-        TokenExpiredException::class,
         UnacceptableConditionException::class,
         ValidationException::class,
     ];

--- a/app/Http/Middleware/AuthenticatedCheckMiddleware.php
+++ b/app/Http/Middleware/AuthenticatedCheckMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthenticatedCheckMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response) $next
+     * @throws AuthenticationException
+     */
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!Auth::check()) {
+            throw new AuthenticationException();
+        }
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Exceptions\Handler;
 use App\Http\Middleware\AccountGuard;
+use App\Http\Middleware\AuthenticatedCheckMiddleware;
 use App\Http\Middleware\RequestLoggerMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -36,8 +37,15 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'bindings' => SubstituteBindings::class,
         ]);
+
+        $middleware->alias([
+            'authenticate' => AuthenticatedCheckMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
+        $exceptions->shouldRenderJsonWhen(function (Request $request, Throwable $e) {
+            return true;
+        });
         $exceptions->dontReport(Handler::NO_REPORTING);
         $exceptions->report(fn(Throwable $e) => Handler::report($e));
         $exceptions->render(fn(Throwable $e, Request $request) => Handler::render($e, $request));

--- a/routes/api.php
+++ b/routes/api.php
@@ -123,7 +123,7 @@ Route::middleware('api')->group(function () {
  * API which require an authorized user
  */
 
-Route::middleware('api')->group(function () {
+Route::middleware(['authenticate', 'api'])->group(function () {
     Route::post('auth/logout', [AuthController::class, 'logout']);
 
     Route::get('auth/oauth2/grant-code', [OAuth2Controller::class, 'grantOAuthCode']);


### PR DESCRIPTION
auth:sanctum will attempt to redirect to the non-existent /login route for non-json requests.

The new middleware AuthenticatedCheckMiddleware will ensure this will not happen.