### PR TITLE
Fix parent/child slot sign-up counts and name the at-capacity shift

### DIFF
--- a/app/Exceptions/ScheduleSignUpException.php
+++ b/app/Exceptions/ScheduleSignUpException.php
@@ -10,10 +10,11 @@ use Exception;
  */
 class ScheduleSignUpException extends Exception
 {
-    public function __construct(string        $message,
-                                public ?int   $signUps = null,
-                                public ?array $linkedSlots = null,
-                                public ?int   $combinedMax)
+    public function __construct(string         $message,
+                                public ?int    $signUps = null,
+                                public ?array  $linkedSlots = null,
+                                public ?int    $combinedMax = null,
+                                public ?string $fullPositionTitle = null)
     {
         parent::__construct($message);
     }

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -302,6 +302,7 @@ class Schedule
                     'signed_up' => $e->signUps,
                     'linked_slots' => $e->linkedSlots,
                     'combined_max' => $e->combinedMax,
+                    'full_position_title' => $e->fullPositionTitle,
                 ];
             }
             // Most likely the database crapped itself
@@ -400,9 +401,12 @@ class Schedule
             $finalSignUps = $signUps + $countAdjustment;
 
             if ($op == self::OP_ADD && !$force && ($signUps >= $max || $combined >= $parentSlot->max)) {
+                // Name whichever shift is actually at capacity: the child's own
+                // max, or the shared parent pool.
+                $fullTitle = $signUps >= $max ? $slot->position->title : $parentSlot->position->title;
                 throw new ScheduleSignUpException(self::FULL, $max, [
                     ['slot_id' => $parentSlot->id, 'signed_up' => $combined],
-                ], $parentSlot->max);
+                ], $parentSlot->max, $fullTitle);
             }
 
             if ($finalSignUps >= $max || $adjustedCombined >= $parentSlot->max) {
@@ -431,10 +435,12 @@ class Schedule
                 $finalSignUps = $adjustedCombined;
 
                 if ($op == self::OP_ADD && !$force && ($signUps >= $max || $combined >= $max)) {
+                    // The parent's own max is the shared pool limit, so the parent
+                    // shift is the one at capacity.
                     throw new ScheduleSignUpException(self::FULL, $max, [
                         ['slot_id' => $childSlot->id, 'signed_up' => $childSignups]
                     ],
-                        $slot->max);
+                        $slot->max, $slot->position->title);
                 }
 
                 if ($finalSignUps >= $max || ($signUps + $countAdjustment) >= $max) {
@@ -462,7 +468,7 @@ class Schedule
                 // Cannot exceed the signup limit unless it is forced.
                 if ($op == self::OP_ADD && $signUps >= $max) {
                     if (!$force) {
-                        throw new ScheduleSignUpException(self::FULL, $signUps, [], $slot->max);
+                        throw new ScheduleSignUpException(self::FULL, $signUps, [], $slot->max, $slot->position->title);
                     }
 
                     $isFull = true;

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -154,12 +154,11 @@ class Schedule
                 if (!$found) {
                     continue;
                 }
-                if (($row->signed_up + $child->signed_up) >= $row->max || $row->signed_up >= $row->max) {
-                    $found->signed_up = $found->max;
-                    $row->signed_up = $row->max;
-                } else {
-                    $row->signed_up = $row->signed_up + $found->signed_up;
-                }
+                // The parent shift displays the combined pool usage (capped at its
+                // own max); the child shift keeps its own real sign-up count. Do NOT
+                // inflate the child to its max when the pool is full -- that makes a
+                // single sign-up appear to fill every child seat.
+                $row->signed_up = min($row->signed_up + $child->signed_up, $row->max);
             }
         }
 
@@ -407,9 +406,10 @@ class Schedule
             }
 
             if ($finalSignUps >= $max || $adjustedCombined >= $parentSlot->max) {
+                // The child slot is full -- either its own max is reached or the
+                // shared pool is. Flag it, but keep the real sign-up counts. Do not
+                // inflate the child count ($finalSignUps) to the child max.
                 $isFull = true;
-                $finalSignUps = $max;
-                $adjustedCombined = $parentSlot->max;
             }
 
             $linkedSlots[] = [
@@ -419,7 +419,7 @@ class Schedule
                 'position_title' => $parentSlot->position->title,
             ];
 
-            if (self::OP_ADD && ($combined + 1) == $parentSlot->max) {
+            if ($op == self::OP_ADD && ($combined + 1) == $parentSlot->max) {
                 $becameFull = true;
             }
         } else {
@@ -432,15 +432,16 @@ class Schedule
 
                 if ($op == self::OP_ADD && !$force && ($signUps >= $max || $combined >= $max)) {
                     throw new ScheduleSignUpException(self::FULL, $max, [
-                        ['slot_id' => $childSlot->id, 'signed_up' => $childSlot->max]
+                        ['slot_id' => $childSlot->id, 'signed_up' => $childSignups]
                     ],
                         $slot->max);
                 }
 
                 if ($finalSignUps >= $max || ($signUps + $countAdjustment) >= $max) {
+                    // Pool/parent is full; cap the parent's combined display at its
+                    // max, but keep the child's real count in the linked entry.
                     $isFull = true;
                     $finalSignUps = $max;
-                    $childSignups = $childSlot->max;
                 }
 
                 $linkedSlots[] = [
@@ -450,7 +451,7 @@ class Schedule
                     'position_title' => $childSlot->position->title,
                 ];
 
-                if (self::OP_ADD && ($combined + 1) == $slot->max) {
+                if ($op == self::OP_ADD && ($combined + 1) == $slot->max) {
                     $becameFull = true;
                 }
             } else {

--- a/app/Models/Slot.php
+++ b/app/Models/Slot.php
@@ -352,13 +352,10 @@ class Slot extends ApiModel
                     ->orderBy('person.callsign', 'asc')
                     ->get();
 
-                $parentCount = $parentSlot->signed_up;
-                if (($parentCount + $slot->signed_up) >= $parentSlot->max) {
-                    $parentCount = $parentSlot->max;
-                    $signedUp = $slot->max;
-                } else {
-                    $parentCount += $signedUp;
-                }
+                // The 'parent' entry shows the combined pool usage capped at the
+                // parent max. The child slot itself ($signedUp) keeps its own real
+                // count -- do not inflate it to the child max when the pool is full.
+                $parentCount = min($parentSlot->signed_up + $slot->signed_up, $parentSlot->max);
 
                 $results['parent'] = [
                     'slot_id' => $parentSlot->id,
@@ -377,13 +374,10 @@ class Slot extends ApiModel
                     ->orderBy('person.callsign', 'asc')
                     ->get();
 
+                // The parent slot ($signedUp) shows the combined pool usage capped
+                // at its max; the 'child' entry keeps its own real count.
                 $childCount = $childSlot->signed_up;
-                if (($signedUp + $childCount) >= $slot->max) {
-                    $signedUp = $slot->max;
-                    $childCount = $childSlot->max;
-                } else {
-                    $signedUp += $childCount;
-                }
+                $signedUp = min($slot->signed_up + $childCount, $slot->max);
 
                 $results['child'] = [
                     'slot_id' => $childSlot->id,

--- a/tests/Feature/ParentChildSlotSignupTest.php
+++ b/tests/Feature/ParentChildSlotSignupTest.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Exceptions\ScheduleSignUpException;
+use App\Models\PersonOnlineCourse;
+use App\Models\PersonPhoto;
+use App\Models\PersonPosition;
+use App\Models\Person;
+use App\Models\Position;
+use App\Models\Schedule;
+use App\Models\Slot;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+/**
+ * Parent/Child sign-up slot behaviour.
+ *
+ * Domain model:
+ *   - A "child" slot carries parent_signup_slot_id pointing at a "parent" slot
+ *     that begins at the same time (e.g. Mentee -> Ridealong).
+ *   - Intended rules (per Schedule::computeSignups doc-block):
+ *       1. A child's own sign-ups may not exceed the child's max.
+ *       2. The combined (parent + child) sign-ups may not exceed the PARENT's max
+ *          (the parent max is the shared capacity pool).
+ *
+ * Each test asserts the *correct* behaviour. A failing test therefore marks a
+ * place where the feature misbehaves.
+ *
+ * Naming below:
+ *   Pm = parent max, Cm = child max, Ps = parent signed_up, Cs = child signed_up.
+ */
+class ParentChildSlotSignupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public string $year;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->signInUser();
+        Mail::fake();
+
+        $this->year = date('Y');
+        Carbon::setTestNow("{$this->year}-02-01 12:00:00");
+
+        // Required for the online-course requirement check used by the HTTP path.
+        Position::factory()->create([
+            'id' => Position::TRAINING,
+            'title' => 'Training',
+            'type' => 'Training',
+        ]);
+        $this->setting('OnlineCourseDisabledAllowSignups', false);
+    }
+
+    /**
+     * Build a linked parent/child slot pair with the given maxes and pre-existing
+     * signed_up counts. Returns freshly loaded [$parent, $child].
+     */
+    private function makeLinked(int $pm, int $cm, int $ps = 0, int $cs = 0): array
+    {
+        $begins = "{$this->year}-08-30 09:00:00";
+        $ends = "{$this->year}-08-30 17:00:00";
+
+        $parentPos = Position::factory()->create(['title' => 'Ridealong', 'type' => 'Frontline']);
+        $childPos = Position::factory()->create([
+            'title' => 'Mentee',
+            'type' => 'Frontline',
+            'parent_position_id' => $parentPos->id,
+        ]);
+
+        $parent = Slot::factory()->create([
+            'position_id' => $parentPos->id,
+            'begins' => $begins,
+            'ends' => $ends,
+            'description' => 'Ridealong Aug 30',
+            'max' => $pm,
+            'min' => 0,
+            'signed_up' => $ps,
+            'active' => true,
+        ]);
+
+        $child = Slot::factory()->create([
+            'position_id' => $childPos->id,
+            'begins' => $begins,
+            'ends' => $ends,
+            'description' => 'Mentee Aug 30',
+            'max' => $cm,
+            'min' => 0,
+            'signed_up' => $cs,
+            'active' => true,
+            'parent_signup_slot_id' => $parent->id,
+        ]);
+
+        return [Slot::find($parent->id), Slot::find($child->id)];
+    }
+
+    /* ===================================================================
+     * GROUP A — Child slot sign-ups (computeSignups, OP_ADD)
+     *
+     * The returned signed_up is the value the UI renders as "N / max" for the
+     * child shift. It must equal the real number of people in the child slot
+     * after the add, never the child's max.
+     * =================================================================== */
+
+    /** A1: Empty pool, Pm=4 Cm=2. One child sign-up -> reports 1, not full. */
+    public function testChildSignupEmptyPoolReportsOne()
+    {
+        [, $child] = $this->makeLinked(pm: 4, cm: 2, ps: 0, cs: 0);
+
+        [$signUps, $isFull] = Schedule::computeSignups($child, Schedule::OP_ADD);
+
+        $this->assertEquals(1, $signUps, 'one child sign-up should report 1');
+        $this->assertFalse($isFull, 'pool of 4 is not full after 1 sign-up');
+    }
+
+    /**
+     * A2: REPORTED BUG. Pm=1 Cm=2, empty. One child sign-up.
+     * The pool (parent max 1) becomes full, but only ONE real person exists in
+     * the child slot, so signed_up must be 1 — not the child max of 2.
+     */
+    public function testChildSignupDoesNotOverstateCountWhenPoolBinds()
+    {
+        [, $child] = $this->makeLinked(pm: 1, cm: 2, ps: 0, cs: 0);
+
+        [$signUps, $isFull] = Schedule::computeSignups($child, Schedule::OP_ADD);
+
+        $this->assertEquals(1, $signUps,
+            'one real sign-up must report 1, even though the shared pool is now full');
+    }
+
+    /**
+     * A3: Bigger overstatement. Pm=2 Cm=3, one parent already (Ps=1).
+     * Adding the first child fills the pool (1+1=2=Pm) but there is only ONE
+     * person in the child slot -> signed_up must be 1, not the child max of 3.
+     */
+    public function testChildSignupReportsRealCountNotChildMax()
+    {
+        [, $child] = $this->makeLinked(pm: 2, cm: 3, ps: 1, cs: 0);
+
+        [$signUps] = Schedule::computeSignups($child, Schedule::OP_ADD);
+
+        $this->assertEquals(1, $signUps,
+            'child slot has 1 real person; must not report the child max (3)');
+    }
+
+    /** A4: Child own-max reached reports the real count. Pm=10 Cm=2, Cs=1. */
+    public function testChildSignupAtOwnMaxReportsRealCount()
+    {
+        [, $child] = $this->makeLinked(pm: 10, cm: 2, ps: 0, cs: 1);
+
+        [$signUps, $isFull] = Schedule::computeSignups($child, Schedule::OP_ADD);
+
+        $this->assertEquals(2, $signUps, 'second of two child sign-ups reports 2');
+        $this->assertTrue($isFull, 'child own max (2) reached');
+    }
+
+    /** A5: Child blocked once its own max is reached. Pm=10 Cm=1, Cs=1. */
+    public function testChildBlockedAtOwnMax()
+    {
+        [, $child] = $this->makeLinked(pm: 10, cm: 1, ps: 0, cs: 1);
+
+        $this->expectException(ScheduleSignUpException::class);
+        Schedule::computeSignups($child, Schedule::OP_ADD);
+    }
+
+    /** A6: Child blocked when shared pool is full even though child max not reached. */
+    public function testChildBlockedWhenPoolFull()
+    {
+        // Pm=2 Cm=5, two parents already -> pool full.
+        [, $child] = $this->makeLinked(pm: 2, cm: 5, ps: 2, cs: 0);
+
+        $this->expectException(ScheduleSignUpException::class);
+        Schedule::computeSignups($child, Schedule::OP_ADD);
+    }
+
+    /* ===================================================================
+     * GROUP B — Parent slot sign-ups (computeSignups, OP_ADD)
+     * =================================================================== */
+
+    /** B1: Parent sign-up combined count. Pm=4 Cm=2, Cs=1. */
+    public function testParentSignupReportsCombined()
+    {
+        [$parent] = $this->makeLinked(pm: 4, cm: 2, ps: 0, cs: 1);
+
+        [$signUps, $isFull, , $linked, $combinedMax] = Schedule::computeSignups($parent, Schedule::OP_ADD);
+
+        $this->assertEquals(2, $signUps, 'combined pool usage is 1 child + 1 new parent = 2');
+        $this->assertFalse($isFull, 'pool of 4 not full');
+        $this->assertEquals(4, $combinedMax);
+
+        // The linked child entry must reflect the child's REAL count (1), not its max.
+        $this->assertEquals(1, $linked[0]['signed_up'],
+            'linked child count must be the real 1, not the child max');
+    }
+
+    /** B2: Parent blocked when pool full. Pm=2 Cm=2, Cs=2. */
+    public function testParentBlockedWhenPoolFull()
+    {
+        [$parent] = $this->makeLinked(pm: 2, cm: 2, ps: 0, cs: 2);
+
+        $this->expectException(ScheduleSignUpException::class);
+        Schedule::computeSignups($parent, Schedule::OP_ADD);
+    }
+
+    /* ===================================================================
+     * GROUP C — becameFull flag must only reflect an actual ADD.
+     *
+     * computeSignups guards the becameFull computation with `self::OP_ADD`
+     * (a constant string) instead of `$op == self::OP_ADD`, so it can fire on
+     * a pure QUERY. becameFull must be false for a non-add.
+     * =================================================================== */
+
+    /** C1: Child QUERY must never report becameFull. Pm=2, Ps=1 -> combined+1==Pm. */
+    public function testChildQueryDoesNotReportBecameFull()
+    {
+        [, $child] = $this->makeLinked(pm: 2, cm: 5, ps: 1, cs: 0);
+
+        [, , $becameFull] = Schedule::computeSignups($child, Schedule::OP_QUERY);
+
+        $this->assertFalse($becameFull, 'a QUERY must not flag became_full');
+    }
+
+    /** C2: Parent QUERY must never report becameFull. Pm=2, Cs=1 -> combined+1==Pm. */
+    public function testParentQueryDoesNotReportBecameFull()
+    {
+        [$parent] = $this->makeLinked(pm: 2, cm: 5, ps: 0, cs: 1);
+
+        [, , $becameFull] = Schedule::computeSignups($parent, Schedule::OP_QUERY);
+
+        $this->assertFalse($becameFull, 'a QUERY must not flag became_full');
+    }
+
+    /* ===================================================================
+     * GROUP D — End-to-end HTTP reproduction of the reported scenario.
+     * Ridealong (parent, max 1) / Mentee (child, max 2). One person signs up
+     * for the Mentee shift via the API.
+     * =================================================================== */
+
+    public function testHttpOneMenteeSignupDoesNotShowSlotFull()
+    {
+        [$parent, $child] = $this->makeLinked(pm: 1, cm: 2, ps: 0, cs: 0);
+
+        // The acting user must hold the child position and meet requirements.
+        $this->addPosition($child->position_id);
+        $this->markOnlineCoursePassed($this->user);
+        $this->setupPhotoApproved($this->user);
+
+        $response = $this->json('POST', "person/{$this->user->id}/schedule", [
+            'slot_id' => $child->id,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => Schedule::SUCCESS]);
+
+        // Exactly one real row in person_slot for the child slot.
+        $this->assertDatabaseHas('person_slot', [
+            'person_id' => $this->user->id,
+            'slot_id' => $child->id,
+        ]);
+        $realCount = \App\Models\PersonSlot::where('slot_id', $child->id)->count();
+        $this->assertEquals(1, $realCount, 'exactly one real sign-up exists');
+
+        // The API must not claim the Mentee shift holds 2 people after one sign-up.
+        $reported = $response->json('signed_up');
+        $this->assertEquals(1, $reported,
+            "Mentee shift reported signed_up={$reported} after a single sign-up");
+    }
+
+    /* ===================================================================
+     * GROUP E — Schedule listing (the calendar grid in the screenshot).
+     * Schedule::findForQuery renders slot_signed_up for each shift. With
+     * Ridealong(parent,max 1)/Mentee(child,max 2) and ONE mentee signed up,
+     * the Mentee shift must display 1, not 2 (which renders as a full 2/2).
+     * =================================================================== */
+
+    public function testScheduleListingDoesNotShowChildAsFull()
+    {
+        [$parent, $child] = $this->makeLinked(pm: 1, cm: 2, ps: 0, cs: 1);
+
+        // The user must hold both positions for the shifts to appear in the listing.
+        $this->addPosition($parent->position_id);
+        $this->addPosition($child->position_id);
+
+        [$entries] = Schedule::findForQuery($this->user->id, (int)$this->year);
+
+        $childEntry = collect($entries)->firstWhere('id', $child->id);
+        $this->assertNotNull($childEntry, 'Mentee shift should be in the listing');
+
+        $this->assertEquals(1, $childEntry->slot_signed_up,
+            "Mentee shift listing shows slot_signed_up={$childEntry->slot_signed_up} (max {$childEntry->slot_max}) for ONE sign-up");
+    }
+
+    private function markOnlineCoursePassed(Person $person): void
+    {
+        $poc = new PersonOnlineCourse;
+        $poc->person_id = $person->id;
+        $poc->completed_at = now();
+        $poc->position_id = Position::TRAINING;
+        $poc->type = PersonOnlineCourse::TYPE_MOODLE;
+        $poc->year = now()->year;
+        $poc->saveWithoutValidation();
+    }
+
+    private function setupPhotoApproved(Person $person): void
+    {
+        $photo = PersonPhoto::factory()->create([
+            'person_id' => $person->id,
+            'status' => PersonPhoto::APPROVED,
+        ]);
+        $person->person_photo_id = $photo->id;
+        $person->saveWithoutValidation();
+    }
+}

--- a/tests/Feature/ParentChildSlotSignupTest.php
+++ b/tests/Feature/ParentChildSlotSignupTest.php
@@ -164,8 +164,13 @@ class ParentChildSlotSignupTest extends TestCase
     {
         [, $child] = $this->makeLinked(pm: 10, cm: 1, ps: 0, cs: 1);
 
-        $this->expectException(ScheduleSignUpException::class);
-        Schedule::computeSignups($child, Schedule::OP_ADD);
+        try {
+            Schedule::computeSignups($child, Schedule::OP_ADD);
+            $this->fail('expected ScheduleSignUpException');
+        } catch (ScheduleSignUpException $e) {
+            // The child's own capacity is the one that is full.
+            $this->assertEquals('Mentee', $e->fullPositionTitle);
+        }
     }
 
     /** A6: Child blocked when shared pool is full even though child max not reached. */
@@ -174,8 +179,13 @@ class ParentChildSlotSignupTest extends TestCase
         // Pm=2 Cm=5, two parents already -> pool full.
         [, $child] = $this->makeLinked(pm: 2, cm: 5, ps: 2, cs: 0);
 
-        $this->expectException(ScheduleSignUpException::class);
-        Schedule::computeSignups($child, Schedule::OP_ADD);
+        try {
+            Schedule::computeSignups($child, Schedule::OP_ADD);
+            $this->fail('expected ScheduleSignUpException');
+        } catch (ScheduleSignUpException $e) {
+            // The shared parent pool is the one that is full, not the child.
+            $this->assertEquals('Ridealong', $e->fullPositionTitle);
+        }
     }
 
     /* ===================================================================


### PR DESCRIPTION
This aims to fix some weirdness in the schedule when signaling a shift with parent and child is full. The issue can be seen in staging at the time of the PR in the attached image. (The Sign Up bar on the Parent shift adjusts to a correct value if the Sign Ups are shown.) The change itself is Claude Code and includes an adjustment that populates the shift name into the Shift is at capacity modal. In my repo, that's two commits for ease of review (first commit is just the bugfix) but I think they might get squashed during this PR so sorry if they are harder to disentangle. I did my best to vet this but am not much good at PHP - still, the change looks parsimonious.

<img width="752" height="589" alt="image" src="https://github.com/user-attachments/assets/2716b579-72e6-4209-9881-6cb5824351ef" />

## Problem
For linked parent/child shifts (e.g. Deep Desert Patrol Ridealong → Mentee), a single child sign-up could render the child shift as full. With Ridealong (parent) max 1 / Mentee (child) max 2, signing up one Mentee showed the Mentee shift as 2/2 and blocked further adds.

## Cause
When the shared parent/child pool filled, three paths overwrote the child's displayed `signed_up` with the child's own max instead of the real count: `Schedule::findForQuery` (calendar), `Schedule::computeSignups` (enforcement + API response), and `Slot::retrieveSignUps` ("people in slot"). A separate `became_full` guard used the constant `self::OP_ADD` (always truthy) instead of `$op == self::OP_ADD`.

## Fix
- Report real counts in all three paths; parent shows combined pool usage capped at its max, child keeps its own count.
- Correct the `became_full` guards.
- On a 'full' sign-up, return `full_position_title` naming the shift actually at capacity (companion web PR uses it in the force modal).

## Tests
New `tests/Feature/ParentChildSlotSignupTest.php` (12 cases; the matrix was previously untested). Full suite green (452 tests).

## Notes
- Companion web [PR](https://github.com/burningmantech/ranger-clubhouse-web/pull/2465). The web change degrades gracefully without this.
- The parent slot's `max` should be ≥ the intended combined capacity; the 1/2 edge is a config artifact, not a code bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01W3WHpzguKQrphQmFbYwqjA